### PR TITLE
feat: Add setup 'extras' to provide install options for dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,13 +20,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install cabinetry and dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install flake8 black pytest pytest-cov
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install -e .[test]
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -36,11 +36,8 @@ jobs:
     - name: Format with Black
       run: |
         black --check --diff --verbose .
-    - name: Install cabinetry and dependencies, run example
+    - name: Run example
       run: |
-        pip install -e .
-        # install extra dependencies the example needs
-        pip install matplotlib uproot scipy iminuit numexpr
         python util/create_histograms.py
         python example.py
     - name: Test with pytest and generate coverage report

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,24 @@
 from setuptools import setup, find_packages
 
+extras_require = {"contrib": ["matplotlib", "uproot", "scipy", "iminuit", "numexpr"]}
+extras_require["test"] = sorted(
+    set(
+        extras_require["contrib"]
+        + [
+            "pytest",
+            "pytest-cov>=2.5.1",
+            "pydocstyle",
+            "check-manifest",
+            "flake8",
+            "black;python_version>='3.6'",  # Black is Python3 only
+        ]
+    )
+)
+extras_require["develop"] = sorted(
+    set(extras_require["test"] + ["pre-commit", "twine"])
+)
+extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))
+
 
 with open("README.md", "r") as f:
     long_description = f.read()
@@ -26,4 +45,5 @@ setup(
     ],
     python_requires=">=3.6",
     install_requires=["numpy", "pyyaml", "pyhf>=0.3.2", "iminuit"],
+    extras_require=extras_require,
 )


### PR DESCRIPTION
Use the `extras_require` ability in `setup.py` to establish "extras" environments that can define the specific dependencies for all stages of the development process. Additionally, add a "complete" extra to be able to install everything a core developer might want.

Suggested squash and merged commit log entry:

```
* Add use of extras_require to setup.py
* Add 'contrib', 'test', 'develop', and 'complete' extras
* Use 'test' extra in CI to install all necessary dependencies
* Update to use GitHub Action setup-python v2
```