### PR TITLE
refactor: file path handling

### DIFF
--- a/example.py
+++ b/example.py
@@ -38,6 +38,7 @@ if __name__ == "__main__":
     cabinetry.workspace.save(ws, workspace_folder, workspace_name)
 
     # run a fit
+    ws = cabinetry.workspace.load(workspace_folder, workspace_name)
     cabinetry.fit.fit(ws)
 
     # visualize some results

--- a/example.py
+++ b/example.py
@@ -32,13 +32,12 @@ if __name__ == "__main__":
     cabinetry.template_postprocessor.run(cabinetry_config, histo_folder)
 
     # build a workspace and save to file
-    workspace_folder = "workspaces/"
-    workspace_name = "example_workspace"
+    workspace_path = "workspaces/example_workspace.json"
     ws = cabinetry.workspace.build(cabinetry_config, histo_folder)
-    cabinetry.workspace.save(ws, workspace_folder, workspace_name)
+    cabinetry.workspace.save(ws, workspace_path)
 
     # run a fit
-    ws = cabinetry.workspace.load(workspace_folder, workspace_name)
+    ws = cabinetry.workspace.load(workspace_path)
     cabinetry.fit.fit(ws)
 
     # visualize some results

--- a/src/cabinetry/config.py
+++ b/src/cabinetry/config.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 import yaml
 
 
@@ -9,13 +10,13 @@ OPTIONAL_CONFIG_KEYS = ["Systematics"]
 log = logging.getLogger(__name__)
 
 
-def read(file_path):
+def read(file_path_string):
     """
     read a config file from a provided path and return it
     """
+    file_path = Path(file_path_string)
     log.info("opening config file %s", file_path)
-    with open(file_path) as f:
-        config = yaml.safe_load(f)
+    config = yaml.safe_load(file_path.read_text())
     validate(config)
     return config
 

--- a/src/cabinetry/contrib/histogram_drawing.py
+++ b/src/cabinetry/contrib/histogram_drawing.py
@@ -3,23 +3,32 @@ import os
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 import numpy as np
+from pathlib import Path
 
 
 log = logging.getLogger(__name__)
 
 
 def _total_yield_uncertainty(sumw2_list):
-    """
-    calculate the absolute statistical uncertainty of a stack of MC
+    """calculate the absolute statistical uncertainty of a stack of MC
     via sum in quadrature
+
+    Args:
+        sumw2_list (list): list of absolute stat. uncertainty per sample
+
+    Returns:
+        np.array: absolute stat. uncertainty of stack of samples
     """
     tot_unc = np.sqrt(np.sum(np.power(sumw2_list, 2), axis=0))
     return tot_unc
 
 
-def data_MC_matplotlib(histogram_dict_list, figure_folder, figure_name):
-    """
-    draw a data/MC histogram with matplotlib
+def data_MC_matplotlib(histogram_dict_list, figure_path):
+    """draw a data/MC histogram with matplotlib
+
+    Args:
+        histogram_dict_list (list[dict]): list of samples (with info stored in one dict per sample)
+        figure_path (pathlib.Path): path where figure should be saved
     """
     mc_histograms_yields = []
     mc_histograms_sumw2 = []
@@ -97,8 +106,8 @@ def data_MC_matplotlib(histogram_dict_list, figure_folder, figure_name):
     plt.ylim([0, y_max * 1.1])  # 10% headroom
     plt.plot()
 
-    if not os.path.exists(figure_folder):
-        os.mkdir(figure_folder)
-    log.debug("saving %s to %s", figure_name, figure_folder)
-    plt.savefig(figure_folder + figure_name)
+    if not os.path.exists(figure_path.parent):
+        os.mkdir(figure_path.parent)
+    log.debug("saving figure as %s", figure_path)
+    plt.savefig(figure_path)
     plt.clf()

--- a/src/cabinetry/contrib/histogram_drawing.py
+++ b/src/cabinetry/contrib/histogram_drawing.py
@@ -3,7 +3,6 @@ import os
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 import numpy as np
-from pathlib import Path
 
 
 log = logging.getLogger(__name__)

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -4,6 +4,7 @@ different formats, so saving and loading should go through this wrapper
 """
 import logging
 import os
+from pathlib import Path
 
 import numpy as np
 
@@ -12,56 +13,98 @@ log = logging.getLogger(__name__)
 
 
 def to_dict(yields, sumw2, bins):
-    """
-    to more conveniently move around histogram information internally, put it
+    """to more conveniently move around histogram information internally, put it
     into a dictionary
+
+    Args:
+        yields (numpy.ndarray): yield per histogram bin
+        sumw2 (numpy.ndarray): statistical uncertainty of yield per bin
+        bins (list): edges of histogram bins
+
+    Returns:
+        dict: dictionary containing histogram information
     """
     histogram = {"yields": yields, "sumw2": sumw2, "bins": bins}
     return histogram
 
 
-def save(histogram, path, histogram_name):
+def save(histogram, histo_path):
+    """save a histogram to disk
+
+    Args:
+        histogram (dict): the histogram to be saved
+        histo_path (pathlib.Path): where to save the histogram
     """
-    save a histogram to disk
-    """
-    log.debug("saving %s to %s", histogram_name, path)
+    log.debug("saving histogram to %s", histo_path.with_suffix(".npz"))
 
     # create output directory if it does not exist yet
-    if not os.path.exists(path):
-        os.mkdir(path)
+    if not os.path.exists(histo_path.parent):
+        os.mkdir(histo_path.parent)
     np.savez(
-        path + histogram_name + ".npz",
+        histo_path.with_suffix(".npz"),
         yields=histogram["yields"],
         sumw2=histogram["sumw2"],
         bins=histogram["bins"],
     )
 
 
-def load(path, histogram_name, modified=True):
-    """
-    load a histogram from disk and convert it into dictionary form
+def _load(histo_path, modified=True):
+    """load a histogram from disk and convert it into dictionary form
     try to load the "modified" version of the histogram by default
     (which received post-processing)
+
+    Args:
+        histo_path (pathlib.Path): where the histogram is located
+        modified (bool, optional): whether to load the modified histogram (after post-processing), defaults to True
+
+    Returns:
+        dict: the loaded histogram
     """
     if modified:
-        histo_path = path + histogram_name + "_modified" + ".npz"
-        if not os.path.exists(histo_path):
+        if not histo_path.exists:
             log.error("the modified histogram %s does not exist", histo_path)
             log.error("loading the un-modified histogram instead!")
-            histo_path = path + histogram_name + ".npz"
     else:
-        histo_path = path + histogram_name + ".npz"
-    histogram_npz = np.load(histo_path)
+        histo_path = histo_path.parent / (histo_path.name + "_modified")
+    histogram_npz = np.load(histo_path.with_suffix(".npz"))
     yields = histogram_npz["yields"]
     sumw2 = histogram_npz["sumw2"]
     bins = histogram_npz["bins"]
     return to_dict(yields, sumw2, bins)
 
 
-def build_name(sample, region, systematic):
+def load_from_config(histo_folder, sample, region, systematic, modified=True):
+    """load a histogram, given a folder the histograms are located in and the
+    relevant information from the config: sample, region, systematic,
+
+    Args:
+        histo_folder (str): folder containing all histograms
+        sample (dict): containing all sample information
+        region (dict): containing all region information
+        systematic (dict): containing all systematic information
+        modified (bool, optional): whether to load the modified histogram (after post-processing), defaults to True
+
+    Returns:
+        dict: the loaded histogram
+        str: name of the histogram
     """
-    construct a unique name for each histogram
-    param sample: the sample
+    # find the histogram name given config information, and then load the histogram
+    histo_name = build_name(sample, region, systematic)
+    histo_path = Path(histo_folder) / histo_name
+    histogram = _load(histo_path, modified)
+    return histogram, histo_name
+
+
+def build_name(sample, region, systematic):
+    """construct a unique name for each histogram
+
+    Args:
+        sample (dict): containing all sample information
+        region (dict): containing all region information
+        systematic (dict): containing all systematic information
+
+    Returns:
+        str: unique name for the histogram
     """
     name = sample["Name"] + "_" + region["Name"] + "_" + systematic["Name"]
     name = name.replace(" ", "-")
@@ -69,9 +112,12 @@ def build_name(sample, region, systematic):
 
 
 def validate(histogram, name):
-    """
-    run consistency checks on a histogram, checking for empty bins
+    """run consistency checks on a histogram, checking for empty bins
     and ill-defined statistical uncertainties
+
+    Args:
+        histogram (dict): the histogram to validate
+        name (str): name of the histogram for logging purposes
     """
     # check for empty bins
     # using np.atleast_1d to fix deprecation warning, even though the

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -61,11 +61,15 @@ def _load(histo_path, modified=True):
         dict: the loaded histogram
     """
     if modified:
-        if not histo_path.exists:
-            log.error("the modified histogram %s does not exist", histo_path)
-            log.error("loading the un-modified histogram instead!")
-    else:
-        histo_path = histo_path.parent / (histo_path.name + "_modified")
+        histo_path_modified = histo_path.parent / (histo_path.name + "_modified")
+        if not histo_path_modified.with_suffix(".npz").exists():
+            log.warning(
+                "the modified histogram %s does not exist",
+                histo_path_modified.with_suffix(".npz"),
+            )
+            log.warning("loading the un-modified histogram instead!")
+        else:
+            histo_path = histo_path_modified
     histogram_npz = np.load(histo_path.with_suffix(".npz"))
     yields = histogram_npz["yields"]
     sumw2 = histogram_npz["sumw2"]

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 
 from . import histo
 
@@ -7,42 +8,77 @@ log = logging.getLogger(__name__)
 
 
 def _get_ntuple_path(sample, region, systematic):
+    """determine the path to ntuples from which a histogram has to be built
+
+    Args:
+        sample (dict): containing all sample information
+        region (dict): containing all region information
+        systematic (dict): containing all systematic information
+
+    Returns:
+        pathlib.Path: path where the ntuples are located
     """
-    determine the path to ntuples from which a histogram has to be built
-    """
-    path = sample["Path"]
+    path_str = sample["Path"]
+    path = Path(path_str)
     return path
 
 
 def _get_selection(sample, region, systematic):
-    """
-    construct the selection to be executed to obtain the histogram
+    """construct the selection to be executed to obtain the histogram
+
+    Args:
+        sample (dict): containing all sample information
+        region (dict): containing all region information
+        systematic (dict): containing all systematic information
+
+    Returns:
+        str: expression determining the selection applied to get the data to histogram
     """
     axis_variable = region["Variable"]
     return axis_variable
 
 
 def _get_weight(sample, region, systematic):
-    """
-    find the weight to be used for the events in the histogram
+    """find the weight to be used for the events in the histogram
+
+    Args:
+        sample (dict): containing all sample information
+        region (dict): containing all region information
+        systematic (dict): containing all systematic information
+
+    Returns:
+        str: weight used for events when filled into histograms
     """
     weight = sample.get("Weight", None)
     return weight
 
 
 def _get_position_in_file(sample):
-    """
-    the file might have some substructure, this specifies where in the file
+    """the file might have some substructure, this specifies where in the file
     the data is
+
+    Args:
+        sample (dict): containing all sample information
+
+    Returns:
+        str: where in the file to find the data, (right now the name of a tree)
     """
     return sample["Tree"]
 
 
 def _get_binning(region):
-    """
-    determine the binning to be used in a given region
+    """determine the binning to be used in a given region
     should eventually also support other ways of specifying bins,
     such as the amount of bins and the range to bin in
+
+    Args:
+        region (dict): containing all region information
+
+    Raises:
+        NotImplementedError: when the binning is not explicitly defined
+
+    Returns:
+        list: bin boundaries to be used for histogram
     """
     if "Binning" in region.keys():
         return region["Binning"]
@@ -50,11 +86,21 @@ def _get_binning(region):
         raise NotImplementedError
 
 
-def create_histograms(config, output_path, method="uproot", only_nominal=False):
-    """
-    generate all required histograms specified by a configuration file
+def create_histograms(config, folder_path_str, method="uproot", only_nominal=False):
+    """generate all required histograms specified by a configuration file
     a tool providing histograms should provide bin yields and statistical
     uncertainties, as well as the bin edges
+
+    Args:
+        config (dict): the cabinetry config
+        folder_path_str (str): folder to save the histograms to
+        method (str, optional): backend to use for histogram production, defaults to "uproot"
+        only_nominal (bool, optional): whether to only produce nominal histograms, defaults to False
+
+    Raises:
+        NotImplementedError: when systematic variations based on histograms are requested (not supported yet)
+        NotImplementedError: when requesting the ServiceX backend
+        NotImplementedError: when requesting another unknown backend
     """
     log.info("creating histograms")
 
@@ -105,4 +151,5 @@ def create_histograms(config, output_path, method="uproot", only_nominal=False):
                 histo.validate(histogram, histogram_name)
 
                 # save it
-                histo.save(histogram, output_path, histogram_name)
+                histo_path = Path(folder_path_str) / histogram_name
+                histo.save(histogram, histo_path)

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -3,6 +3,7 @@ need to save the histogram bins for visualization purposes still,
 as well as cosmetics such as axis labels and region names
 """
 import logging
+from pathlib import Path
 
 from . import histo
 
@@ -11,8 +12,14 @@ log = logging.getLogger(__name__)
 
 
 def _build_figure_name(region, is_prefit):
-    """
-    construct a name for the file a figure is saved as
+    """construct a name for the file a figure is saved as
+
+    Args:
+        region (dict): the region shown in the figure
+        is_prefit (bool): whether the figure shows the pre- or post-fit model
+
+    Returns:
+        str: name of the file the figure should be saved to
     """
     figure_name = region.replace(" ", "-")
     if is_prefit:
@@ -24,8 +31,18 @@ def _build_figure_name(region, is_prefit):
 
 
 def data_MC(config, histogram_folder, figure_folder, prefit=True, method="matplotlib"):
-    """
-    draw a data/MC histogram, control whether it is pre- or postfit with a flag
+    """draw a data/MC histogram, control whether it is pre- or postfit with a flag
+
+    Args:
+        config (dict): cabinetry configuration file
+        histogram_folder (str): path to the folder containing template histograms
+        figure_folder (str): path to the folder to save figures in
+        prefit (bool, optional): show the pre- or post-fit model, defaults to True
+        method (str, optional): what backend to use for plotting, defaults to "matplotlib"
+
+    Raises:
+        NotImplementedError: when trying to plot with a method that is not supported
+        NotImplementedError: when trying to visualize post-fit distributions, not supported yet
     """
     log.info("visualizing histogram")
     for region in config["Regions"]:
@@ -50,9 +67,8 @@ def data_MC(config, histogram_folder, figure_folder, prefit=True, method="matplo
             if method == "matplotlib":
                 from cabinetry.contrib import histogram_drawing
 
-                histogram_drawing.data_MC_matplotlib(
-                    histogram_dict_list, figure_folder, figure_name
-                )
+                figure_path = Path(figure_folder) / figure_name
+                histogram_drawing.data_MC_matplotlib(histogram_dict_list, figure_path)
             else:
                 raise NotImplementedError
         else:

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -50,8 +50,9 @@ def data_MC(config, histogram_folder, figure_folder, prefit=True, method="matplo
         for sample in config["Samples"]:
             for systematic in [{"Name": "nominal"}]:
                 is_data = sample.get("Data", False)
-                histogram_name = histo.build_name(sample, region, systematic)
-                histogram = histo.load(histogram_folder, histogram_name, modified=True)
+                histogram, _ = histo.load_from_config(
+                    histogram_folder, sample, region, systematic, modified=True
+                )
                 histogram_dict_list.append(
                     {
                         "label": sample["Name"],

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -27,8 +27,9 @@ def get_yield_for_sample(
     get the yield for a specific sample, by figuring out its name and then
     obtaining the yield from the correct histogram
     """
-    histogram_name = histo.build_name(sample, region, systematic)
-    histogram = histo.load(histogram_folder, histogram_name, modified=True)
+    histogram, _ = histo.load_from_config(
+        histogram_folder, sample, region, systematic, modified=True
+    )
     histo_yield = histogram["yields"].tolist()
     return histo_yield
 
@@ -40,8 +41,9 @@ def get_unc_for_sample(
     get the uncertainty of a specific sample, by figuring out its name and then
     obtaining the sumw2 from the correct histogram
     """
-    histogram_name = histo.build_name(sample, region, systematic)
-    histogram = histo.load(histogram_folder, histogram_name, modified=True)
+    histogram, _ = histo.load_from_config(
+        histogram_folder, sample, region, systematic, modified=True
+    )
     histo_yield = histogram["sumw2"].tolist()
     return histo_yield
 

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from pathlib import Path
 
 import pyhf
 
@@ -227,24 +228,23 @@ def validate(ws):
     pyhf.Workspace(ws)
 
 
-def save(ws, path, name):
+def save(ws, file_path_string):
     """
     save the workspace to a file
     """
-    log.debug("saving workspace %s to %s", name, path + name + ".json")
-
+    file_path = Path(file_path_string)
+    log.debug("saving workspace to %s", file_path)
     # create output directory if it does not exist yet
-    if not os.path.exists(path):
-        os.mkdir(path)
+    if not os.path.exists(file_path.parent):
+        os.mkdir(file_path.parent)
     # save workspace to file
-    with open(path + name + ".json", "w") as f:
-        json.dump(ws, f, sort_keys=True, indent=4)
+    file_path.write_text(json.dumps(ws, sort_keys=True, indent=4))
 
 
-def load(path, name):
+def load(file_path_string):
     """
     load a workspace from file
     """
-    with open(path + name + ".json", "r") as f:
-        ws = json.loads(f.read())
+    file_path = Path(file_path_string)
+    ws = json.loads(file_path.read_text())
     return ws

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -239,3 +239,12 @@ def save(ws, path, name):
     # save workspace to file
     with open(path + name + ".json", "w") as f:
         json.dump(ws, f, sort_keys=True, indent=4)
+
+
+def load(path, name):
+    """
+    load a workspace from file
+    """
+    with open(path + name + ".json", "r") as f:
+        ws = json.loads(f.read())
+    return ws

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -9,12 +9,12 @@ from cabinetry import fit
 
 def _get_spec():
     # fmt: off
-    spec = {"channels":[{"name":"Signal Region","samples":[{"data":[51.839756],
-    "modifiers":[{"data":[2.5695188],"name":"staterror_Signal-Region",
-    "type":"staterror"},{"data":None,"name":"Signal strength","type":"normfactor"}],
-    "name":"Signal"}]}],"measurements":[{"config":{"parameters":[],
-    "poi":"Signal strength"},"name":"My fit"}],"observations":
-    [{"data":[475],"name":"Signal Region"}],"version":"1.0.0"}
+    spec = {"channels": [{"name": "Signal Region", "samples": [{"data": [51.839756],
+            "modifiers":[{"data": [2.5695188], "name": "staterror_Signal-Region",
+            "type": "staterror"}, {"data": None, "name": "Signal strength", "type": "normfactor"}],
+            "name": "Signal"}]}], "measurements": [{"config": {"parameters": [],
+            "poi": "Signal strength"}, "name":"My fit"}], "observations":
+            [{"data": [475], "name": "Signal Region"}], "version": "1.0.0"}
     # fmt: on
     return spec
 

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -1,7 +1,5 @@
 import logging
 
-import pytest
-
 from cabinetry import histo
 
 

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -55,7 +55,11 @@ def test_save(tmpdir):
     pass
 
 
-def test_load():
+def test__load():
+    pass
+
+
+def test_load_from_config():
     pass
 
 

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -1,13 +1,13 @@
+from pathlib import Path
 import pytest
 
 from cabinetry import template_builder
 
 
 def test__get_ntuple_path():
-    assert (
-        template_builder._get_ntuple_path({"Path": "test/path.root"}, {}, {})
-        == "test/path.root"
-    )
+    assert template_builder._get_ntuple_path(
+        {"Path": "test/path.root"}, {}, {}
+    ) == Path("test/path.root")
 
 
 def test__get_selection():

--- a/util/create_histograms.py
+++ b/util/create_histograms.py
@@ -87,7 +87,7 @@ def plot_distributions(data, weights, labels, pseudodata, bins):
 
     # labels = [l.split('\'')[1] for l in labels]
     yield_each = [str(round(np.sum(w), 1)) for w in weights]
-    labels = [l.decode().split(";")[0] for l in labels]
+    labels = [label.decode().split(";")[0] for label in labels]
 
     # plot normalized distributions
     for i in reversed(range(len(data))):


### PR DESCRIPTION
Using `pathlib` for file path handling. Adding workspace loading and a more convenient histogram loading function. Updating various docstrings and fixing some flake8 warnings.