### PR TITLE
feat: using logging instead of prints

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,6 +1,14 @@
+import logging
 import os
 
 import cabinetry
+
+
+# set up log formatting and suppress verbose output from matplotlib
+logging.basicConfig(
+    level=logging.DEBUG, format="%(levelname)s - %(name)s - %(message)s"
+)
+logging.getLogger("matplotlib").setLevel(logging.WARNING)
 
 
 if __name__ == "__main__":

--- a/src/cabinetry/config.py
+++ b/src/cabinetry/config.py
@@ -1,14 +1,19 @@
+import logging
 import yaml
+
 
 REQUIRED_CONFIG_KEYS = ["General", "Samples", "Regions", "NormFactors"]
 
 OPTIONAL_CONFIG_KEYS = ["Systematics"]
+
+log = logging.getLogger(__name__)
 
 
 def read(file_path):
     """
     read a config file from a provided path and return it
     """
+    log.info("opening config file %s", file_path)
     with open(file_path) as f:
         config = yaml.safe_load(f)
     validate(config)
@@ -39,9 +44,9 @@ def print_overview(config):
     """
     output a compact summary of a config file
     """
-    print("# the config contains:")
-    print("-", len(config["Samples"]), "Sample(s)")
-    print("-", len(config["Regions"]), "Region(s)")
-    print("-", len(config["NormFactors"]), "NormFactor(s)")
+    log.info("the config contains:")
+    log.info("  %i Sample(s)", len(config["Samples"]))
+    log.info("  %i Regions(s)", len(config["Regions"]))
+    log.info("  %i NormFactor(s)", len(config["NormFactors"]))
     if "Systematics" in config.keys():
-        print("-", len(config["Systematics"]), "Systematic(s)")
+        log.info("  %i Systematic(s)", len(config["Systematics"]))

--- a/src/cabinetry/contrib/histogram_drawing.py
+++ b/src/cabinetry/contrib/histogram_drawing.py
@@ -1,6 +1,10 @@
+import logging
 import os
 import matplotlib.pyplot as plt
 import numpy as np
+
+
+log = logging.getLogger(__name__)
 
 
 def data_MC_matplotlib(histogram_dict_list, figure_folder, figure_name):
@@ -48,5 +52,5 @@ def data_MC_matplotlib(histogram_dict_list, figure_folder, figure_name):
 
     if not os.path.exists(figure_folder):
         os.mkdir(figure_folder)
-    print("- saving", figure_name, "to", figure_folder)
+    log.info("saving %s to %s", figure_name, figure_folder)
     plt.savefig(figure_folder + figure_name)

--- a/src/cabinetry/histogram_wrapper.py
+++ b/src/cabinetry/histogram_wrapper.py
@@ -2,16 +2,20 @@
 it might make sense to allow serialization of histograms in various
 different formats, so saving and loading should go through this wrapper
 """
+import logging
 import os
 
 import numpy as np
+
+
+log = logging.getLogger(__name__)
 
 
 def save_histogram(histogram, path, histogram_name):
     """
     save a histogram to disk
     """
-    print("- saving", histogram_name, "to", path)
+    log.info("saving %s to %s", histogram_name, path)
 
     # create output directory if it does not exist yet
     if not os.path.exists(path):

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -1,4 +1,9 @@
+import logging
+
 from . import histogram_wrapper
+
+
+log = logging.getLogger(__name__)
 
 
 def _get_ntuple_path(sample, region, systematic):
@@ -49,13 +54,13 @@ def create_histograms(config, output_path, method="uproot", only_nominal=False):
     """
     generate all required histograms specified by a configuration file
     """
-    print("# creating histograms")
+    log.info("creating histograms")
 
     for sample in config["Samples"]:
-        # print("- reading sample", sample["Name"])
+        log.debug("  reading sample %s", sample["Name"])
 
         for region in config["Regions"]:
-            # print("- in region", region["Name"])
+            log.debug("  in region %s", region["Name"])
 
             for isyst, systematic in enumerate(
                 ([{"Name": "nominal"}] + config["Systematics"])
@@ -67,7 +72,7 @@ def create_histograms(config, output_path, method="uproot", only_nominal=False):
                 elif isyst > 0:
                     raise NotImplementedError("systematics not yet implemented")
 
-                # print("- variation", systematic["Name"])
+                log.debug("  variation %s", systematic["Name"])
                 ntuple_path = _get_ntuple_path(sample, region, systematic)
                 pos_in_file = _get_position_in_file(sample)
                 selection = _get_selection(sample, region, systematic)

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -1,4 +1,9 @@
+import logging
+
 from . import histogram_wrapper
+
+
+log = logging.getLogger(__name__)
 
 
 def _adjust_histogram(histogram):
@@ -13,7 +18,7 @@ def run(config, histogram_folder):
     """
     apply post-processing as needed for all histograms
     """
-    print("# applying post-processing to histograms")
+    log.info("applying post-processing to histograms")
     # loop over all histograms
     for sample in config["Samples"]:
         for region in config["Regions"]:

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -2,8 +2,12 @@
 need to save the histogram bins for visualization purposes still,
 as well as cosmetics such as axis labels and region names
 """
+import logging
 
 from . import histogram_wrapper
+
+
+log = logging.getLogger(__name__)
 
 
 def _build_figure_name(region, is_prefit):
@@ -23,7 +27,7 @@ def data_MC(config, histogram_folder, figure_folder, prefit=True, method="matplo
     """
     draw a data/MC histogram, control whether it is pre- or postfit with a flag
     """
-    print("# visualizing histogram")
+    log.info("visualizing histogram")
     for region in config["Regions"]:
         histogram_dict_list = []
         for sample in config["Samples"]:


### PR DESCRIPTION
Switching from print statements to using the python `logging` module allows users to customize their output  and more easily parse it.