### PR TITLE
refactor:  uproot4 in contrib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 from setuptools import setup, find_packages
 
-extras_require = {"contrib": ["matplotlib", "uproot", "boost_histogram", "numexpr"]}
+extras_require = {
+    "contrib": ["matplotlib", "uproot", "boost_histogram", "uproot4", "awkward1"]
+}
 extras_require["test"] = sorted(
     set(
         extras_require["contrib"]

--- a/src/cabinetry/contrib/histogram_creation.py
+++ b/src/cabinetry/contrib/histogram_creation.py
@@ -1,7 +1,6 @@
 import boost_histogram as bh
-import numexpr as ne
 import numpy as np
-import uproot
+import uproot4 as uproot
 
 
 def from_uproot(
@@ -14,32 +13,23 @@ def from_uproot(
         ntuple_path (pathlib.Path): path to ntuple
         pos_in_file (str): name of tree within ntuple
         variable (str): variable to bin histogram in
-        weight (str): event weight to extract
         bins (numpy.ndarray): bin edges for histogram
+        weight (str): event weight to extract, defaults to None (no weights applied)
         selection_filter (str, optional): filter to be applied on events, defaults to None (no filter)
 
     Returns:
         (numpy.ndarray, numpy.ndarray): tuple of yields and stat. uncertainties for all bins
     """
-    table = uproot.open(ntuple_path)[pos_in_file].lazyarrays()
+    tree = uproot.open(str(ntuple_path) + ":" + pos_in_file)
 
     # extract observable and weights
-    observables = table[variable]
+    # need the last [variable] to select the right entry out of the dict
+    observables = tree[variable].arrays(cut=selection_filter, library="np")[variable]
+
     if weight is not None:
-        weights = table[weight]
+        weights = tree[weight].arrays(cut=selection_filter, library="np")[weight]
     else:
         weights = np.ones_like(observables)
-
-    # filter events if requested
-    if selection_filter is not None:
-        selection_mask = ne.evaluate(selection_filter, table)
-        observables = observables[selection_mask]
-        weights = weights[selection_mask]
-
-    # convert everything into numpy ndarrays - probably not needed in general
-    # and there might be a better solution
-    observables = np.asarray(observables)
-    weights = np.asarray(weights)
 
     yields, sumw2 = _bin_data(observables, weights, bins)
     return yields, sumw2

--- a/src/cabinetry/contrib/histogram_creation.py
+++ b/src/cabinetry/contrib/histogram_creation.py
@@ -6,8 +6,7 @@ import uproot4 as uproot
 def from_uproot(
     ntuple_path, pos_in_file, variable, bins, weight=None, selection_filter=None
 ):
-    """create a single histogram with uproot, return bin yields and statistical
-    uncertainties on the yield
+    """read an ntuple with uproot, the resulting arrays are then filled into a histogram
 
     Args:
         ntuple_path (pathlib.Path): path to ntuple
@@ -24,6 +23,7 @@ def from_uproot(
 
     # extract observable and weights
     # need the last [variable] to select the right entry out of the dict
+    # this only reads the observable branch and branches needed for the cut into memory
     observables = tree[variable].arrays(cut=selection_filter, library="np")[variable]
 
     if weight is not None:


### PR DESCRIPTION
Switching to `uproot4` in `cabinetry.contrib` for ntuple reading. This requires also the addition of `awkward1` to the setup extras. The package names need to be updated when the transition `uproot4` -> `uproot` and `awkward1` -> `awkward` happens.

`uproot` is still needed for the ntuple creation code in `util/`, but `numexpr` is no longer needed as the cut functionality is provided by `uproot4`.