### PR TITLE
refactor: boost_histogram for histogramming

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,7 +49,7 @@ Hello world
    cabinetry.fit.fit(ws)
 
 The above is an abbreviated version of an example included in `example.py`, which shows how to use `cabinetry`.
-Beyond the core dependencies of `cabinetry` (currently `pyyaml`, `numpy`, `pyhf`, `iminuit`), it also requires additional libraries: `uproot`, `scipy`, `matplotlib`, `numexpr`.
+It requires additional libraries beyond the core dependencies of `cabinetry`, which can be installed via `pip install cabinetry[contrib]` (or `pip install -e .[contrib]` from the repository).
 
 Acknowledgements
 ----------------

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-extras_require = {"contrib": ["matplotlib", "uproot", "scipy", "iminuit", "numexpr"]}
+extras_require = {"contrib": ["matplotlib", "uproot", "boost_histogram", "numexpr"]}
 extras_require["test"] = sorted(
     set(
         extras_require["contrib"]

--- a/src/cabinetry/contrib/histogram_creation.py
+++ b/src/cabinetry/contrib/histogram_creation.py
@@ -57,7 +57,7 @@ def _bin_data(observables, weights, bins):
     Returns:
         tuple: a tuple containing
             - numpy.ndarray: yields per bin
-            - numpy.ndarray): and stat. uncertainty per bin
+            - numpy.ndarray: and stat. uncertainty per bin
     """
     hist = bh.Histogram(bh.axis.Variable(bins), storage=bh.storage.Weight())
     hist.fill(observables, weight=weights)

--- a/tests/contrib/test_histogram_creation.py
+++ b/tests/contrib/test_histogram_creation.py
@@ -35,11 +35,6 @@ def test_from_uproot(tmp_path, utils):
     assert np.allclose(sumw2, [1, 1, 2.23606798])
 
 
-def test__sumw2():
-    weights = np.array([0.1, 0.2, 0.1])
-    assert np.allclose(histogram_creation._sumw2(weights), 0.2449489743)
-
-
 def test__bin_data():
     data = [1.1, 2.2, 2.9, 2.5, 1.4]
     weights = [1.0, 1.1, 0.9, 0.8, 1.5]


### PR DESCRIPTION
Instead of using `scipy` to histogram the output from `uproot` in `cabinetry.contrib`, switch to using [boost_histogram](https://github.com/scikit-hep/boost-histogram).
It might make sense to also use `boost_histogram` in `cabinetry.histo.Histogram`, which would make it a core dependency. This is a separate consideration for the future.

Also removing `iminuit` from install extras, since it is already a core dependency.