### PR TITLE
test: ignoring numpy warning

### DIFF
--- a/example.py
+++ b/example.py
@@ -43,5 +43,5 @@ if __name__ == "__main__":
     # visualize some results
     figure_folder = "figures/"
     cabinetry.visualize.data_MC(
-        cabinetry_config, histo_folder, figure_folder, prefit=True, method="matplotlib",
+        cabinetry_config, histo_folder, figure_folder, prefit=True, method="matplotlib"
     )

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -2,6 +2,7 @@ import logging
 import numpy as np
 
 import pyhf
+import pytest
 
 from cabinetry import fit
 
@@ -37,6 +38,9 @@ def test_print_results(caplog):
     caplog.clear()
 
 
+# skip a "RuntimeWarning: numpy.ufunc size changed" warning
+# due to different numpy versions used in dependencies
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_fit():
     spec = _get_spec()
     bestfit, uncertainty, labels = fit.fit(spec)


### PR DESCRIPTION
`pytest` reports a warning produced likely due to different `numpy` versions used by `cabinetry` dependencies, this ignores the warning. See also https://github.com/scikit-hep/pyhf/issues/871. Small formatting fix in example script.