### PR TITLE
feat: two-point systematics

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cabinetry_config = cabinetry.config.read("config_example.yml")
 # create template histograms
 histo_folder = "histograms/"
 cabinetry.template_builder.create_histograms(
-    cabinetry_config, histo_folder, only_nominal=True, method="uproot"
+    cabinetry_config, histo_folder, method="uproot"
 )
 
 # perform histogram post-processing

--- a/config_example.yml
+++ b/config_example.yml
@@ -32,7 +32,13 @@ Systematics:
     OverallDown: -0.05
     OverallUp: 0.05
     Samples: ["Signal", "Background"]
-    Type: OVERALL
+    Type: "Overall"
+
+  - Name: "Background modeling"
+    PathUp: "ntuples/prediction.root"
+    TreeUp: "background_varied"
+    Samples: "Background"
+    Type: "NormPlusShape"
 
 NormFactors:
   - Name: "Signal strength"

--- a/config_example.yml
+++ b/config_example.yml
@@ -1,6 +1,6 @@
 General:
-  Measurement: "My fit"
-  POI: "Signal strength"
+  Measurement: "minimal_example"
+  POI: "Signal_norm"
 
 Samples:
   - Name: "Data"
@@ -22,10 +22,10 @@ Samples:
     Color: "#FFAA55"
 
 Regions:
-  - Name: "Signal Region"
+  - Name: "Signal_region"
     Variable: "jet_pt"
     Filter: "lep_charge > 0"
-    Binning: [0, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
+    Binning: [200, 300, 400, 500, 600]
 
 Systematics:
   - Name: "Luminosity"
@@ -34,14 +34,14 @@ Systematics:
     Samples: ["Signal", "Background"]
     Type: "Overall"
 
-  - Name: "Background modeling"
+  - Name: "Modeling"
     PathUp: "ntuples/prediction.root"
     TreeUp: "background_varied"
     Samples: "Background"
     Type: "NormPlusShape"
 
 NormFactors:
-  - Name: "Signal strength"
+  - Name: "Signal_norm"
     Nominal: 1
     Min: 0
     Max: 5

--- a/example.py
+++ b/example.py
@@ -18,13 +18,13 @@ if __name__ == "__main__":
         raise SystemExit
 
     # import example config file
-    cabinetry_config = cabinetry.config.read("config_example.yml")
-    cabinetry.config.print_overview(cabinetry_config)
+    cabinetry_config = cabinetry.configuration.read("config_example.yml")
+    cabinetry.configuration.print_overview(cabinetry_config)
 
     # create template histograms
     histo_folder = "histograms/"
     cabinetry.template_builder.create_histograms(
-        cabinetry_config, histo_folder, only_nominal=True, method="uproot"
+        cabinetry_config, histo_folder, only_nominal=False, method="uproot"
     )
 
     # perform histogram post-processing

--- a/example.py
+++ b/example.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     # create template histograms
     histo_folder = "histograms/"
     cabinetry.template_builder.create_histograms(
-        cabinetry_config, histo_folder, only_nominal=False, method="uproot"
+        cabinetry_config, histo_folder, method="uproot"
     )
 
     # perform histogram post-processing

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -1,4 +1,4 @@
-from . import config
+from . import configuration
 from . import template_builder
 from . import template_postprocessor
 from . import workspace

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -69,3 +69,40 @@ def print_overview(config):
     log.info("  %i NormFactor(s)", len(config["NormFactors"]))
     if "Systematics" in config.keys():
         log.info("  %i Systematic(s)", len(config["Systematics"]))
+
+
+def _convert_samples_to_list(samples):
+    """the config can allow for two ways of specifying samples, a single sample:
+    "Samples": "ABC"
+    or a list of samples:
+    "Samples": ["ABC", "DEF"]
+    for consistent treatment, convert the single sample into a single-element list
+
+    Args:
+        samples (string/list): name of single sample or list of sample names
+
+    Returns:
+        list: name(s) of sample(s)
+    """
+    if isinstance(samples, list):
+        return samples
+    else:
+        return [samples]
+
+
+def sample_affected_by_modifier(sample, modifier):
+    """check if a sample is affected by a given modifier (Systematic, NormFactor)
+
+    Args:
+        sample (dict): containing all sample information
+        modifier (dict): containing all modifier information (a Systematic of a NormFactor)
+
+    Returns:
+        bool: True if sample is affected, False otherwise
+    """
+    affected_samples = _convert_samples_to_list(modifier["Samples"])
+    if sample["Name"] in affected_samples:
+        affected = True
+    else:
+        affected = False
+    return affected

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -89,8 +89,9 @@ def load_from_config(histo_folder, sample, region, systematic, modified=True):
         modified (bool, optional): whether to load the modified histogram (after post-processing), defaults to True
 
     Returns:
-        dict: the loaded histogram
-        str: name of the histogram
+        tuple: a tuple containing
+            dict: the loaded histogram
+            str: name of the histogram
     """
     # find the histogram name given config information, and then load the histogram
     histo_name = build_name(sample, region, systematic)
@@ -144,3 +145,24 @@ def validate(histogram, name):
             name,
             not_empty_but_nan,
         )
+
+
+def normalize_to_yield(histogram, reference_histogram):
+    """normalize a histogram to match the yield of a reference, and return the
+    modified histogram along with the normalization factor
+
+    Args:
+        histogram (dict): the histogram to be normalized
+        reference_histogram (dict): reference histogram to normalize to
+
+    Returns:
+        tuple: a tuple containing
+            dict: the normalized histogram
+            np.float64: the yield ratio: un-normalized yield / normalized yield
+    """
+    target_integrated_yield = sum(reference_histogram["yields"])
+    current_integrated_yield = sum(histogram["yields"])
+    normalization_ratio = current_integrated_yield / target_integrated_yield
+    # update integrated yield to match target
+    histogram["yields"] /= normalization_ratio
+    return histogram, normalization_ratio

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -18,10 +18,18 @@ def _get_ntuple_path(sample, region, systematic):
         region (dict): containing all region information
         systematic (dict): containing all systematic information
 
+    Raises:
+        NotImplementedError: if ntuple path treatment is not yet implemented
+
     Returns:
         pathlib.Path: path where the ntuples are located
     """
-    path_str = sample["Path"]
+    if systematic["Name"] == "nominal":
+        path_str = sample["Path"]
+    elif systematic["Type"] == "NormPlusShape":
+        path_str = systematic["PathUp"]
+    else:
+        raise NotImplementedError("ntuple path treatment not yet defined")
     path = Path(path_str)
     return path
 
@@ -71,17 +79,27 @@ def _get_weight(sample, region, systematic):
     return weight
 
 
-def _get_position_in_file(sample):
+def _get_position_in_file(sample, systematic):
     """the file might have some substructure, this specifies where in the file
     the data is
 
     Args:
         sample (dict): containing all sample information
+        systematic (dict): containing all systematic information
+
+    Raises:
+        NotImplementedError: if finding the position in file is not yet implemented
 
     Returns:
         str: where in the file to find the data, (right now the name of a tree)
     """
-    return sample["Tree"]
+    if systematic["Name"] == "nominal":
+        position = sample["Tree"]
+    elif systematic["Type"] == "NormPlusShape":
+        position = systematic["TreeUp"]
+    else:
+        raise NotImplementedError("ntuple path treatment not yet defined")
+    return position
 
 
 def _get_binning(region):
@@ -173,7 +191,7 @@ def create_histograms(config, folder_path_str, method="uproot", only_nominal=Fal
 
                 log.debug("  variation %s", systematic["Name"])
                 ntuple_path = _get_ntuple_path(sample, region, systematic)
-                pos_in_file = _get_position_in_file(sample)
+                pos_in_file = _get_position_in_file(sample, systematic)
                 variable = _get_variable(sample, region, systematic)
                 selection_filter = _get_filter(sample, region, systematic)
                 weight = _get_weight(sample, region, systematic)

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -122,7 +122,7 @@ def _get_binning(region):
         raise NotImplementedError
 
 
-def create_histograms(config, folder_path_str, method="uproot", only_nominal=False):
+def create_histograms(config, folder_path_str, method="uproot"):
     """generate all required histograms specified by a configuration file
     a tool providing histograms should provide bin yields and statistical
     uncertainties, as well as the bin edges
@@ -131,7 +131,6 @@ def create_histograms(config, folder_path_str, method="uproot", only_nominal=Fal
         config (dict): cabinetry configuration
         folder_path_str (str): folder to save the histograms to
         method (str, optional): backend to use for histogram production, defaults to "uproot"
-        only_nominal (bool, optional): whether to only produce nominal histograms, defaults to False
 
     Raises:
         NotImplementedError: when systematic variations based on histograms are requested (not supported yet)
@@ -156,9 +155,6 @@ def create_histograms(config, folder_path_str, method="uproot", only_nominal=Fal
                 if is_nominal:
                     # for nominal, histograms are generally needed
                     histo_needed = True
-                elif (not is_nominal) and only_nominal:
-                    # if not a nominal variation, but only nominal is requested, then no histo is needed
-                    histo_needed = False
                 elif (not is_nominal) and sample.get("Data", False):
                     # for data, only nominal histograms are needed
                     histo_needed = False

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -52,6 +52,7 @@ def run(config, histogram_folder):
     for sample in config["Samples"]:
         for region in config["Regions"]:
             for systematic in [{"Name": "nominal"}]:
+                # need to add histogram-based systematics here as well
                 histogram, histogram_name = histo.load_from_config(
                     histogram_folder, sample, region, systematic, modified=False
                 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,16 +1,16 @@
 import pytest
 
-from cabinetry import config
+from cabinetry import configuration
 
 
 def test_read():
-    config.read("config_example.yml")
+    configuration.read("config_example.yml")
 
 
 def test_validate_missing_key():
     config_example = {"General": []}
     with pytest.raises(Exception) as e_info:
-        config.validate(config_example)
+        configuration.validate(config_example)
 
 
 def test_validate_unknown_key():
@@ -22,7 +22,7 @@ def test_validate_unknown_key():
         "unknown": [],
     }
     with pytest.raises(Exception) as e_info:
-        config.validate(config_example)
+        configuration.validate(config_example)
 
 
 def test_validate_multiple_data_samples():
@@ -33,7 +33,7 @@ def test_validate_multiple_data_samples():
         "Samples": [{"Data": True}, {"Data": True}],
     }
     with pytest.raises(Exception) as e_info:
-        config.validate(config_example)
+        configuration.validate(config_example)
 
 
 def test_validate_valid():
@@ -43,7 +43,7 @@ def test_validate_valid():
         "NormFactors": "",
         "Samples": [{"Data": True}],
     }
-    config.validate(config_example)
+    configuration.validate(config_example)
 
 
 def test_print_overview():
@@ -54,7 +54,7 @@ def test_print_overview():
         "Samples": [{"Data": True}],
         "Systematics": "",
     }
-    config.print_overview(config_example)
+    configuration.print_overview(config_example)
 
 
 def test_print_overview_no_sys():
@@ -64,4 +64,4 @@ def test_print_overview_no_sys():
         "NormFactors": "",
         "Samples": [{"Data": True}],
     }
-    config.print_overview(config_example)
+    configuration.print_overview(config_example)

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -48,6 +48,4 @@ def test__get_binning():
 def test_create_histograms(tmpdir):
     # needs to be expanded into a proper test
     config = {"Samples": {}, "Regions": {}, "Systematics": {}}
-    template_builder.create_histograms(
-        config, tmpdir, method="uproot", only_nominal=True
-    )
+    template_builder.create_histograms(config, tmpdir, method="uproot")

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -8,7 +8,7 @@ from cabinetry import template_builder
 
 def test__get_ntuple_path():
     assert template_builder._get_ntuple_path(
-        {"Path": "test/path.root"}, {}, {}
+        {"Path": "test/path.root"}, {}, {"Name": "nominal"}
     ) == Path("test/path.root")
 
 
@@ -29,7 +29,12 @@ def test__get_weight():
 
 
 def test__get_position_in_file():
-    assert template_builder._get_position_in_file({"Tree": "tree_name"}) == "tree_name"
+    assert (
+        template_builder._get_position_in_file(
+            {"Tree": "tree_name"}, {"Name": "nominal"}
+        )
+        == "tree_name"
+    )
 
 
 def test__get_binning():


### PR DESCRIPTION
- renaming config module to configuration
- additional distribution created in toy ntuple script to test template-based variations
- fixes in logic for histogram creation and modifier creation in workspace
- removing nominal-only histogram creation option
- support for two-point systematics (shape and normalization effect from comparing two templates)