### PR TITLE
ci: fixing flake8 path

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,9 +27,9 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 cabinetry --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 src/cabinetry --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 cabinetry --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=cabinetry/__init__.py
+        flake8 src/cabinetry --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=src/cabinetry/__init__.py
     - name: Lint with Black
       run: |
         black --check --diff --verbose .


### PR DESCRIPTION
The `flake8` check pointed to `cabinetry` instead of `src/cabinetry`, fixed with this. 