### PR TITLE
test: adding first tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: CI
@@ -13,13 +13,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -33,7 +36,6 @@ jobs:
     - name: Lint with Black
       run: |
         black --check --diff --verbose .
-
     - name: Install cabinetry and test example
       run: |
         pip install .
@@ -41,3 +43,6 @@ jobs:
         pip install matplotlib uproot scipy iminuit
         python util/create_histograms.py
         python example.py
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,17 +26,17 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 black
+        pip install flake8 black pytest
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 src/cabinetry --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 src/cabinetry --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=src/cabinetry/__init__.py
-    - name: Lint with Black
+    - name: Format with Black
       run: |
         black --check --diff --verbose .
-    - name: Install cabinetry and test example
+    - name: Install cabinetry and dependencies, run example
       run: |
         pip install .
         # install extra dependencies the example needs

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 __pycache__
 *.pyc
 
+# code coverage
+.coverage
+
 # packaging
 *.egg-info
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__
 
 # code coverage
 .coverage
+htmlcov
 
 # packaging
 *.egg-info

--- a/example.py
+++ b/example.py
@@ -18,23 +18,23 @@ if __name__ == "__main__":
         raise SystemExit
 
     # import example config file
-    fit_config = cabinetry.config.read("config_example.yml")
-    cabinetry.config.print_overview(fit_config)
+    cabinetry_config = cabinetry.config.read("config_example.yml")
+    cabinetry.config.print_overview(cabinetry_config)
 
     # create template histograms
     input_folder = "util/ntuples"
     histo_folder = "histograms/"
     cabinetry.template_builder.create_histograms(
-        fit_config, histo_folder, only_nominal=True, method="uproot"
+        cabinetry_config, histo_folder, only_nominal=True, method="uproot"
     )
 
     # perform histogram post-processing
-    cabinetry.template_postprocessor.run(fit_config, histo_folder)
+    cabinetry.template_postprocessor.run(cabinetry_config, histo_folder)
 
     # build a workspace and save to file
     workspace_folder = "workspaces/"
     workspace_name = "example_workspace"
-    ws = cabinetry.workspace.build(fit_config, histo_folder)
+    ws = cabinetry.workspace.build(cabinetry_config, histo_folder)
     cabinetry.workspace.save(ws, workspace_folder, workspace_name)
 
     # run a fit
@@ -43,5 +43,5 @@ if __name__ == "__main__":
     # visualize some results
     figure_folder = "figures/"
     cabinetry.visualize.data_MC(
-        fit_config, histo_folder, figure_folder, prefit=True, method="matplotlib",
+        cabinetry_config, histo_folder, figure_folder, prefit=True, method="matplotlib",
     )

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -50,3 +50,4 @@ def fit(spec):
     labels = get_parameter_names(model)
 
     print_results(bestfit, uncertainty, labels)
+    return bestfit, uncertainty, labels

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -74,20 +74,22 @@ def validate(histogram, name):
     and ill-defined statistical uncertainties
     """
     # check for empty bins
-    empty_bins = np.where(histogram["yields"] == 0.0)[0]
+    # using np.atleast_1d to fix deprecation warning, even though the
+    # input should never need it
+    empty_bins = np.where(np.atleast_1d(histogram["yields"]) == 0.0)[0]
     if len(empty_bins) > 0:
-        log.warn("%s has empty bins: %s", name, empty_bins)
+        log.warning("%s has empty bins: %s", name, empty_bins)
 
     # check for ill-defined stat. unc.
     nan_pos = np.where(np.isnan(histogram["sumw2"]))[0]
     if len(nan_pos) > 0:
-        log.warn("%s has bins with ill-defined stat. unc.: %s", name, nan_pos)
+        log.warning("%s has bins with ill-defined stat. unc.: %s", name, nan_pos)
 
     # check whether there are any bins with ill-defined stat. uncertainty
     # but non-empty yield, those deserve a closer look
     not_empty_but_nan = [b for b in nan_pos if b not in empty_bins]
     if len(not_empty_but_nan) > 0:
-        log.warn(
+        log.warning(
             "%s has non-empty bins with ill-defined stat. unc.: %s",
             name,
             not_empty_but_nan,

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -18,7 +18,7 @@ def _build_figure_name(region, is_prefit):
     if is_prefit:
         figure_name += "_" + "prefit"
     else:
-        figure_name += "_" + "prefit"
+        figure_name += "_" + "postfit"
     figure_name += ".pdf"
     return figure_name
 

--- a/tests/contrib/test_histogram_creation.py
+++ b/tests/contrib/test_histogram_creation.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from cabinetry.contrib import histogram_creation
+
+
+def test__sumw2():
+    weights = np.array([0.1, 0.2, 0.1])
+    assert np.allclose(histogram_creation._sumw2(weights), 0.2449489743)
+
+
+def test__bin_data():
+    data = [1.1, 2.2, 2.9, 2.5, 1.4]
+    weights = [1.0, 1.1, 0.9, 0.8, 1.5]
+    bins = [1, 2, 3]
+    yields, sumw2 = histogram_creation._bin_data(data, weights, bins)
+    assert np.allclose(yields, [2.5, 2.8])
+    assert np.allclose(sumw2, [1.80277564, 1.63095064])

--- a/tests/contrib/test_histogram_drawing.py
+++ b/tests/contrib/test_histogram_drawing.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+from cabinetry.contrib import histogram_drawing
+
+
+def test__total_yield_uncertainty():
+    sumw2_list = [[0.1, 0.2, 0.1], [0.3, 0.2, 0.1]]
+    expected_uncertainties = [0.31622777, 0.28284271, 0.14142136]
+    assert np.allclose(
+        histogram_drawing._total_yield_uncertainty(sumw2_list), expected_uncertainties
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,67 @@
+import pytest
+
+from cabinetry import config
+
+
+def test_read():
+    config.read("config_example.yml")
+
+
+def test_validate_missing_key():
+    config_example = {"General": []}
+    with pytest.raises(Exception) as e_info:
+        config.validate(config_example)
+
+
+def test_validate_unknown_key():
+    config_example = {
+        "General": "",
+        "Regions": "",
+        "NormFactors": "",
+        "Samples": "",
+        "unknown": [],
+    }
+    with pytest.raises(Exception) as e_info:
+        config.validate(config_example)
+
+
+def test_validate_multiple_data_samples():
+    config_example = {
+        "General": "",
+        "Regions": "",
+        "NormFactors": "",
+        "Samples": [{"Data": True}, {"Data": True}],
+    }
+    with pytest.raises(Exception) as e_info:
+        config.validate(config_example)
+
+
+def test_validate_valid():
+    config_example = {
+        "General": "",
+        "Regions": "",
+        "NormFactors": "",
+        "Samples": [{"Data": True}],
+    }
+    config.validate(config_example)
+
+
+def test_print_overview():
+    config_example = {
+        "General": "",
+        "Regions": "",
+        "NormFactors": "",
+        "Samples": [{"Data": True}],
+        "Systematics": "",
+    }
+    config.print_overview(config_example)
+
+
+def test_print_overview_no_sys():
+    config_example = {
+        "General": "",
+        "Regions": "",
+        "NormFactors": "",
+        "Samples": [{"Data": True}],
+    }
+    config.print_overview(config_example)

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -22,7 +22,7 @@ def test_get_parameter_names():
     spec = _get_spec()
     model = pyhf.Workspace(spec).model()
     labels = fit.get_parameter_names(model)
-    assert labels == ['staterror_Signal-Region', 'Signal strength']
+    assert labels == ["staterror_Signal-Region", "Signal strength"]
 
 
 def test_print_results(caplog):
@@ -42,4 +42,4 @@ def test_fit():
     bestfit, uncertainty, labels = fit.fit(spec)
     assert np.allclose(bestfit, [0.99998772, 9.16255687])
     assert np.allclose(uncertainty, [0.04954955, 0.61348804])
-    assert labels == ['staterror_Signal-Region', 'Signal strength']
+    assert labels == ["staterror_Signal-Region", "Signal strength"]

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -1,0 +1,45 @@
+import logging
+import numpy as np
+
+import pyhf
+
+from cabinetry import fit
+
+
+def _get_spec():
+    # fmt: off
+    spec = {"channels":[{"name":"Signal Region","samples":[{"data":[51.839756],
+    "modifiers":[{"data":[2.5695188],"name":"staterror_Signal-Region",
+    "type":"staterror"},{"data":None,"name":"Signal strength","type":"normfactor"}],
+    "name":"Signal"}]}],"measurements":[{"config":{"parameters":[],
+    "poi":"Signal strength"},"name":"My fit"}],"observations":
+    [{"data":[475],"name":"Signal Region"}],"version":"1.0.0"}
+    # fmt: on
+    return spec
+
+
+def test_get_parameter_names():
+    spec = _get_spec()
+    model = pyhf.Workspace(spec).model()
+    labels = fit.get_parameter_names(model)
+    assert labels == ['staterror_Signal-Region', 'Signal strength']
+
+
+def test_print_results(caplog):
+    caplog.set_level(logging.DEBUG)
+
+    bestfit = [1.0, 2.0]
+    uncertainty = [0.1, 0.3]
+    labels = ["param_A", "param_B"]
+    fit.print_results(bestfit, uncertainty, labels)
+    assert "param_A: 1.000000 +/- 0.100000" in [rec.message for rec in caplog.records]
+    assert "param_B: 2.000000 +/- 0.300000" in [rec.message for rec in caplog.records]
+    caplog.clear()
+
+
+def test_fit():
+    spec = _get_spec()
+    bestfit, uncertainty, labels = fit.fit(spec)
+    assert np.allclose(bestfit, [0.99998772, 9.16255687])
+    assert np.allclose(uncertainty, [0.04954955, 0.61348804])
+    assert labels == ['staterror_Signal-Region', 'Signal strength']

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -1,0 +1,105 @@
+import logging
+
+import pytest
+
+from cabinetry import histo
+
+
+def _example_hist():
+    yields = [1, 2]
+    sumw2 = [0.1, 0.2]
+    bins = [1, 2]
+    return histo.to_dict(yields, sumw2, bins)
+
+
+def _example_hist_single_bin():
+    yields = [1]
+    sumw2 = [0.1]
+    bins = [1]
+    return histo.to_dict(yields, sumw2, bins)
+
+
+def _example_hist_empty_bin():
+    yields = [1, 0]
+    sumw2 = [0.1, 0.2]
+    bins = [1, 2]
+    return histo.to_dict(yields, sumw2, bins)
+
+
+def _example_hist_nan_sumw2_empty_bin():
+    yields = [1, 0]
+    sumw2 = [0.1, float("NaN")]
+    bins = [1, 2]
+    return histo.to_dict(yields, sumw2, bins)
+
+
+def _example_hist_nan_sumw2_nonempty_bin():
+    yields = [1, 2]
+    sumw2 = [0.1, float("NaN")]
+    bins = [1, 2]
+    return histo.to_dict(yields, sumw2, bins)
+
+
+def test_to_dict():
+    yields = [1, 2]
+    sumw2 = [0.1, 0.2]
+    bins = [1, 2]
+    assert histo.to_dict(yields, sumw2, bins) == {
+        "yields": yields,
+        "sumw2": sumw2,
+        "bins": bins,
+    }
+
+
+def test_save(tmpdir):
+    pass
+
+
+def test_load():
+    pass
+
+
+def test_build_name():
+    sample = {"Name": "Sample"}
+    region = {"Name": "Region"}
+    systematic = {"Name": "Systematic"}
+    assert histo.build_name(sample, region, systematic) == "Sample_Region_Systematic"
+
+    sample = {"Name": "Sample 1"}
+    region = {"Name": "Region 1"}
+    systematic = {"Name": "Systematic 1"}
+    assert (
+        histo.build_name(sample, region, systematic) == "Sample-1_Region-1_Systematic-1"
+    )
+
+
+def test_validate(caplog):
+    caplog.set_level(logging.DEBUG)
+    name = "test_histo"
+
+    # should cause no warnings
+    histo.validate(_example_hist(), name)
+    histo.validate(_example_hist_single_bin(), name)
+
+    # check for empty bin warning
+    histo.validate(_example_hist_empty_bin(), name)
+    assert "test_histo has empty bins: [1]" in [rec.message for rec in caplog.records]
+    caplog.clear()
+
+    # check for ill-defined stat uncertainty warning
+    histo.validate(_example_hist_nan_sumw2_empty_bin(), name)
+    assert "test_histo has empty bins: [1]" in [rec.message for rec in caplog.records]
+    assert "test_histo has bins with ill-defined stat. unc.: [1]" in [
+        rec.message for rec in caplog.records
+    ]
+    caplog.clear()
+
+    # check for ill-defined stat uncertainty warning with non-zero bin
+    histo.validate(_example_hist_nan_sumw2_nonempty_bin(), name)
+    assert "test_histo has bins with ill-defined stat. unc.: [1]" in [
+        rec.message for rec in caplog.records
+    ]
+    assert "test_histo has non-empty bins with ill-defined stat. unc.: [1]" in [
+        rec.message for rec in caplog.records
+    ]
+    caplog.clear()

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -1,0 +1,37 @@
+import pytest
+
+from cabinetry import template_builder
+
+
+def test__get_ntuple_path():
+    assert (
+        template_builder._get_ntuple_path({"Path": "test/path.root"}, {}, {})
+        == "test/path.root"
+    )
+
+
+def test__get_selection():
+    assert template_builder._get_selection({}, {"Variable": "jet_pt"}, {}) == "jet_pt"
+
+
+def test__get_weight():
+    assert template_builder._get_weight({"Weight": "weight_mc"}, {}, {}) == "weight_mc"
+    assert template_builder._get_weight({}, {}, {}) == None
+
+
+def test__get_position_in_file():
+    assert template_builder._get_position_in_file({"Tree": "tree_name"}) == "tree_name"
+
+
+def test__get_binning():
+    assert template_builder._get_binning({"Binning": [1, 2, 3]}) == [1, 2, 3]
+    with pytest.raises(Exception) as e_info:
+        assert template_builder._get_binning({})
+
+
+def test_create_histograms(tmpdir):
+    # needs to be expanded into a proper test
+    config = {"Samples": {}, "Regions": {}, "Systematics": {}}
+    template_builder.create_histograms(
+        config, tmpdir, method="uproot", only_nominal=True
+    )

--- a/tests/test_template_postprocessor.py
+++ b/tests/test_template_postprocessor.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from cabinetry import template_postprocessor
+
+
+def test__fix_stat_unc():
+    histo = {"sumw2": [float("nan"), 0.2]}
+    name = "test_histo"
+    fixed_sumw2 = [0.0, 0.2]
+    assert np.allclose(
+        template_postprocessor._fix_stat_unc(histo, name)["sumw2"], fixed_sumw2
+    )
+
+
+def test__fix_stat_unc_no_fix():
+    histo = {"sumw2": [0.1, 0.2]}
+    name = "test_histo"
+    fixed_sumw2 = [0.1, 0.2]
+    assert np.allclose(
+        template_postprocessor._fix_stat_unc(histo, name)["sumw2"], fixed_sumw2
+    )
+
+
+def test_adjust_histogram():
+    histo = {"sumw2": [float("nan"), 0.2]}
+    name = "test_histo"
+    fixed_sumw2 = [0.0, 0.2]
+    assert np.allclose(
+        template_postprocessor.adjust_histogram(histo, name)["sumw2"], fixed_sumw2
+    )
+
+
+def test_run(tmpdir):
+    # needs to be expanded into a proper test
+    config = {"Samples": {}, "Regions": {}, "Systematics": {}}
+    template_postprocessor.run(config, tmpdir)

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -1,0 +1,8 @@
+from cabinetry import visualize
+
+
+def test__build_figure_name():
+    assert visualize._build_figure_name("SR", True) == "SR_prefit.pdf"
+    assert visualize._build_figure_name("SR", False) == "SR_postfit.pdf"
+    assert visualize._build_figure_name("SR 1", True) == "SR-1_prefit.pdf"
+    assert visualize._build_figure_name("SR 1", False) == "SR-1_postfit.pdf"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,40 @@
+from cabinetry import workspace
+
+
+def test__get_data_sample():
+    mc_sample = {"Name": "MC"}
+    data_sample = {"Name": "Data", "Data": True}
+    config_example = {"Samples": [mc_sample, data_sample]}
+    assert workspace._get_data_sample(config_example) == data_sample
+
+
+def test_get_NF_modifiers():
+    # one NF affects sample
+    example_config = {"NormFactors": [{"Name": "mu", "Samples": ["ABC", "DEF"]}]}
+    sample = {"Name": "DEF"}
+    expected_modifier = [{"data": None, "name": "mu", "type": "normfactor"}]
+    assert workspace.get_NF_modifiers(example_config, sample) == expected_modifier
+
+    # no NF affects sample
+    sample = {"Name": "GHI"}
+    assert workspace.get_NF_modifiers(example_config, sample) == []
+
+    # multiple NFs affect sample
+    example_config = {
+        "NormFactors": [
+            {"Name": "mu", "Samples": ["ABC", "DEF"]},
+            {"Name": "k", "Samples": ["DEF", "GHI"]},
+        ]
+    }
+    sample = {"Name": "DEF"}
+    expected_modifier = [
+        {"data": None, "name": "mu", "type": "normfactor"},
+        {"data": None, "name": "k", "type": "normfactor"},
+    ]
+    assert workspace.get_NF_modifiers(example_config, sample) == expected_modifier
+
+
+def test_get_measurement():
+    example_config = {"General": {"Measurement": "fit", "POI": "mu"}}
+    expected_measurement = [{"name": "fit", "config": {"poi": "mu", "parameters": []}}]
+    assert workspace.get_measurements(example_config) == expected_measurement


### PR DESCRIPTION
Adding the first tests to be run with `pytest` to test framework functionality. All modules are tested separately. Also fixing a typo for postfit histogram naming and returning MLE fit results for easier access. CI expanded to test python 3.6, 3.7, 3.8.