### PR TITLE
refactor: order of coordinates for templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ The production of a template histogram requires the following information:
 
 In practice, histogram information can be given by specifying lists of:
 
+- regions of phase space (or channels, independent regions obtained via different selection requirements),
 - samples (physics processes),
-- systematic uncertainties for the samples, which might vary across samples (and phase space regions),
-- regions of phase space (or channels, independent regions obtained via different selection requirements).
+- systematic uncertainties for the samples, which might vary across samples and phase space regions.
 
 For LHC-style template profile likelihood fits, typically a few thousand histograms are needed.
-An analysis that considers 10 different physics processes (simulated as 10 independent Monte Carlo samples), with an average of 50 systematic uncertainties for all the samples (implemented by specifying variations from the nominal configuration in two directions), which uses 5 different phase space regions, needs `10x100x5=5000` histograms.
+An analysis that considers 5 different phase space regions, with 10 different physics processes (simulated as 10 independent Monte Carlo samples), and an average of 50 systematic uncertainties for all the samples (implemented by specifying variations from the nominal configuration in two directions), needs `5x10x100=5000` histograms.
 
 ### 2. Histogram adjustments
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ The production of a template histogram requires the following information:
 In practice, histogram information can be given by specifying lists of:
 
 - samples (physics processes),
-- regions of phase space (or channels, independent regions obtained via different selection requirements),
-- systematic uncertainties for the samples, which might vary across samples and phase space regions.
+- systematic uncertainties for the samples, which might vary across samples (and phase space regions),
+- regions of phase space (or channels, independent regions obtained via different selection requirements).
 
 For LHC-style template profile likelihood fits, typically a few thousand histograms are needed.
-An analysis that considers 10 different physics processes (simulated as 10 independent Monte Carlo samples, uses 5 different phase space regions, and an average of 50 systematic uncertainties for all the samples (implemented by specifying variations from the nominal configuration in two directions) needs `10x5x100=5000` systematics.
+An analysis that considers 10 different physics processes (simulated as 10 independent Monte Carlo samples), with an average of 50 systematic uncertainties for all the samples (implemented by specifying variations from the nominal configuration in two directions), which uses 5 different phase space regions, needs `10x100x5=5000` histograms.
 
 ### 2. Histogram adjustments
 

--- a/config_example.yml
+++ b/config_example.yml
@@ -2,6 +2,12 @@ General:
   Measurement: "minimal_example"
   POI: "Signal_norm"
 
+Regions:
+  - Name: "Signal_region"
+    Variable: "jet_pt"
+    Filter: "lep_charge > 0"
+    Binning: [200, 300, 400, 500, 600]
+
 Samples:
   - Name: "Data"
     Tree: "pseudodata"
@@ -20,12 +26,6 @@ Samples:
     Path: "ntuples/prediction.root"
     Weight: "weight"
     Color: "#FFAA55"
-
-Regions:
-  - Name: "Signal_region"
-    Variable: "jet_pt"
-    Filter: "lep_charge > 0"
-    Binning: [200, 300, 400, 500, 600]
 
 Systematics:
   - Name: "Luminosity"

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -106,14 +106,14 @@ def sample_affected_by_modifier(sample, modifier):
     return affected
 
 
-def histogram_is_needed(sample, systematic, region):
+def histogram_is_needed(region, sample, systematic):
     """determine whether for a given sample-region-systematic pairing, there is
     an associated histogram
 
     Args:
+        region (dict): containing all region information
         sample (dict): containing all sample information
         systematic (dict): containing all systematic information
-        region (dict): containing all region information
 
     Raises:
         NotImplementedError: non-supported systematic variations based on histograms are requested

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -106,14 +106,14 @@ def sample_affected_by_modifier(sample, modifier):
     return affected
 
 
-def histogram_is_needed(sample, region, systematic):
+def histogram_is_needed(sample, systematic, region):
     """determine whether for a given sample-region-systematic pairing, there is
     an associated histogram
 
     Args:
         sample (dict): containing all sample information
-        region (dict): containing all region information
         systematic (dict): containing all systematic information
+        region (dict): containing all region information
 
     Raises:
         NotImplementedError: non-supported systematic variations based on histograms are requested

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -58,22 +58,22 @@ class Histogram:
         return cls(yields, sumw2, bins)
 
     @classmethod
-    def from_config(cls, histo_folder, sample, systematic, region, modified=True):
+    def from_config(cls, histo_folder, region, sample, systematic, modified=True):
         """load a histogram, given a folder the histogram is located in and the
         relevant information from the config: sample, systematic, region
 
         Args:
             histo_folder (str): folder containing all histograms
+            region (dict): containing all region information
             sample (dict): containing all sample information
             systematic (dict): containing all systematic information
-            region (dict): containing all region information
             modified (bool, optional): whether to load the modified histogram (after post-processing), defaults to True
 
         Returns:
             cabinetry.histo.Histogram: the loaded histogram
         """
         # find the histogram name given config information, and then load the histogram
-        histo_name = build_name(sample, systematic, region)
+        histo_name = build_name(region, sample, systematic)
         histo_path = Path(histo_folder) / histo_name
         return cls.from_path(histo_path, modified)
 
@@ -142,17 +142,17 @@ class Histogram:
         return normalization_ratio
 
 
-def build_name(sample, systematic, region):
+def build_name(region, sample, systematic):
     """construct a unique name for each histogram
 
     Args:
+        region (dict): containing all region information
         sample (dict): containing all sample information
         systematic (dict): containing all systematic information
-        region (dict): containing all region information
 
     Returns:
         str: unique name for the histogram
     """
-    name = sample["Name"] + "_" + systematic["Name"] + "_" + region["Name"]
+    name = region["Name"] + "_" + sample["Name"] + "_" + systematic["Name"]
     name = name.replace(" ", "-")
     return name

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -58,22 +58,22 @@ class Histogram:
         return cls(yields, sumw2, bins)
 
     @classmethod
-    def from_config(cls, histo_folder, sample, region, systematic, modified=True):
+    def from_config(cls, histo_folder, sample, systematic, region, modified=True):
         """load a histogram, given a folder the histogram is located in and the
-        relevant information from the config: sample, region, systematic
+        relevant information from the config: sample, systematic, region
 
         Args:
             histo_folder (str): folder containing all histograms
             sample (dict): containing all sample information
-            region (dict): containing all region information
             systematic (dict): containing all systematic information
+            region (dict): containing all region information
             modified (bool, optional): whether to load the modified histogram (after post-processing), defaults to True
 
         Returns:
             cabinetry.histo.Histogram: the loaded histogram
         """
         # find the histogram name given config information, and then load the histogram
-        histo_name = build_name(sample, region, systematic)
+        histo_name = build_name(sample, systematic, region)
         histo_path = Path(histo_folder) / histo_name
         return cls.from_path(histo_path, modified)
 
@@ -142,17 +142,17 @@ class Histogram:
         return normalization_ratio
 
 
-def build_name(sample, region, systematic):
+def build_name(sample, systematic, region):
     """construct a unique name for each histogram
 
     Args:
         sample (dict): containing all sample information
-        region (dict): containing all region information
         systematic (dict): containing all systematic information
+        region (dict): containing all region information
 
     Returns:
         str: unique name for the histogram
     """
-    name = sample["Name"] + "_" + region["Name"] + "_" + systematic["Name"]
+    name = sample["Name"] + "_" + systematic["Name"] + "_" + region["Name"]
     name = name.replace(" ", "-")
     return name

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -60,7 +60,7 @@ class Histogram:
     @classmethod
     def from_config(cls, histo_folder, region, sample, systematic, modified=True):
         """load a histogram, given a folder the histogram is located in and the
-        relevant information from the config: sample, systematic, region
+        relevant information from the config: region, sample, systematic
 
         Args:
             histo_folder (str): folder containing all histograms

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -154,7 +154,7 @@ def create_histograms(config, folder_path_str, method="uproot"):
                 )
 
                 if not histo_needed:
-                    # no further action is needed, continue with the next sample-systematic-region combination
+                    # no further action is needed, continue with the next region-sample-systematic combination
                     continue
 
                 log.debug("  variation %s", systematic["Name"])

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -140,8 +140,10 @@ def create_histograms(config, folder_path_str, method="uproot"):
 
     for region in config["Regions"]:
         log.debug("  in region %s", region["Name"])
+
         for sample in config["Samples"]:
             log.debug("  reading sample %s", sample["Name"])
+
             for isyst, systematic in enumerate(
                 ([{"Name": "nominal"}] + config["Systematics"])
             ):

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -50,14 +50,14 @@ def run(config, histogram_folder):
     """
     log.info("applying post-processing to histograms")
     # loop over all histograms
-    for sample in config["Samples"]:
-        for systematic in [{"Name": "nominal"}]:
-            for region in config["Regions"]:
+    for region in config["Regions"]:
+        for sample in config["Samples"]:
+            for systematic in [{"Name": "nominal"}]:
                 # need to add histogram-based systematics here as well
                 histogram = histo.Histogram.from_config(
-                    histogram_folder, sample, systematic, region, modified=False
+                    histogram_folder, region, sample, systematic, modified=False
                 )
-                histogram_name = histo.build_name(sample, systematic, region)
+                histogram_name = histo.build_name(region, sample, systematic)
                 new_histogram = apply_postprocessing(histogram, histogram_name)
                 histogram.validate(histogram_name)
                 new_histo_path = Path(histogram_folder) / (histogram_name + "_modified")

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -51,13 +51,13 @@ def run(config, histogram_folder):
     log.info("applying post-processing to histograms")
     # loop over all histograms
     for sample in config["Samples"]:
-        for region in config["Regions"]:
-            for systematic in [{"Name": "nominal"}]:
+        for systematic in [{"Name": "nominal"}]:
+            for region in config["Regions"]:
                 # need to add histogram-based systematics here as well
                 histogram = histo.Histogram.from_config(
-                    histogram_folder, sample, region, systematic, modified=False
+                    histogram_folder, sample, systematic, region, modified=False
                 )
-                histogram_name = histo.build_name(sample, region, systematic)
+                histogram_name = histo.build_name(sample, systematic, region)
                 new_histogram = apply_postprocessing(histogram, histogram_name)
                 histogram.validate(histogram_name)
                 new_histo_path = Path(histogram_folder) / (histogram_name + "_modified")

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -51,7 +51,7 @@ def data_MC(config, histogram_folder, figure_folder, prefit=True, method="matplo
             for systematic in [{"Name": "nominal"}]:
                 is_data = sample.get("Data", False)
                 histogram = histo.Histogram.from_config(
-                    histogram_folder, sample, systematic, region, modified=True
+                    histogram_folder, region, sample, systematic, modified=True
                 )
                 histogram_dict_list.append(
                     {

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -51,7 +51,7 @@ def data_MC(config, histogram_folder, figure_folder, prefit=True, method="matplo
             for systematic in [{"Name": "nominal"}]:
                 is_data = sample.get("Data", False)
                 histogram = histo.Histogram.from_config(
-                    histogram_folder, sample, region, systematic, modified=True
+                    histogram_folder, sample, systematic, region, modified=True
                 )
                 histogram_dict_list.append(
                     {

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -42,7 +42,7 @@ def get_yield_for_sample(
         list: yields per bin for the sample
     """
     histogram = histo.Histogram.from_config(
-        histogram_folder, sample, region, systematic, modified=True
+        histogram_folder, sample, systematic, region, modified=True
     )
     histo_yield = histogram.yields.tolist()
     return histo_yield
@@ -64,7 +64,7 @@ def get_unc_for_sample(
         list: statistical uncertainty of yield per bin for the sample
     """
     histogram = histo.Histogram.from_config(
-        histogram_folder, sample, region, systematic, modified=True
+        histogram_folder, sample, systematic, region, modified=True
     )
     histo_yield = histogram.sumw2.tolist()
     return histo_yield
@@ -117,7 +117,7 @@ def get_OverallSys_modifier(systematic):
     return modifier
 
 
-def get_NormPlusShape_modifiers(sample, region, systematic, histogram_folder):
+def get_NormPlusShape_modifiers(sample, systematic, region, histogram_folder):
     """For a variation including a correlated shape + normalization effect, this
     provides the histosys and normsys modifiers for pyhf (in HistFactory language,
     this corresponds to a HistoSys and an OverallSys).
@@ -126,8 +126,8 @@ def get_NormPlusShape_modifiers(sample, region, systematic, histogram_folder):
 
     Args:
         sample (dict): sample the systematic variation acts on
-        region (dict): region the systematic variation acts in
         systematic (dict): the systematic variation under consideration
+        region (dict): region the systematic variation acts in
         histogram_folder (str): path to folder containing histograms
 
     Returns:
@@ -135,12 +135,12 @@ def get_NormPlusShape_modifiers(sample, region, systematic, histogram_folder):
     """
     # load the systematic variation histogram
     histogram_variation = histo.Histogram.from_config(
-        histogram_folder, sample, region, systematic, modified=True
+        histogram_folder, sample, systematic, region, modified=True
     )
 
     # also need the nominal histogram
     histogram_nominal = histo.Histogram.from_config(
-        histogram_folder, sample, region, {"Name": "nominal"}, modified=True
+        histogram_folder, sample, {"Name": "nominal"}, region, modified=True
     )
 
     # need to add support for two-sided variations that do not require symmetrization here
@@ -217,7 +217,7 @@ def get_sys_modifiers(config, sample, region, histogram_folder):
                     sample["Name"],
                 )
                 modifiers += get_NormPlusShape_modifiers(
-                    sample, region, systematic, histogram_folder
+                    sample, systematic, region, histogram_folder
                 )
             else:
                 raise NotImplementedError("not supporting other systematic types yet")

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -42,7 +42,7 @@ def get_yield_for_sample(
         list: yields per bin for the sample
     """
     histogram = histo.Histogram.from_config(
-        histogram_folder, sample, systematic, region, modified=True
+        histogram_folder, region, sample, systematic, modified=True
     )
     histo_yield = histogram.yields.tolist()
     return histo_yield
@@ -64,7 +64,7 @@ def get_unc_for_sample(
         list: statistical uncertainty of yield per bin for the sample
     """
     histogram = histo.Histogram.from_config(
-        histogram_folder, sample, systematic, region, modified=True
+        histogram_folder, region, sample, systematic, modified=True
     )
     histo_yield = histogram.sumw2.tolist()
     return histo_yield
@@ -117,7 +117,7 @@ def get_OverallSys_modifier(systematic):
     return modifier
 
 
-def get_NormPlusShape_modifiers(sample, systematic, region, histogram_folder):
+def get_NormPlusShape_modifiers(region, sample, systematic, histogram_folder):
     """For a variation including a correlated shape + normalization effect, this
     provides the histosys and normsys modifiers for pyhf (in HistFactory language,
     this corresponds to a HistoSys and an OverallSys).
@@ -125,9 +125,9 @@ def get_NormPlusShape_modifiers(sample, systematic, region, histogram_folder):
     or somewhere earlier, such as during template postprocessing.
 
     Args:
+        region (dict): region the systematic variation acts in
         sample (dict): sample the systematic variation acts on
         systematic (dict): the systematic variation under consideration
-        region (dict): region the systematic variation acts in
         histogram_folder (str): path to folder containing histograms
 
     Returns:
@@ -135,12 +135,12 @@ def get_NormPlusShape_modifiers(sample, systematic, region, histogram_folder):
     """
     # load the systematic variation histogram
     histogram_variation = histo.Histogram.from_config(
-        histogram_folder, sample, systematic, region, modified=True
+        histogram_folder, region, sample, systematic, modified=True
     )
 
     # also need the nominal histogram
     histogram_nominal = histo.Histogram.from_config(
-        histogram_folder, sample, {"Name": "nominal"}, region, modified=True
+        histogram_folder, region, sample, {"Name": "nominal"}, modified=True
     )
 
     # need to add support for two-sided variations that do not require symmetrization here
@@ -217,7 +217,7 @@ def get_sys_modifiers(config, sample, region, histogram_folder):
                     sample["Name"],
                 )
                 modifiers += get_NormPlusShape_modifiers(
-                    sample, systematic, region, histogram_folder
+                    region, sample, systematic, histogram_folder
                 )
             else:
                 raise NotImplementedError("not supporting other systematic types yet")

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -94,35 +94,35 @@ def test_sample_affected_by_modifier(sample_and_modifier, affected):
 
 
 @pytest.mark.parametrize(
-    "sam_reg_sys, needed",
+    "sam_sys_reg, needed",
     [
         # nominal
-        (({}, {}, {"Name": "nominal"}), True),
+        (({}, {"Name": "nominal"}, {}), True),
         # non-nominal data
-        (({"Data": True}, {}, {"Name": "var"}), False),
+        (({"Data": True}, {"Name": "var"}, {}), False),
         # overall normalization variation
-        (({}, {}, {"Type": "Overall"}), False),
+        (({}, {"Type": "Overall"}, {}), False),
         # normalization + shape variation on affected sample
         (
-            ({"Name": "Signal"}, {}, {"Type": "NormPlusShape", "Samples": "Signal"}),
+            ({"Name": "Signal"}, {"Type": "NormPlusShape", "Samples": "Signal"}, {}),
             True,
         ),
         # normalization + shape variation on non-affected sample
         (
             (
                 {"Name": "Background"},
-                {},
                 {"Type": "NormPlusShape", "Samples": "Signal"},
+                {},
             ),
             False,
         ),
     ],
 )
-def test_histogram_is_needed(sam_reg_sys, needed):
-    assert configuration.histogram_is_needed(*sam_reg_sys) is needed
+def test_histogram_is_needed(sam_sys_reg, needed):
+    assert configuration.histogram_is_needed(*sam_sys_reg) is needed
 
     # non-supported systematic
     with pytest.raises(
         NotImplementedError, match="other systematics not yet implemented"
     ) as e_info:
-        configuration.histogram_is_needed({}, {}, {"Type": "unknown"})
+        configuration.histogram_is_needed({}, {"Type": "unknown"}, {})

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -94,35 +94,35 @@ def test_sample_affected_by_modifier(sample_and_modifier, affected):
 
 
 @pytest.mark.parametrize(
-    "sam_sys_reg, needed",
+    "reg_sam_sys, needed",
     [
         # nominal
-        (({}, {"Name": "nominal"}, {}), True),
+        (({}, {}, {"Name": "nominal"}), True),
         # non-nominal data
-        (({"Data": True}, {"Name": "var"}, {}), False),
+        (({}, {"Data": True}, {"Name": "var"}), False),
         # overall normalization variation
-        (({}, {"Type": "Overall"}, {}), False),
+        (({}, {}, {"Type": "Overall"}), False),
         # normalization + shape variation on affected sample
         (
-            ({"Name": "Signal"}, {"Type": "NormPlusShape", "Samples": "Signal"}, {}),
+            ({}, {"Name": "Signal"}, {"Type": "NormPlusShape", "Samples": "Signal"}),
             True,
         ),
         # normalization + shape variation on non-affected sample
         (
             (
+                {},
                 {"Name": "Background"},
                 {"Type": "NormPlusShape", "Samples": "Signal"},
-                {},
             ),
             False,
         ),
     ],
 )
-def test_histogram_is_needed(sam_sys_reg, needed):
-    assert configuration.histogram_is_needed(*sam_sys_reg) is needed
+def test_histogram_is_needed(reg_sam_sys, needed):
+    assert configuration.histogram_is_needed(*reg_sam_sys) is needed
 
     # non-supported systematic
     with pytest.raises(
         NotImplementedError, match="other systematics not yet implemented"
     ) as e_info:
-        configuration.histogram_is_needed({}, {"Type": "unknown"}, {})
+        configuration.histogram_is_needed({}, {}, {"Type": "unknown"})

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -106,14 +106,14 @@ def test_Histogram_from_path(tmp_path, caplog, example_histograms, histogram_hel
 
 def test_Histogram_from_config(tmp_path, example_histograms, histogram_helpers):
     h_ref = histo.Histogram(*example_histograms.normal())
-    histo_path = tmp_path / "sample_nominal_region.npz"
+    histo_path = tmp_path / "region_sample_nominal.npz"
     h_ref.save(histo_path)
 
+    region = {"Name": "region"}
     sample = {"Name": "sample"}
     systematic = {"Name": "nominal"}
-    region = {"Name": "region"}
     h_from_path = histo.Histogram.from_config(
-        tmp_path, sample, systematic, region, modified=False
+        tmp_path, region, sample, systematic, modified=False
     )
     histogram_helpers.assert_equal(h_ref, h_from_path)
 
@@ -173,14 +173,14 @@ def test_Histogram_normalize_to_yield(example_histograms):
 
 
 def test_build_name():
+    region = {"Name": "Region"}
     sample = {"Name": "Sample"}
     systematic = {"Name": "Systematic"}
-    region = {"Name": "Region"}
-    assert histo.build_name(sample, systematic, region) == "Sample_Systematic_Region"
+    assert histo.build_name(region, sample, systematic) == "Region_Sample_Systematic"
 
+    region = {"Name": "Region 1"}
     sample = {"Name": "Sample 1"}
     systematic = {"Name": "Systematic 1"}
-    region = {"Name": "Region 1"}
     assert (
-        histo.build_name(sample, systematic, region) == "Sample-1_Systematic-1_Region-1"
+        histo.build_name(region, sample, systematic) == "Region-1_Sample-1_Systematic-1"
     )

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -106,14 +106,14 @@ def test_Histogram_from_path(tmp_path, caplog, example_histograms, histogram_hel
 
 def test_Histogram_from_config(tmp_path, example_histograms, histogram_helpers):
     h_ref = histo.Histogram(*example_histograms.normal())
-    histo_path = tmp_path / "sample_region_nominal.npz"
+    histo_path = tmp_path / "sample_nominal_region.npz"
     h_ref.save(histo_path)
 
     sample = {"Name": "sample"}
-    region = {"Name": "region"}
     systematic = {"Name": "nominal"}
+    region = {"Name": "region"}
     h_from_path = histo.Histogram.from_config(
-        tmp_path, sample, region, systematic, modified=False
+        tmp_path, sample, systematic, region, modified=False
     )
     histogram_helpers.assert_equal(h_ref, h_from_path)
 
@@ -174,13 +174,13 @@ def test_Histogram_normalize_to_yield(example_histograms):
 
 def test_build_name():
     sample = {"Name": "Sample"}
-    region = {"Name": "Region"}
     systematic = {"Name": "Systematic"}
-    assert histo.build_name(sample, region, systematic) == "Sample_Region_Systematic"
+    region = {"Name": "Region"}
+    assert histo.build_name(sample, systematic, region) == "Sample_Systematic_Region"
 
     sample = {"Name": "Sample 1"}
-    region = {"Name": "Region 1"}
     systematic = {"Name": "Systematic 1"}
+    region = {"Name": "Region 1"}
     assert (
-        histo.build_name(sample, region, systematic) == "Sample-1_Region-1_Systematic-1"
+        histo.build_name(sample, systematic, region) == "Sample-1_Systematic-1_Region-1"
     )

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -10,36 +10,36 @@ from cabinetry import template_builder
 
 def test__get_ntuple_path():
     assert template_builder._get_ntuple_path(
-        {"Path": "test/path.root"}, {"Name": "nominal"}, {}
+        {}, {"Path": "test/path.root"}, {"Name": "nominal"}
     ) == Path("test/path.root")
 
     assert template_builder._get_ntuple_path(
         {},
-        {"Name": "variation", "Type": "NormPlusShape", "PathUp": "test/path.root"},
         {},
+        {"Name": "variation", "Type": "NormPlusShape", "PathUp": "test/path.root"},
     ) == Path("test/path.root")
 
     with pytest.raises(
         NotImplementedError, match="ntuple path treatment not yet defined"
     ) as e_info:
         assert template_builder._get_ntuple_path(
-            {}, {"Name": "unknown_variation_type", "Type": "unknown"}, {}
+            {}, {}, {"Name": "unknown_variation_type", "Type": "unknown"}
         )
 
 
 def test__get_variable():
-    assert template_builder._get_variable({}, {}, {"Variable": "jet_pt"}) == "jet_pt"
+    assert template_builder._get_variable({"Variable": "jet_pt"}, {}, {}) == "jet_pt"
 
 
 def test__get_filter():
     assert (
-        template_builder._get_filter({}, {}, {"Filter": "jet_pt > 0"}) == "jet_pt > 0"
+        template_builder._get_filter({"Filter": "jet_pt > 0"}, {}, {}) == "jet_pt > 0"
     )
     assert template_builder._get_filter({}, {}, {}) is None
 
 
 def test__get_weight():
-    assert template_builder._get_weight({"Weight": "weight_mc"}, {}, {}) == "weight_mc"
+    assert template_builder._get_weight({}, {"Weight": "weight_mc"}, {}) == "weight_mc"
     assert template_builder._get_weight({}, {}, {}) is None
 
 
@@ -87,8 +87,8 @@ def test_create_histograms(tmp_path, caplog, utils):
     utils.create_ntuple(fname, treename, varname, var_array, weightname, weight_array)
 
     config = {
-        "Samples": [{"Name": "sample", "Tree": treename, "Path": fname}],
         "Regions": [{"Name": "test_region", "Variable": varname, "Binning": bins}],
+        "Samples": [{"Name": "sample", "Tree": treename, "Path": fname}],
         "Systematics": [],
     }
     template_builder.create_histograms(config, tmp_path, method="uproot")
@@ -105,9 +105,9 @@ def test_create_histograms(tmp_path, caplog, utils):
 
     saved_histo = histo.Histogram.from_config(
         tmp_path,
+        config["Regions"][0],
         config["Samples"][0],
         {"Name": "nominal"},
-        config["Regions"][0],
         modified=False,
     )
 

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -10,30 +10,30 @@ from cabinetry import template_builder
 
 def test__get_ntuple_path():
     assert template_builder._get_ntuple_path(
-        {"Path": "test/path.root"}, {}, {"Name": "nominal"}
+        {"Path": "test/path.root"}, {"Name": "nominal"}, {}
     ) == Path("test/path.root")
 
     assert template_builder._get_ntuple_path(
         {},
-        {},
         {"Name": "variation", "Type": "NormPlusShape", "PathUp": "test/path.root"},
+        {},
     ) == Path("test/path.root")
 
     with pytest.raises(
         NotImplementedError, match="ntuple path treatment not yet defined"
     ) as e_info:
         assert template_builder._get_ntuple_path(
-            {}, {}, {"Name": "unknown_variation_type", "Type": "unknown"}
+            {}, {"Name": "unknown_variation_type", "Type": "unknown"}, {}
         )
 
 
 def test__get_variable():
-    assert template_builder._get_variable({}, {"Variable": "jet_pt"}, {}) == "jet_pt"
+    assert template_builder._get_variable({}, {}, {"Variable": "jet_pt"}) == "jet_pt"
 
 
 def test__get_filter():
     assert (
-        template_builder._get_filter({}, {"Filter": "jet_pt > 0"}, {}) == "jet_pt > 0"
+        template_builder._get_filter({}, {}, {"Filter": "jet_pt > 0"}) == "jet_pt > 0"
     )
     assert template_builder._get_filter({}, {}, {}) is None
 
@@ -106,8 +106,8 @@ def test_create_histograms(tmp_path, caplog, utils):
     saved_histo = histo.Histogram.from_config(
         tmp_path,
         config["Samples"][0],
-        config["Regions"][0],
         {"Name": "nominal"},
+        config["Regions"][0],
         modified=False,
     )
 

--- a/tests/test_template_postprocessor.py
+++ b/tests/test_template_postprocessor.py
@@ -32,7 +32,7 @@ def test_run(tmp_path):
     config = {"Samples": [{"Name": "signal"}], "Regions": [{"Name": "region_1"}]}
 
     # create an input histogram
-    histo_path = tmp_path / "signal_region_1_nominal.npz"
+    histo_path = tmp_path / "signal_nominal_region_1.npz"
     histogram = histo.Histogram(
         np.asarray([1.0, 2.0]), np.asarray([1.0, 1.0]), np.asarray([0.0, 1.0, 2.0])
     )

--- a/tests/test_template_postprocessor.py
+++ b/tests/test_template_postprocessor.py
@@ -32,7 +32,7 @@ def test_run(tmp_path):
     config = {"Samples": [{"Name": "signal"}], "Regions": [{"Name": "region_1"}]}
 
     # create an input histogram
-    histo_path = tmp_path / "signal_nominal_region_1.npz"
+    histo_path = tmp_path / "region_1_signal_nominal.npz"
     histogram = histo.Histogram(
         np.asarray([1.0, 2.0]), np.asarray([1.0, 1.0]), np.asarray([0.0, 1.0, 2.0])
     )

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -45,8 +45,8 @@ def test_data_MC(mock_load, mock_draw, tmp_path):
             (
                 tmp_path,
                 {"Name": "sample_1"},
-                {"Name": "reg_1", "Variable": "x"},
                 {"Name": "nominal"},
+                {"Name": "reg_1", "Variable": "x"},
             ),
             {"modified": True},
         )

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -44,9 +44,9 @@ def test_data_MC(mock_load, mock_draw, tmp_path):
         (
             (
                 tmp_path,
+                {"Name": "reg_1", "Variable": "x"},
                 {"Name": "sample_1"},
                 {"Name": "nominal"},
-                {"Name": "reg_1", "Variable": "x"},
             ),
             {"modified": True},
         )

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -89,7 +89,7 @@ def test_get_channels(tmp_path):
     }
 
     # create a histogram for testing
-    histo_path = tmp_path / "signal_nominal_region_1.npz"
+    histo_path = tmp_path / "region_1_signal_nominal.npz"
     histogram = histo.Histogram(
         np.asarray([1.0, 2.0]), np.asarray([1.0, 1.0]), np.asarray([0.0, 1.0, 2.0])
     )
@@ -124,7 +124,7 @@ def test_get_measurement():
 
 
 def test_get_observations(tmp_path):
-    histo_path = tmp_path / "Data_nominal_test_region.npz"
+    histo_path = tmp_path / "test_region_Data_nominal.npz"
 
     # build a test histogram and save it
     histogram = histo.Histogram(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -89,7 +89,7 @@ def test_get_channels(tmp_path):
     }
 
     # create a histogram for testing
-    histo_path = tmp_path / "signal_region_1_nominal.npz"
+    histo_path = tmp_path / "signal_nominal_region_1.npz"
     histogram = histo.Histogram(
         np.asarray([1.0, 2.0]), np.asarray([1.0, 1.0]), np.asarray([0.0, 1.0, 2.0])
     )
@@ -124,7 +124,7 @@ def test_get_measurement():
 
 
 def test_get_observations(tmp_path):
-    histo_path = tmp_path / "Data_test_region_nominal.npz"
+    histo_path = tmp_path / "Data_nominal_test_region.npz"
 
     # build a test histogram and save it
     histogram = histo.Histogram(


### PR DESCRIPTION
Templates are categorized by phase space region, sample, and systematic variation. Before this PR, the internal structure was accessing them as (sample , region, systematic). This changes the coordinates to use (region, sample, systematic) instead.

Motivation for this change:
- A phase space region does not logically depend on either samples or systematics. While neither the list of samples nor systematics generally strongly depend on the phase space region, they can.
- Systematic variations affect samples, and the list of variations is sample-dependent. It feels intuitively better to think of samples as a higher up category than systematics.