### PR TITLE
chore: Add Black helper utilities

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
         flake8 cabinetry --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=cabinetry/__init__.py
     - name: Lint with Black
       run: |
-        black --check --diff --verbose .
+        black --check --diff --verbose cabinetry
 
     - name: Test example
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,8 +31,9 @@ jobs:
         flake8 cabinetry --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 cabinetry --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=cabinetry/__init__.py
-        # run black as well
-        black cabinetry
+    - name: Lint with Black
+      run: |
+        black --check --diff --verbose .
 
     - name: Test example
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.black]
+target-version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | .eggs
+  | build
+)/
+'''


### PR DESCRIPTION
Add a few things to help make Black a more useful utility.

- `pyproject.toml`: What you can config with Black is controlled through `pyproject.toml`, so avoid Black-ing things that don't need it
- `.pre-commit-config.yaml`: If you run `pre-commit install` then Black will be run automatically every time you try to commit
- `black --check --diff --verbose .` gives much more helpful output to the CI logs

Squash and merge suggested commit message:

```
* Add pyproject.toml for Black config
* Add .pre-commit-config.yaml for Black pre-commit hook
* Use --check --diff --verbose in CI for more helpful log output
```