### PR TITLE
test: file handling

### DIFF
--- a/src/cabinetry/contrib/histogram_creation.py
+++ b/src/cabinetry/contrib/histogram_creation.py
@@ -15,11 +15,11 @@ def from_uproot(
         pos_in_file (str): name of tree within ntuple
         variable (str): variable to bin histogram in
         weight (str): event weight to extract
-        bins (list): bin edges for histogram
+        bins (numpy.ndarray): bin edges for histogram
         selection_filter (str, optional): filter to be applied on events, defaults to None (no filter)
 
     Returns:
-        (np.ndarray, np.ndarray): tuple of yields and stat. uncertainties for all bins
+        (numpy.ndarray, numpy.ndarray): tuple of yields and stat. uncertainties for all bins
     """
     table = uproot.open(ntuple_path)[pos_in_file].lazyarrays()
 
@@ -49,7 +49,7 @@ def _sumw2(arr):
     """calculate the absolute statistical uncertainty given an array of weights in a bin
 
     Args:
-        arr (np.ndarray): all event weights in a given bin
+        arr (numpy.ndarray): all event weights in a given bin
 
     Returns:
         np.float64: stat. uncertainty calculated via sum in quadrature
@@ -62,12 +62,12 @@ def _bin_data(observables, weights, bins):
     and the bin edges
 
     Args:
-        observables (np.ndarray): values the histogram will be binned in
-        weights (np.ndarray): weights to apply for each histogram entry
-        bins (list): bin edges for histogram
+        observables (numpy.ndarray): values the histogram will be binned in
+        weights (numpy.ndarray): weights to apply for each histogram entry
+        bins (numpy.ndarray): bin edges for histogram
 
     Returns:
-        (np.ndarray, np.ndarray): tuple of yields and stat. uncertainties for all bins
+        (numpy.ndarray, numpy.ndarray): tuple of yields and stat. uncertainties for all bins
     """
     # get bin yield and stat. uncertainty
     yields, _, _ = stats.binned_statistic(

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -19,7 +19,7 @@ def to_dict(yields, sumw2, bins):
     Args:
         yields (numpy.ndarray): yield per histogram bin
         sumw2 (numpy.ndarray): statistical uncertainty of yield per bin
-        bins (list): edges of histogram bins
+        bins (numpy.ndarray): edges of histogram bins
 
     Returns:
         dict: dictionary containing histogram information

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -1,6 +1,8 @@
 import logging
 from pathlib import Path
 
+import numpy as np
+
 from . import histo
 
 
@@ -93,10 +95,10 @@ def _get_binning(region):
         NotImplementedError: when the binning is not explicitly defined
 
     Returns:
-        list: bin boundaries to be used for histogram
+        numpy.ndarray: bin boundaries to be used for histogram
     """
     if region.get("Binning", False):
-        return region["Binning"]
+        return np.asarray(region["Binning"])
     else:
         raise NotImplementedError
 

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 import pytest
 
+import numpy as np
+
 from cabinetry import template_builder
 
 
@@ -18,12 +20,12 @@ def test__get_filter():
     assert (
         template_builder._get_filter({}, {"Filter": "jet_pt > 0"}, {}) == "jet_pt > 0"
     )
-    assert template_builder._get_filter({}, {}, {}) == None
+    assert template_builder._get_filter({}, {}, {}) is None
 
 
 def test__get_weight():
     assert template_builder._get_weight({"Weight": "weight_mc"}, {}, {}) == "weight_mc"
-    assert template_builder._get_weight({}, {}, {}) == None
+    assert template_builder._get_weight({}, {}, {}) is None
 
 
 def test__get_position_in_file():
@@ -31,7 +33,9 @@ def test__get_position_in_file():
 
 
 def test__get_binning():
-    assert template_builder._get_binning({"Binning": [1, 2, 3]}) == [1, 2, 3]
+    np.testing.assert_equal(
+        template_builder._get_binning({"Binning": [1, 2, 3]}), [1, 2, 3]
+    )
     with pytest.raises(Exception) as e_info:
         assert template_builder._get_binning({})
 


### PR DESCRIPTION
Adding tests for histogram file handling, and adding small improvements to existing tests. Also refactoring the internal handling of histograms: instead of using lists, numpy.ndarrays are used for yields/sumw2/bins.