### PR TITLE
feat: statistical uncertainties for histograms

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,6 @@ jobs:
       run: |
         pip install .
         # install extra dependencies the example needs
-        pip install matplotlib uproot
+        pip install matplotlib uproot scipy
         python util/create_histograms.py
         python example.py

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build
 *.png
 *.pdf
 *.npy
+*.npz

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ## Table of contents
 
 - [Introduction](#introduction)
+- [Hello world](#hello-world)
 - [Template fits](#template-fits)
 - [Configuration file thoughts](#configuration-file-thoughts)
 - [Scope](#scope)
@@ -41,6 +42,13 @@ Interesting related projects:
 - [ServiceX for TRExFitter](https://github.com/kyungeonchoi/ServiceXforTRExFitter)
 - [Template fit workflows](https://github.com/alexander-held/template-fit-workflows)
 - [TRExFitter config translation](https://github.com/alexander-held/TRExFitter-config-translation)
+
+## Hello world
+
+The script `example.py` shows an example of how to use `cabinetry`.
+Beyond the core dependencies of `cabinetry` (currently `pyyaml` and `numpy`), it also requires additional libraries: `uproot`, `scipy` and `matplotlib`.
+Those additional dependencies are not installed together with `cabinetry`, as they are only used to perform tasks that are outside the `cabinetry` core functionality.
+Eventually the basic implementation (from `cabinetry/contrib`) will be replaced by calls to external modules (see also [Code](#code)).
 
 ## Template fits
 

--- a/src/cabinetry/contrib/histogram_drawing.py
+++ b/src/cabinetry/contrib/histogram_drawing.py
@@ -1,52 +1,99 @@
 import logging
 import os
 import matplotlib.pyplot as plt
+import matplotlib as mpl
 import numpy as np
 
 
 log = logging.getLogger(__name__)
 
 
+def _total_yield_uncertainty(sumw2_list):
+    """
+    calculate the absolute statistical uncertainty of a stack of MC
+    via sum in quadrature
+    """
+    tot_unc = np.sqrt(np.sum(np.power(sumw2_list, 2), axis=0))
+    return tot_unc
+
+
 def data_MC_matplotlib(histogram_dict_list, figure_folder, figure_name):
     """
     draw a data/MC histogram with matplotlib
     """
-
-    mc_histograms = []
+    mc_histograms_yields = []
+    mc_histograms_sumw2 = []
     mc_labels = []
     for h in histogram_dict_list:
         if h["isData"]:
-            data_histogram = h["hist"]
+            data_histogram_yields = h["hist"]["yields"]
+            data_histogram_sumw2 = h["hist"]["sumw2"]
             data_label = h["label"]
         else:
-            mc_histograms.append(h["hist"])
+            mc_histograms_yields.append(h["hist"]["yields"])
+            mc_histograms_sumw2.append(h["hist"]["sumw2"])
             mc_labels.append(h["label"])
 
     # get the highest single bin from the sum of MC
     y_max = np.max(
-        np.sum([h["hist"] for h in histogram_dict_list if not h["isData"]], axis=0)
+        np.sum(
+            [h["hist"]["yields"] for h in histogram_dict_list if not h["isData"]],
+            axis=0,
+        )
     )
 
     # if data is higher in any bin, the maximum y axis range should take that into account
-    y_max = max(y_max, np.max([h["hist"] for h in histogram_dict_list if h["isData"]]))
+    y_max = max(
+        y_max, np.max([h["hist"]["yields"] for h in histogram_dict_list if h["isData"]])
+    )
+
+    mpl.style.use("seaborn-colorblind")
 
     # plot MC stacked together
-    total_yield = np.zeros_like(mc_histograms[0])
-    x_dummy = np.arange(0, len(mc_histograms[0]))
-    for i_sample in range(len(mc_histograms)):
+    total_yield = np.zeros_like(mc_histograms_yields[0])
+    bins = histogram_dict_list[0]["hist"]["bins"]
+    bin_right_edges = bins[1:]
+    bin_left_edges = bins[:-1]
+    bin_width = bin_right_edges - bin_left_edges
+    bin_centers = 0.5 * (bin_left_edges + bin_right_edges)
+    for i_sample in range(len(mc_histograms_yields)):
         plt.bar(
-            x_dummy,
-            mc_histograms[i_sample],
-            width=1.0,
+            bin_centers,
+            mc_histograms_yields[i_sample],
+            width=bin_width,
             bottom=total_yield,
             label=mc_labels[i_sample],
         )
-        total_yield += mc_histograms[i_sample]
+        total_yield += mc_histograms_yields[i_sample]
+
+    # add total MC uncertainty
+    mc_stack_unc = _total_yield_uncertainty(mc_histograms_sumw2)
+    plt.bar(
+        bin_centers,
+        2 * mc_stack_unc,
+        width=bin_width,
+        bottom=total_yield - mc_stack_unc,
+        label="Stat. uncertainty",
+        fill=False,
+        linewidth=0,
+        edgecolor="gray",
+        hatch=3 * "/",
+    )
 
     # plot data
-    plt.plot(data_histogram, "x", c="k", label=data_label)
+    plt.errorbar(
+        bin_centers,
+        data_histogram_yields,
+        yerr=data_histogram_sumw2,
+        fmt="o",
+        c="k",
+        label=data_label,
+    )
 
-    plt.legend()
+    plt.legend(frameon=False)
+    plt.xlabel(histogram_dict_list[0]["variable"])
+    plt.ylabel("events")
+    plt.xlim(bin_left_edges[0], bin_right_edges[-1])
     plt.ylim([0, y_max * 1.1])  # 10% headroom
     plt.plot()
 

--- a/src/cabinetry/histogram_wrapper.py
+++ b/src/cabinetry/histogram_wrapper.py
@@ -11,7 +11,16 @@ import numpy as np
 log = logging.getLogger(__name__)
 
 
-def save_histogram(histogram, path, histogram_name):
+def to_dict(yields, sumw2, bins):
+    """
+    to more conveniently move around histogram information internally, put it
+    into a dictionary
+    """
+    histogram = {"yields": yields, "sumw2": sumw2, "bins": bins}
+    return histogram
+
+
+def save(histogram, path, histogram_name):
     """
     save a histogram to disk
     """
@@ -20,18 +29,26 @@ def save_histogram(histogram, path, histogram_name):
     # create output directory if it does not exist yet
     if not os.path.exists(path):
         os.mkdir(path)
-    np.save(path + histogram_name + ".npy", histogram)
+    np.savez(
+        path + histogram_name + ".npz",
+        yields=histogram["yields"],
+        sumw2=histogram["sumw2"],
+        bins=histogram["bins"],
+    )
 
 
-def load_histogram(path, histogram_name):
+def load(path, histogram_name):
     """
-    load a histogram from disk
+    load a histogram from disk and convert it into dictionary form
     """
-    histogram = np.load(path + histogram_name + ".npy")
-    return histogram
+    histogram_npz = np.load(path + histogram_name + ".npz")
+    yields = histogram_npz["yields"]
+    sumw2 = histogram_npz["sumw2"]
+    bins = histogram_npz["bins"]
+    return to_dict(yields, sumw2, bins)
 
 
-def _build_histogram_name(sample, region, systematic):
+def _build_name(sample, region, systematic):
     """
     construct a unique name for each histogram
     param sample: the sample
@@ -39,3 +56,34 @@ def _build_histogram_name(sample, region, systematic):
     name = sample["Name"] + "_" + region["Name"] + "_" + systematic["Name"]
     name = name.replace(" ", "-")
     return name
+
+
+def _validate_and_fix(histogram, name):
+    """
+    run consistency checks on a histogram, checking for empty bins
+    and ill-defined statistical uncertainties, fix issues if possible
+    """
+    # check for empty bins
+    empty_bins = np.where(histogram["yields"] == 0.0)[0]
+    if len(empty_bins) > 0:
+        log.warn("%s has empty bins: %s", name, empty_bins)
+
+    # check for ill-defined stat. unc.
+    nan_pos = np.where(np.isnan(histogram["sumw2"]))[0]
+    if len(nan_pos) > 0:
+        log.warn("%s has bins with ill-defined stat. unc.: %s", name, nan_pos)
+
+    # check whether there are any bins with ill-defined stat. uncertainty
+    # but non-empty yield, those deserve a closer look
+    not_empty_but_nan = [b for b in nan_pos if b not in empty_bins]
+    if len(not_empty_but_nan) > 0:
+        log.warn(
+            "%s has non-empty bins with ill-defined stat. unc.: %s",
+            name,
+            not_empty_but_nan,
+        )
+
+    # fix ill defined stat. unc. (replace nan by 0)
+    log.debug("fixing ill-defined stat. unc. for %s", name)
+    histogram["sumw2"] = np.nan_to_num(histogram["sumw2"], nan=0.0)
+    return histogram

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -99,14 +99,12 @@ def create_histograms(config, output_path, method="uproot", only_nominal=False):
                 histogram = histogram_wrapper.to_dict(yields, sumw2, bins)
 
                 # generate a name for the histogram
-                histogram_name = histogram_wrapper._build_name(
+                histogram_name = histogram_wrapper.build_name(
                     sample, region, systematic
                 )
 
-                # check the histogram for common issues, fix them possible
-                histogram = histogram_wrapper._validate_and_fix(
-                    histogram, histogram_name
-                )
+                # check the histogram for common issues
+                histogram_wrapper.validate(histogram, histogram_name)
 
                 # save it
                 histogram_wrapper.save(histogram, output_path, histogram_name)

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -23,13 +23,11 @@ def run(config, histogram_folder):
     for sample in config["Samples"]:
         for region in config["Regions"]:
             for systematic in [{"Name": "nominal"}]:
-                histogram_name = histogram_wrapper._build_histogram_name(
+                histogram_name = histogram_wrapper._build_name(
                     sample, region, systematic
                 )
-                histogram = histogram_wrapper.load_histogram(
-                    histogram_folder, histogram_name
-                )
+                histogram = histogram_wrapper.load(histogram_folder, histogram_name)
                 new_histogram = _adjust_histogram(histogram)
-                histogram_wrapper.save_histogram(
+                histogram_wrapper.save(
                     new_histogram, histogram_folder, histogram_name + "_modified"
                 )

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -1,4 +1,5 @@
 import logging
+import numpy as np
 
 from . import histogram_wrapper
 
@@ -6,11 +7,22 @@ from . import histogram_wrapper
 log = logging.getLogger(__name__)
 
 
-def _adjust_histogram(histogram):
+def _fix_stat_unc(histogram, name):
+    """
+    replace nan stat. unc. by zero
+    """
+    nan_pos = np.where(np.isnan(histogram["sumw2"]))[0]
+    if len(nan_pos) > 0:
+        log.debug("fixing ill-defined stat. unc. for %s", name)
+        histogram["sumw2"] = np.nan_to_num(histogram["sumw2"], nan=0.0)
+    return histogram
+
+
+def adjust_histogram(histogram, name):
     """
     create a new modified histogram
     """
-    new_histogram = histogram  # for now, the histogram is unchanged
+    new_histogram = _fix_stat_unc(histogram, name)
     return new_histogram
 
 
@@ -23,11 +35,14 @@ def run(config, histogram_folder):
     for sample in config["Samples"]:
         for region in config["Regions"]:
             for systematic in [{"Name": "nominal"}]:
-                histogram_name = histogram_wrapper._build_name(
+                histogram_name = histogram_wrapper.build_name(
                     sample, region, systematic
                 )
-                histogram = histogram_wrapper.load(histogram_folder, histogram_name)
-                new_histogram = _adjust_histogram(histogram)
+                histogram = histogram_wrapper.load(
+                    histogram_folder, histogram_name, modified=False
+                )
+                new_histogram = adjust_histogram(histogram, histogram_name)
+                histogram_wrapper.validate(histogram, histogram_name)
                 histogram_wrapper.save(
                     new_histogram, histogram_folder, histogram_name + "_modified"
                 )

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -33,14 +33,17 @@ def data_MC(config, histogram_folder, figure_folder, prefit=True, method="matplo
         for sample in config["Samples"]:
             for systematic in [{"Name": "nominal"}]:
                 is_data = sample.get("Data", False)
-                histogram_name = histogram_wrapper._build_histogram_name(
+                histogram_name = histogram_wrapper._build_name(
                     sample, region, systematic
                 )
-                histogram = histogram_wrapper.load_histogram(
-                    histogram_folder, histogram_name
-                )
+                histogram = histogram_wrapper.load(histogram_folder, histogram_name)
                 histogram_dict_list.append(
-                    {"label": sample["Name"], "isData": is_data, "hist": histogram}
+                    {
+                        "label": sample["Name"],
+                        "isData": is_data,
+                        "hist": histogram,
+                        "variable": region["Variable"],
+                    }
                 )
 
         figure_name = _build_figure_name(region["Name"], prefit)

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -33,10 +33,12 @@ def data_MC(config, histogram_folder, figure_folder, prefit=True, method="matplo
         for sample in config["Samples"]:
             for systematic in [{"Name": "nominal"}]:
                 is_data = sample.get("Data", False)
-                histogram_name = histogram_wrapper._build_name(
+                histogram_name = histogram_wrapper.build_name(
                     sample, region, systematic
                 )
-                histogram = histogram_wrapper.load(histogram_folder, histogram_name)
+                histogram = histogram_wrapper.load(
+                    histogram_folder, histogram_name, modified=True
+                )
                 histogram_dict_list.append(
                     {
                         "label": sample["Name"],

--- a/util/create_histograms.py
+++ b/util/create_histograms.py
@@ -125,9 +125,9 @@ def plot_distributions(data, weights, labels, pseudodata, bins):
 
 if __name__ == "__main__":
     # configuration
-    num_events = 100000
-    yield_s = 12500
-    yield_b = 100000
+    num_events = 1000
+    yield_s = 125
+    yield_b = 1000
     labels = ["signal", "background"]  # names of prcesses
     file_name = output_directory + "prediction.root"
     file_name_pseudodata = output_directory + "data.root"


### PR DESCRIPTION
This adds reading and propagating of statistical uncertainties, changes the way histograms are passed around internally to a dict, and propagates the new information to the plotting code as well. It also adds examples and infrastructure for sanity checks for the histograms. Lastly, a small readme update with instructions for running a simple example.

```
* statistical uncertainty extraction and propagation for histograms
* data/MC drawing improvements
* sanity checks for histograms
* functionality to load original/post-processed histogram
```