### PR TITLE
refactor: histogram class

### DIFF
--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -12,92 +12,134 @@ import numpy as np
 log = logging.getLogger(__name__)
 
 
-def to_dict(yields, sumw2, bins):
-    """to more conveniently move around histogram information internally, put it
-    into a dictionary
-
-    Args:
-        yields (numpy.ndarray): yield per histogram bin
-        sumw2 (numpy.ndarray): statistical uncertainty of yield per bin
-        bins (numpy.ndarray): edges of histogram bins
-
-    Returns:
-        dict: dictionary containing histogram information
+class Histogram:
+    """class to hold histogram information
     """
-    histogram = {"yields": yields, "sumw2": sumw2, "bins": bins}
-    return histogram
 
+    def __init__(self, yields, sumw2, bins):
+        """constructor building histogram from arrays
 
-def save(histogram, histo_path):
-    """save a histogram to disk
+        Args:
+            yields (numpy.ndarray): yield per histogram bin
+            sumw2 (numpy.ndarray): statistical uncertainty of yield per bin
+            bins (numpy.ndarray): edges of histogram bins
+        """
+        self.yields = yields
+        self.sumw2 = sumw2
+        self.bins = bins
 
-    Args:
-        histogram (dict): the histogram to be saved
-        histo_path (pathlib.Path): where to save the histogram
-    """
-    log.debug("saving histogram to %s", histo_path.with_suffix(".npz"))
+    @classmethod
+    def from_path(cls, histo_path, modified=True):
+        """build a histogram from disk
+        try to load the "modified" version of the histogram by default
+        (which received post-processing)
 
-    # create output directory if it does not exist yet
-    if not os.path.exists(histo_path.parent):
-        os.mkdir(histo_path.parent)
-    np.savez(
-        histo_path.with_suffix(".npz"),
-        yields=histogram["yields"],
-        sumw2=histogram["sumw2"],
-        bins=histogram["bins"],
-    )
+        Args:
+            histo_path (pathlib.Path): where the histogram is located
+            modified (bool, optional): whether to load the modified histogram (after post-processing), defaults to True
 
+        Returns:
+            cabinetry.histo.Histogram: the loaded histogram
+        """
+        if modified:
+            histo_path_modified = histo_path.parent / (histo_path.name + "_modified")
+            if not histo_path_modified.with_suffix(".npz").exists():
+                log.warning(
+                    "the modified histogram %s does not exist",
+                    histo_path_modified.with_suffix(".npz"),
+                )
+                log.warning("loading the un-modified histogram instead!")
+            else:
+                histo_path = histo_path_modified
+        histogram_npz = np.load(histo_path.with_suffix(".npz"))
+        yields = histogram_npz["yields"]
+        sumw2 = histogram_npz["sumw2"]
+        bins = histogram_npz["bins"]
+        return cls(yields, sumw2, bins)
 
-def _load(histo_path, modified=True):
-    """load a histogram from disk and convert it into dictionary form
-    try to load the "modified" version of the histogram by default
-    (which received post-processing)
+    @classmethod
+    def from_config(cls, histo_folder, sample, region, systematic, modified=True):
+        """load a histogram, given a folder the histogram is located in and the
+        relevant information from the config: sample, region, systematic
 
-    Args:
-        histo_path (pathlib.Path): where the histogram is located
-        modified (bool, optional): whether to load the modified histogram (after post-processing), defaults to True
+        Args:
+            histo_folder (str): folder containing all histograms
+            sample (dict): containing all sample information
+            region (dict): containing all region information
+            systematic (dict): containing all systematic information
+            modified (bool, optional): whether to load the modified histogram (after post-processing), defaults to True
 
-    Returns:
-        dict: the loaded histogram
-    """
-    if modified:
-        histo_path_modified = histo_path.parent / (histo_path.name + "_modified")
-        if not histo_path_modified.with_suffix(".npz").exists():
+        Returns:
+            cabinetry.histo.Histogram: the loaded histogram
+        """
+        # find the histogram name given config information, and then load the histogram
+        histo_name = build_name(sample, region, systematic)
+        histo_path = Path(histo_folder) / histo_name
+        return cls.from_path(histo_path, modified)
+
+    def save(self, histo_path):
+        """save a histogram to disk
+
+        Args:
+            histo_path (pathlib.Path): where to save the histogram
+        """
+        log.debug("saving histogram to %s", histo_path.with_suffix(".npz"))
+
+        # create output directory if it does not exist yet
+        if not os.path.exists(histo_path.parent):
+            os.mkdir(histo_path.parent)
+        np.savez(
+            histo_path.with_suffix(".npz"),
+            yields=self.yields,
+            sumw2=self.sumw2,
+            bins=self.bins,
+        )
+
+    def validate(self, name):
+        """run consistency checks on a histogram, checking for empty bins
+        and ill-defined statistical uncertainties
+
+        Args:
+            name (str): name of the histogram for logging purposes
+        """
+        # check for empty bins
+        # using np.atleast_1d to fix deprecation warning, even though the
+        # input should never need it
+        empty_bins = np.where(np.atleast_1d(self.yields) == 0.0)[0]
+        if len(empty_bins) > 0:
+            log.warning("%s has empty bins: %s", name, empty_bins)
+
+        # check for ill-defined stat. unc.
+        nan_pos = np.where(np.isnan(self.sumw2))[0]
+        if len(nan_pos) > 0:
+            log.warning("%s has bins with ill-defined stat. unc.: %s", name, nan_pos)
+
+        # check whether there are any bins with ill-defined stat. uncertainty
+        # but non-empty yield, those deserve a closer look
+        not_empty_but_nan = [b for b in nan_pos if b not in empty_bins]
+        if len(not_empty_but_nan) > 0:
             log.warning(
-                "the modified histogram %s does not exist",
-                histo_path_modified.with_suffix(".npz"),
+                "%s has non-empty bins with ill-defined stat. unc.: %s",
+                name,
+                not_empty_but_nan,
             )
-            log.warning("loading the un-modified histogram instead!")
-        else:
-            histo_path = histo_path_modified
-    histogram_npz = np.load(histo_path.with_suffix(".npz"))
-    yields = histogram_npz["yields"]
-    sumw2 = histogram_npz["sumw2"]
-    bins = histogram_npz["bins"]
-    return to_dict(yields, sumw2, bins)
 
+    def normalize_to_yield(self, reference_histogram):
+        """normalize a histogram to match the yield of a reference, and return the
+        normalization factor
 
-def load_from_config(histo_folder, sample, region, systematic, modified=True):
-    """load a histogram, given a folder the histograms are located in and the
-    relevant information from the config: sample, region, systematic
+        Args:
+            reference_histogram (cabinetry.histo.Histogram): reference histogram to normalize to
 
-    Args:
-        histo_folder (str): folder containing all histograms
-        sample (dict): containing all sample information
-        region (dict): containing all region information
-        systematic (dict): containing all systematic information
-        modified (bool, optional): whether to load the modified histogram (after post-processing), defaults to True
-
-    Returns:
-        tuple: a tuple containing
-            dict: the loaded histogram
-            str: name of the histogram
-    """
-    # find the histogram name given config information, and then load the histogram
-    histo_name = build_name(sample, region, systematic)
-    histo_path = Path(histo_folder) / histo_name
-    histogram = _load(histo_path, modified)
-    return histogram, histo_name
+        Returns:
+            np.float64: the yield ratio: un-normalized yield / normalized yield
+        """
+        target_integrated_yield = sum(reference_histogram.yields)
+        current_integrated_yield = sum(self.yields)
+        normalization_ratio = current_integrated_yield / target_integrated_yield
+        # update integrated yield to match target
+        self.yields /= normalization_ratio
+        return normalization_ratio
 
 
 def build_name(sample, region, systematic):
@@ -114,55 +156,3 @@ def build_name(sample, region, systematic):
     name = sample["Name"] + "_" + region["Name"] + "_" + systematic["Name"]
     name = name.replace(" ", "-")
     return name
-
-
-def validate(histogram, name):
-    """run consistency checks on a histogram, checking for empty bins
-    and ill-defined statistical uncertainties
-
-    Args:
-        histogram (dict): the histogram to validate
-        name (str): name of the histogram for logging purposes
-    """
-    # check for empty bins
-    # using np.atleast_1d to fix deprecation warning, even though the
-    # input should never need it
-    empty_bins = np.where(np.atleast_1d(histogram["yields"]) == 0.0)[0]
-    if len(empty_bins) > 0:
-        log.warning("%s has empty bins: %s", name, empty_bins)
-
-    # check for ill-defined stat. unc.
-    nan_pos = np.where(np.isnan(histogram["sumw2"]))[0]
-    if len(nan_pos) > 0:
-        log.warning("%s has bins with ill-defined stat. unc.: %s", name, nan_pos)
-
-    # check whether there are any bins with ill-defined stat. uncertainty
-    # but non-empty yield, those deserve a closer look
-    not_empty_but_nan = [b for b in nan_pos if b not in empty_bins]
-    if len(not_empty_but_nan) > 0:
-        log.warning(
-            "%s has non-empty bins with ill-defined stat. unc.: %s",
-            name,
-            not_empty_but_nan,
-        )
-
-
-def normalize_to_yield(histogram, reference_histogram):
-    """normalize a histogram to match the yield of a reference, and return the
-    modified histogram along with the normalization factor
-
-    Args:
-        histogram (dict): the histogram to be normalized
-        reference_histogram (dict): reference histogram to normalize to
-
-    Returns:
-        tuple: a tuple containing
-            dict: the normalized histogram
-            np.float64: the yield ratio: un-normalized yield / normalized yield
-    """
-    target_integrated_yield = sum(reference_histogram["yields"])
-    current_integrated_yield = sum(histogram["yields"])
-    normalization_ratio = current_integrated_yield / target_integrated_yield
-    # update integrated yield to match target
-    histogram["yields"] /= normalization_ratio
-    return histogram, normalization_ratio

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -184,15 +184,15 @@ def create_histograms(config, folder_path_str, method="uproot"):
                 else:
                     raise NotImplementedError("unknown backend")
 
-                # convert the information into a dictionary for easier handling
-                histogram = histo.to_dict(yields, sumw2, bins)
+                # store information in a Histogram instance
+                histogram = histo.Histogram(yields, sumw2, bins)
 
                 # generate a name for the histogram
                 histogram_name = histo.build_name(sample, region, systematic)
 
                 # check the histogram for common issues
-                histo.validate(histogram, histogram_name)
+                histogram.validate(histogram_name)
 
                 # save it
                 histo_path = Path(folder_path_str) / histogram_name
-                histo.save(histogram, histo_path)
+                histogram.save(histo_path)

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import numpy as np
 from pathlib import Path
@@ -9,35 +10,35 @@ log = logging.getLogger(__name__)
 
 
 def _fix_stat_unc(histogram, name):
-    """replace nan stat. unc. by zero
+    """replace nan stat. unc. by zero for a histogram, modifies the
+    histogram handed over in the argument
 
     Args:
         histogram (cabinetry.histo.Histogram): the histogram to fix
         name (str): histogram name for logging
-
-    Returns:
-        cabinetry.histo.Histogram: the fixed histogram
     """
     nan_pos = np.where(np.isnan(histogram.sumw2))[0]
     if len(nan_pos) > 0:
         log.debug("fixing ill-defined stat. unc. for %s", name)
         histogram.sumw2 = np.nan_to_num(histogram.sumw2, nan=0.0)
-    return histogram
 
 
-def adjust_histogram(histogram, name):
-    """create a new modified histogram, currently only calling the
-    stat. uncertainty fix
+def apply_postprocessing(histogram, name):
+    """Create a new modified histogram, currently only calling the
+    stat. uncertainty fix. The histogram in the function argument
+    stays unchanged.
 
     Args:
-        histogram (cabinetry.histo.Histogram): the histogram to modify
+        histogram (cabinetry.histo.Histogram): the histogram to postprocess
         name (str): histogram name for logging
 
     Returns:
-        cabinetry.histo.Histogram: the modified histogram
+        cabinetry.histo.Histogram: the fixed histogram
     """
-    new_histogram = _fix_stat_unc(histogram, name)
-    return new_histogram
+    # copy histogram to new object to leave it unchanged
+    adjusted_histogram = copy.deepcopy(histogram)
+    _fix_stat_unc(adjusted_histogram, name)
+    return adjusted_histogram
 
 
 def run(config, histogram_folder):
@@ -57,7 +58,7 @@ def run(config, histogram_folder):
                     histogram_folder, sample, region, systematic, modified=False
                 )
                 histogram_name = histo.build_name(sample, region, systematic)
-                new_histogram = adjust_histogram(histogram, histogram_name)
+                new_histogram = apply_postprocessing(histogram, histogram_name)
                 histogram.validate(histogram_name)
                 new_histo_path = Path(histogram_folder) / (histogram_name + "_modified")
                 new_histogram.save(new_histo_path)

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -50,14 +50,18 @@ def data_MC(config, histogram_folder, figure_folder, prefit=True, method="matplo
         for sample in config["Samples"]:
             for systematic in [{"Name": "nominal"}]:
                 is_data = sample.get("Data", False)
-                histogram, _ = histo.load_from_config(
+                histogram = histo.Histogram.from_config(
                     histogram_folder, sample, region, systematic, modified=True
                 )
                 histogram_dict_list.append(
                     {
                         "label": sample["Name"],
                         "isData": is_data,
-                        "hist": histogram,
+                        "hist": {
+                            "yields": histogram.yields,
+                            "sumw2": histogram.sumw2,
+                            "bins": histogram.bins,
+                        },
                         "variable": region["Variable"],
                     }
                 )

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -41,10 +41,10 @@ def get_yield_for_sample(
     Returns:
         list: yields per bin for the sample
     """
-    histogram, _ = histo.load_from_config(
+    histogram = histo.Histogram.from_config(
         histogram_folder, sample, region, systematic, modified=True
     )
-    histo_yield = histogram["yields"].tolist()
+    histo_yield = histogram.yields.tolist()
     return histo_yield
 
 
@@ -63,10 +63,10 @@ def get_unc_for_sample(
     Returns:
         list: statistical uncertainty of yield per bin for the sample
     """
-    histogram, _ = histo.load_from_config(
+    histogram = histo.Histogram.from_config(
         histogram_folder, sample, region, systematic, modified=True
     )
-    histo_yield = histogram["sumw2"].tolist()
+    histo_yield = histogram.sumw2.tolist()
     return histo_yield
 
 
@@ -134,12 +134,12 @@ def get_NormPlusShape_modifiers(sample, region, systematic, histogram_folder):
         list[dict]: a list with a pyhf normsys modifier and a histosys modifier
     """
     # load the systematic variation histogram
-    histogram_variation, _ = histo.load_from_config(
+    histogram_variation = histo.Histogram.from_config(
         histogram_folder, sample, region, systematic, modified=True
     )
 
     # also need the nominal histogram
-    histogram_nominal, _ = histo.load_from_config(
+    histogram_nominal = histo.Histogram.from_config(
         histogram_folder, sample, region, {"Name": "nominal"}, modified=True
     )
 
@@ -149,10 +149,8 @@ def get_NormPlusShape_modifiers(sample, region, systematic, histogram_folder):
     # symmetrization according to "method 1" from issue #26: first normalization, then symmetrization
 
     # normalize the variation to the same yield as nominal
-    histogram_variation, norm_effect = histo.normalize_to_yield(
-        histogram_variation, histogram_nominal
-    )
-    histo_yield_up = histogram_variation["yields"].tolist()
+    norm_effect = histogram_variation.normalize_to_yield(histogram_nominal)
+    histo_yield_up = histogram_variation.yields.tolist()
     log.debug(
         "normalization impact of systematic %s on sample %s in region %s is %f",
         systematic["Name"],
@@ -162,7 +160,7 @@ def get_NormPlusShape_modifiers(sample, region, systematic, histogram_folder):
     )
     # need another histogram that corresponds to the "down" variation, which is 2*nominal - up
     histo_yield_down = (
-        2 * histogram_nominal["yields"] - histogram_variation["yields"]
+        2 * histogram_nominal.yields - histogram_variation.yields
     ).tolist()
 
     # add the normsys

--- a/tests/contrib/test_histogram_drawing.py
+++ b/tests/contrib/test_histogram_drawing.py
@@ -15,15 +15,21 @@ def test__total_yield_uncertainty():
 
 def test_data_MC_matplotlib(tmp_path):
     fname = tmp_path / "subdir" / "fig.pdf"
-    bg_hist = histo.to_dict(
-        np.asarray([12.5, 14]), np.asarray([0.4, 0.5]), np.asarray([1, 2, 3])
-    )
-    sig_hist = histo.to_dict(
-        np.asarray([2, 5]), np.asarray([0.1, 0.2]), np.asarray([1, 2, 3])
-    )
-    data_hist = histo.to_dict(
-        np.asarray([13, 15]), np.asarray([3.61, 3.87]), np.asarray([1, 2, 3])
-    )
+    bg_hist = {
+        "yields": np.asarray([12.5, 14]),
+        "sumw2": np.asarray([0.4, 0.5]),
+        "bins": np.asarray([1, 2, 3]),
+    }
+    sig_hist = {
+        "yields": np.asarray([2, 5]),
+        "sumw2": np.asarray([0.1, 0.2]),
+        "bins": np.asarray([1, 2, 3]),
+    }
+    data_hist = {
+        "yields": np.asarray([13, 15]),
+        "sumw2": np.asarray([3.61, 3.87]),
+        "bins": np.asarray([1, 2, 3]),
+    }
     histo_dict_list = [
         {"label": "Background", "isData": False, "hist": bg_hist, "variable": "x"},
         {"label": "Signal", "isData": False, "hist": sig_hist, "variable": "x"},

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -20,7 +20,7 @@ def test_validate():
         "NormFactors": "",
         "Samples": [{"Data": True}],
     }
-    assert configuration.validate(config_valid) is True
+    assert configuration.validate(config_valid)
 
     config_missing_key = {"General": []}
     with pytest.raises(ValueError, match="missing required key in config") as e_info:

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -103,7 +103,7 @@ def test_create_histograms(tmp_path, caplog, utils):
     with pytest.raises(NotImplementedError, match="unknown backend") as e_info:
         assert template_builder.create_histograms(config, tmp_path, method="unknown")
 
-    saved_histo, _ = histo.load_from_config(
+    saved_histo = histo.Histogram.from_config(
         tmp_path,
         config["Samples"][0],
         config["Regions"][0],
@@ -111,9 +111,9 @@ def test_create_histograms(tmp_path, caplog, utils):
         modified=False,
     )
 
-    assert np.allclose(saved_histo["yields"], [1, 1, 2])
-    assert np.allclose(saved_histo["sumw2"], [1, 1, 1.41421356])
-    assert np.allclose(saved_histo["bins"], bins)
+    assert np.allclose(saved_histo.yields, [1, 1, 2])
+    assert np.allclose(saved_histo.sumw2, [1, 1, 1.41421356])
+    assert np.allclose(saved_histo.bins, bins)
 
     assert "  reading sample sample" in [rec.message for rec in caplog.records]
     assert "  in region test_region" in [rec.message for rec in caplog.records]

--- a/tests/test_template_postprocessor.py
+++ b/tests/test_template_postprocessor.py
@@ -8,24 +8,24 @@ from cabinetry import template_postprocessor
 @pytest.mark.parametrize(
     "test_histo, fixed_sumw2",
     [
-        ({"sumw2": [float("nan"), 0.2]}, [0.0, 0.2]),
-        ({"sumw2": [0.1, 0.2]}, [0.1, 0.2]),
+        (histo.Histogram([], [float("nan"), 0.2], []), [0.0, 0.2]),
+        (histo.Histogram([], [0.1, 0.2], []), [0.1, 0.2]),
     ],
 )
 def test__fix_stat_unc(test_histo, fixed_sumw2):
     name = "test_histo"
-    assert np.allclose(
-        template_postprocessor._fix_stat_unc(test_histo, name)["sumw2"], fixed_sumw2
-    )
+    template_postprocessor._fix_stat_unc(test_histo, name)
+    assert np.allclose(test_histo.sumw2, fixed_sumw2)
 
 
-def test_adjust_histogram():
-    histo = {"sumw2": [float("nan"), 0.2]}
+def test_apply_postprocessing():
+    histogram = histo.Histogram([], [float("nan"), 0.2], [])
     name = "test_histo"
     fixed_sumw2 = [0.0, 0.2]
-    assert np.allclose(
-        template_postprocessor.adjust_histogram(histo, name)["sumw2"], fixed_sumw2
-    )
+    fixed_histogram = template_postprocessor.apply_postprocessing(histogram, name)
+    assert np.allclose(fixed_histogram.sumw2, fixed_sumw2)
+    # the original histogram should be unchanged
+    np.testing.assert_equal(histogram.sumw2, [float("nan"), 0.2])
 
 
 def test_run(tmp_path):
@@ -33,13 +33,13 @@ def test_run(tmp_path):
 
     # create an input histogram
     histo_path = tmp_path / "signal_region_1_nominal.npz"
-    histogram = histo.to_dict(
+    histogram = histo.Histogram(
         np.asarray([1.0, 2.0]), np.asarray([1.0, 1.0]), np.asarray([0.0, 1.0, 2.0])
     )
-    histo.save(histogram, histo_path)
+    histogram.save(histo_path)
 
     template_postprocessor.run(config, tmp_path)
-    modified_histo = histo._load(histo_path, modified=True)
-    assert np.allclose(modified_histo["yields"], histogram["yields"])
-    assert np.allclose(modified_histo["sumw2"], histogram["sumw2"])
-    assert np.allclose(modified_histo["bins"], histogram["bins"])
+    modified_histo = histo.Histogram.from_path(histo_path, modified=True)
+    assert np.allclose(modified_histo.yields, histogram.yields)
+    assert np.allclose(modified_histo.sumw2, histogram.sumw2)
+    assert np.allclose(modified_histo.bins, histogram.bins)

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 
+from cabinetry import histo
 from cabinetry import visualize
 from cabinetry.contrib import histogram_drawing
 
@@ -20,10 +21,12 @@ def test__build_figure_name(test_input, expected):
 
 
 @mock.patch("cabinetry.contrib.histogram_drawing.data_MC_matplotlib")
-@mock.patch("cabinetry.visualize.histo.load_from_config", return_value=({}, ""))
+@mock.patch(
+    "cabinetry.histo.Histogram.from_config", return_value=histo.Histogram([], [], [])
+)
 def test_data_MC(mock_load, mock_draw, tmp_path):
     """contrib.histogram_drawing is only imported depending on the keyword argument,
-    so the patch works differently from the patch of load_from_config
+    so cannot patch via cabinetry.visualize.histogram_drawing
     Generally it seems like following the path to the module is preferred, but that
     does not work for the `data_MC_matplotlib` case. For some information see also
     https://docs.python.org/3/library/unittest.mock.html#where-to-patch
@@ -51,7 +54,14 @@ def test_data_MC(mock_load, mock_draw, tmp_path):
     assert mock_draw.call_args_list == [
         (
             (
-                [{"label": "sample_1", "isData": False, "hist": {}, "variable": "x"}],
+                [
+                    {
+                        "label": "sample_1",
+                        "isData": False,
+                        "hist": {"yields": [], "sumw2": [], "bins": []},
+                        "variable": "x",
+                    }
+                ],
                 tmp_path / "reg_1_prefit.pdf",
             ),
         )

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -90,10 +90,10 @@ def test_get_channels(tmp_path):
 
     # create a histogram for testing
     histo_path = tmp_path / "signal_region_1_nominal.npz"
-    histogram = histo.to_dict(
+    histogram = histo.Histogram(
         np.asarray([1.0, 2.0]), np.asarray([1.0, 1.0]), np.asarray([0.0, 1.0, 2.0])
     )
-    histo.save(histogram, histo_path)
+    histogram.save(histo_path)
 
     channels = workspace.get_channels(example_config, tmp_path)
     expected_channels = [
@@ -127,10 +127,10 @@ def test_get_observations(tmp_path):
     histo_path = tmp_path / "Data_test_region_nominal.npz"
 
     # build a test histogram and save it
-    histogram = histo.to_dict(
+    histogram = histo.Histogram(
         np.asarray([1.0, 2.0]), np.asarray([1.0, 1.0]), np.asarray([0.0, 1.0, 2.0])
     )
-    histo.save(histogram, histo_path)
+    histogram.save(histo_path)
 
     # create observations list from config
     config = {


### PR DESCRIPTION
Creating a histogram class to simplify the internal handling. This should later on also help when exchanging histograms by differentiable alternatives.