### PR TITLE
ci: codecov settings

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1.0%
+    patch:
+      default:
+        enabled: no


### PR DESCRIPTION
Adding a settings file to configure https://codecov.io/. The threshold of 1% will cause the codecov check to fail only when coverage decreases by more than 1%. This is useful for cases like #37. The threshold should be reduced as the codebase expands.