### PR TITLE
chore: more pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,5 +2,11 @@ repos:
 -   repo: https://github.com/psf/black
     rev: stable
     hooks:
-    - id: black
-      language_version: python3
+    -   id: black
+        language_version: python3
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.1.0
+    hooks:
+    -   id: check-added-large-files
+        args: ["--maxkb=100"]
+    -   id: trailing-whitespace


### PR DESCRIPTION
adding a check for large (>100 KB) files and trailing whitespaces