### PR TITLE
ci: adding iminuit dependency

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,6 @@ jobs:
       run: |
         pip install .
         # install extra dependencies the example needs
-        pip install matplotlib uproot scipy
+        pip install matplotlib uproot scipy iminuit
         python util/create_histograms.py
         python example.py


### PR DESCRIPTION
#8 introduced an `iminuit` dependency through `pyhf`, which needs to be manually installed for the CI.