### PR TITLE
test: additional tests

### DIFF
--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -200,7 +200,7 @@ def get_sys_modifiers(config, sample, region, histogram_folder):
         list: modifiers for pyhf-style workspace
     """
     modifiers = []
-    for systematic in config["Systematics"]:
+    for systematic in config.get("Systematics", []):
         if configuration.sample_affected_by_modifier(sample, systematic):
             if systematic["Type"] == "Overall":
                 # OverallSys (norm uncertainty with Gaussian constraint)
@@ -323,12 +323,13 @@ def get_observations(config, histogram_folder):
     return observations
 
 
-def build(config, histogram_folder):
+def build(config, histogram_folder, with_validation=True):
     """build a HistFactory workspace, pyhf style
 
     Args:
         config (dict): cabinetry configuration
         histogram_folder (str): path to folder containing histograms
+        with_validation (bool, optional): validate workspace validity with pyhf, defaults to True
 
     Returns:
         dict: pyhf-compatible HistFactory workspace
@@ -352,8 +353,9 @@ def build(config, histogram_folder):
     # workspace version
     ws.update({"version": "1.0.0"})
 
-    # validate the workspace
-    validate(ws)
+    if with_validation:
+        # validate the workspace
+        validate(ws)
     return ws
 
 

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -7,44 +7,44 @@ from cabinetry import histo
 
 
 def _example_hist():
-    yields = [1, 2]
-    sumw2 = [0.1, 0.2]
-    bins = [1, 2]
+    yields = np.asarray([1.0, 2.0])
+    sumw2 = np.asarray([0.1, 0.2])
+    bins = np.asarray([1, 2, 3])
     return histo.to_dict(yields, sumw2, bins)
 
 
 def _example_hist_single_bin():
-    yields = [1]
-    sumw2 = [0.1]
-    bins = [1]
+    yields = np.asarray([1.0])
+    sumw2 = np.asarray([0.1])
+    bins = np.asarray([1, 2])
     return histo.to_dict(yields, sumw2, bins)
 
 
 def _example_hist_empty_bin():
-    yields = [1, 0]
-    sumw2 = [0.1, 0.2]
-    bins = [1, 2]
+    yields = np.asarray([1.0, 0.0])
+    sumw2 = np.asarray([0.1, 0.2])
+    bins = np.asarray([1, 2, 3])
     return histo.to_dict(yields, sumw2, bins)
 
 
 def _example_hist_nan_sumw2_empty_bin():
-    yields = [1, 0]
-    sumw2 = [0.1, float("NaN")]
-    bins = [1, 2]
+    yields = np.asarray([1.0, 0.0])
+    sumw2 = np.asarray([0.1, float("NaN")])
+    bins = np.asarray([1, 2, 3])
     return histo.to_dict(yields, sumw2, bins)
 
 
 def _example_hist_nan_sumw2_nonempty_bin():
-    yields = [1, 2]
-    sumw2 = [0.1, float("NaN")]
-    bins = [1, 2]
+    yields = np.asarray([1.0, 2.0])
+    sumw2 = np.asarray([0.1, float("NaN")])
+    bins = np.asarray([1, 2, 3])
     return histo.to_dict(yields, sumw2, bins)
 
 
 def test_to_dict():
-    yields = [1, 2]
-    sumw2 = [0.1, 0.2]
-    bins = [1, 2]
+    yields = np.asarray([1.0, 2.0])
+    sumw2 = np.asarray([0.1, 0.2])
+    bins = np.asarray([1, 2, 3])
     assert histo.to_dict(yields, sumw2, bins) == {
         "yields": yields,
         "sumw2": sumw2,
@@ -156,3 +156,11 @@ def test_validate(caplog):
         rec.message for rec in caplog.records
     ]
     caplog.clear()
+
+
+def test_normalize_to_yield():
+    hist = _example_hist_empty_bin()
+    var_hist = _example_hist()
+    modified_hist, factor = histo.normalize_to_yield(var_hist, hist)
+    assert factor == 3.0
+    np.testing.assert_equal(modified_hist["yields"], np.asarray([1 / 3, 2 / 3]))

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -58,11 +58,10 @@ def test_save(tmp_path):
     np.testing.assert_equal(histo._load(tmp_path, modified=False), hist)
 
 
-def test_save_new_dir(tmpdir):
+def test_save_new_dir(tmp_path):
     hist = _example_hist()
     # add a subdirectory that needs to be created for histogram saving
-    subdir = tmpdir / "subdir"
-    fname = Path(subdir.join("file"))
+    fname = tmp_path / "subdir" / "file"
     histo.save(hist, fname)
     np.testing.assert_equal(histo._load(fname, modified=False), hist)
 
@@ -86,27 +85,28 @@ def test__load(tmp_path, caplog):
     caplog.clear()
 
 
-def test__load_modified(tmpdir, caplog):
+def test__load_modified(tmp_path, caplog):
     hist = _example_hist()
     histo_name = "histo"
-    fname_modified = Path(tmpdir.join(histo_name + "_modified"))
-    fname_original = Path(tmpdir.join(histo_name))
+    fname_modified = tmp_path / (histo_name + "_modified")
+    fname_original = tmp_path / histo_name
     histo.save(hist, fname_modified)
     # load the modified histogram by specifying the original name, which should produce no warning
     np.testing.assert_equal(histo._load(fname_original, modified=True), hist)
     assert [rec.message for rec in caplog.records] == []
+    caplog.clear()
 
 
-def test_load_from_config(tmpdir):
+def test_load_from_config(tmp_path):
     hist = _example_hist()
     expected_name = "Sample_Region_Systematic"
-    fname = Path(tmpdir.join(expected_name))
+    fname = tmp_path / expected_name
     histo.save(hist, fname)
     sample = {"Name": "Sample"}
     region = {"Name": "Region"}
     systematic = {"Name": "Systematic"}
     loaded_histo, loaded_name = histo.load_from_config(
-        tmpdir, sample, region, systematic, modified=False
+        tmp_path, sample, region, systematic, modified=False
     )
     np.testing.assert_equal(loaded_histo, hist)
     assert loaded_name == expected_name

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -68,7 +68,7 @@ def test__get_binning():
         assert template_builder._get_binning({})
 
 
-def test_create_histograms(tmpdir):
+def test_create_histograms(tmp_path):
     # needs to be expanded into a proper test
     config = {"Samples": {}, "Regions": {}, "Systematics": {}}
-    template_builder.create_histograms(config, tmpdir, method="uproot")
+    template_builder.create_histograms(config, tmp_path, method="uproot")

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -11,6 +11,17 @@ def test__get_ntuple_path():
         {"Path": "test/path.root"}, {}, {"Name": "nominal"}
     ) == Path("test/path.root")
 
+    assert template_builder._get_ntuple_path(
+        {},
+        {},
+        {"Name": "variation", "Type": "NormPlusShape", "PathUp": "test/path.root"},
+    ) == Path("test/path.root")
+
+    with pytest.raises(Exception) as e_info:
+        assert template_builder._get_ntuple_path(
+            {}, {}, {"Name": "unknown_variation_type", "Type": "unknown"}
+        )
+
 
 def test__get_variable():
     assert template_builder._get_variable({}, {"Variable": "jet_pt"}, {}) == "jet_pt"
@@ -35,6 +46,18 @@ def test__get_position_in_file():
         )
         == "tree_name"
     )
+
+    assert (
+        template_builder._get_position_in_file(
+            {}, {"Name": "variation", "Type": "NormPlusShape", "TreeUp": "up_tree"}
+        )
+        == "up_tree"
+    )
+
+    with pytest.raises(Exception) as e_info:
+        template_builder._get_position_in_file(
+            {}, {"Name": "unknown_variation", "Type": "unknown"}
+        )
 
 
 def test__get_binning():

--- a/tests/test_template_postprocessor.py
+++ b/tests/test_template_postprocessor.py
@@ -30,7 +30,7 @@ def test_adjust_histogram():
     )
 
 
-def test_run(tmpdir):
+def test_run(tmp_path):
     # needs to be expanded into a proper test
     config = {"Samples": {}, "Regions": {}, "Systematics": {}}
-    template_postprocessor.run(config, tmpdir)
+    template_postprocessor.run(config, tmp_path)

--- a/tests/test_template_postprocessor.py
+++ b/tests/test_template_postprocessor.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from cabinetry import histo
 from cabinetry import template_postprocessor
 
 
@@ -32,5 +33,17 @@ def test_adjust_histogram():
 
 def test_run(tmp_path):
     # needs to be expanded into a proper test
-    config = {"Samples": {}, "Regions": {}, "Systematics": {}}
+    config = {"Samples": [{"Name": "signal"}], "Regions": [{"Name": "region_1"}]}
+
+    # create an input histogram
+    histo_path = tmp_path / "signal_region_1_nominal.npz"
+    histogram = histo.to_dict(
+        np.asarray([1.0, 2.0]), np.asarray([1.0, 1.0]), np.asarray([0.0, 1.0, 2.0])
+    )
+    histo.save(histogram, histo_path)
+
     template_postprocessor.run(config, tmp_path)
+    modified_histo = histo._load(histo_path, modified=True)
+    assert np.allclose(modified_histo["yields"], histogram["yields"])
+    assert np.allclose(modified_histo["sumw2"], histogram["sumw2"])
+    assert np.allclose(modified_histo["bins"], histogram["bins"])

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,3 +1,5 @@
+import pytest
+
 from cabinetry import workspace
 
 
@@ -32,6 +34,45 @@ def test_get_NF_modifiers():
         {"data": None, "name": "k", "type": "normfactor"},
     ]
     assert workspace.get_NF_modifiers(example_config, sample) == expected_modifier
+
+
+def test_get_OverallSys_modifier():
+    systematic = {"Name": "sys", "OverallUp": 0.1, "OverallDown": -0.05}
+    expected_modifier = {
+        "name": "sys",
+        "type": "normsys",
+        "data": {"hi": 1.1, "lo": 0.95},
+    }
+    assert workspace.get_OverallSys_modifier(systematic) == expected_modifier
+
+
+def test_get_sys_modifiers():
+    config_example = {
+        "Systematics": [
+            {
+                "Name": "sys",
+                "Type": "Overall",
+                "Samples": "Signal",
+                "OverallUp": 0.1,
+                "OverallDown": -0.05,
+            }
+        ]
+    }
+    sample = {"Name": "Signal"}
+    region = {}
+    # needs to be expanded to include histogram loading
+    modifiers = workspace.get_sys_modifiers(config_example, sample, region, None)
+    expected_modifiers = [
+        {"name": "sys", "type": "normsys", "data": {"hi": 1.1, "lo": 0.95}}
+    ]
+    assert modifiers == expected_modifiers
+
+    # unsupported systematics type
+    config_example_unsupported = {
+        "Systematics": [{"Name": "Normalization", "Type": "unknown"}]
+    }
+    with pytest.raises(Exception) as e_info:
+        workspace.get_sys_modifiers(config_example_unsupported, sample, region, None)
 
 
 def test_get_measurement():

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,6 +1,8 @@
+import numpy as np
 import pytest
 
 from cabinetry import workspace
+from cabinetry import histo
 
 
 def test__get_data_sample():
@@ -75,7 +77,95 @@ def test_get_sys_modifiers():
         workspace.get_sys_modifiers(config_example_unsupported, sample, region, None)
 
 
+def test_get_channels(tmp_path):
+    example_config = {
+        "Regions": [{"Name": "region_1"}],
+        "Samples": [{"Name": "signal"}],
+        "NormFactors": [],
+    }
+
+    # create a histogram for testing
+    histo_path = tmp_path / "signal_region_1_nominal.npz"
+    histogram = histo.to_dict(
+        np.asarray([1.0, 2.0]), np.asarray([1.0, 1.0]), np.asarray([0.0, 1.0, 2.0])
+    )
+    histo.save(histogram, histo_path)
+
+    channels = workspace.get_channels(example_config, tmp_path)
+    expected_channels = [
+        {
+            "name": "region_1",
+            "samples": [
+                {
+                    "name": "signal",
+                    "data": [1.0, 2.0],
+                    "modifiers": [
+                        {
+                            "name": "staterror_region_1",
+                            "type": "staterror",
+                            "data": [1.0, 1.0],
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+    assert channels == expected_channels
+
+
 def test_get_measurement():
     example_config = {"General": {"Measurement": "fit", "POI": "mu"}}
     expected_measurement = [{"name": "fit", "config": {"poi": "mu", "parameters": []}}]
     assert workspace.get_measurements(example_config) == expected_measurement
+
+
+def test_get_observations(tmp_path):
+    histo_path = tmp_path / "Data_test_region_nominal.npz"
+
+    # build a test histogram and save it
+    histogram = histo.to_dict(
+        np.asarray([1.0, 2.0]), np.asarray([1.0, 1.0]), np.asarray([0.0, 1.0, 2.0])
+    )
+    histo.save(histogram, histo_path)
+
+    # create observations list from config
+    config = {
+        "Samples": [{"Name": "Data", "Tree": "tree", "Path": tmp_path, "Data": True}],
+        "Regions": [{"Name": "test_region"}],
+    }
+    obs = workspace.get_observations(config, tmp_path)
+    expected_obs = [{"name": "test_region", "data": [1.0, 2.0]}]
+    assert obs == expected_obs
+
+
+def test_build(tmp_path):
+    minimal_config = {
+        "General": {"Measurement": "test", "POI": "test_POI"},
+        "Regions": [],
+        "Samples": [{"Name": "data", "Data": True}],
+    }
+    ws = workspace.build(minimal_config, tmp_path, with_validation=False)
+    ws_expected = {
+        "channels": [],
+        "measurements": [
+            {"config": {"parameters": [], "poi": "test_POI"}, "name": "test"}
+        ],
+        "observations": [],
+        "version": "1.0.0",
+    }
+    assert ws == ws_expected
+
+
+def test_save(tmp_path):
+    # save to subfolder that needs to be created
+    fname = tmp_path / "subdir" / "ws.json"
+    ws = {"version": "1.0.0"}
+    workspace.save(ws, fname)
+    assert workspace.load(fname) == ws
+
+
+def test_load(tmp_path):
+    fname = tmp_path / "ws.json"
+    ws = {"version": "1.0.0"}
+    workspace.save(ws, fname)
+    assert workspace.load(fname) == ws


### PR DESCRIPTION
Adding more tests for histograms / workspace functionality, plus fixes to the histogram components in the tests. Also adding tests for uproot backend in `contrib`, and switching from use of `tmpdir` to `tmp_path` everywhere.