### PR TITLE
feat: nll at best-fit point

### DIFF
--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -49,7 +49,11 @@ def fit(spec):
         spec (dict): a pyhf workspace
 
     Returns:
-        (numpy.ndarray, numpy.ndarray, list): best-fit positions of parameters, their uncertainties and names
+        tuple: a tuple containing
+            - numpy.ndarray: best-fit positions of parameters
+            - numpy.ndarray: parameter uncertainties
+            - list: parameter names
+            - float: -2 log(likelihood) at best-fit point
     """
     log.info("performing unconstrained fit")
 
@@ -58,10 +62,12 @@ def fit(spec):
     data = workspace.data(model)
 
     pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=True))
-    result = pyhf.infer.mle.fit(data, model, return_uncertainties=True)
+    result, twice_nll = pyhf.infer.mle.fit(
+        data, model, return_uncertainties=True, return_fitted_val=True
+    )
     bestfit = result[:, 0]
     uncertainty = result[:, 1]
     labels = get_parameter_names(model)
 
     print_results(bestfit, uncertainty, labels)
-    return bestfit, uncertainty, labels
+    return bestfit, uncertainty, labels, twice_nll

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -42,7 +42,8 @@ def test_print_results(caplog):
 # due to different numpy versions used in dependencies
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_fit(example_spec):
-    bestfit, uncertainty, labels = fit.fit(example_spec)
+    bestfit, uncertainty, labels, twice_nll = fit.fit(example_spec)
     assert np.allclose(bestfit, [0.99998772, 9.16255687])
     assert np.allclose(uncertainty, [0.04954955, 0.61348804])
     assert labels == ["staterror_Signal-Region", "Signal strength"]
+    assert np.allclose(twice_nll, 3.83054341)


### PR DESCRIPTION
enable the return of twice the negative log likelihood at the best-fit point in `cabinetry.fit.fit()`