### PR TITLE
test: integration test

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,7 +38,7 @@ jobs:
         black --check --diff --verbose .
     - name: Run example
       run: |
-        python util/create_histograms.py
+        python util/create_ntuples.py
         python example.py
     - name: Test with pytest and generate coverage report
       run: |

--- a/src/cabinetry/contrib/histogram_drawing.py
+++ b/src/cabinetry/contrib/histogram_drawing.py
@@ -56,6 +56,7 @@ def data_MC_matplotlib(histogram_dict_list, figure_path):
     )
 
     mpl.style.use("seaborn-colorblind")
+    fig, ax = plt.subplots()
 
     # plot MC stacked together
     total_yield = np.zeros_like(mc_histograms_yields[0])
@@ -65,7 +66,7 @@ def data_MC_matplotlib(histogram_dict_list, figure_path):
     bin_width = bin_right_edges - bin_left_edges
     bin_centers = 0.5 * (bin_left_edges + bin_right_edges)
     for i_sample, mc_sample_yield in enumerate(mc_histograms_yields):
-        plt.bar(
+        ax.bar(
             bin_centers,
             mc_sample_yield,
             width=bin_width,
@@ -76,7 +77,7 @@ def data_MC_matplotlib(histogram_dict_list, figure_path):
 
     # add total MC uncertainty
     mc_stack_unc = _total_yield_uncertainty(mc_histograms_sumw2)
-    plt.bar(
+    ax.bar(
         bin_centers,
         2 * mc_stack_unc,
         width=bin_width,
@@ -89,7 +90,7 @@ def data_MC_matplotlib(histogram_dict_list, figure_path):
     )
 
     # plot data
-    plt.errorbar(
+    ax.errorbar(
         bin_centers,
         data_histogram_yields,
         yerr=data_histogram_sumw2,
@@ -98,15 +99,13 @@ def data_MC_matplotlib(histogram_dict_list, figure_path):
         label=data_label,
     )
 
-    plt.legend(frameon=False)
-    plt.xlabel(histogram_dict_list[0]["variable"])
-    plt.ylabel("events")
-    plt.xlim(bin_left_edges[0], bin_right_edges[-1])
-    plt.ylim([0, y_max * 1.1])  # 10% headroom
-    plt.plot()
+    ax.legend(frameon=False)
+    ax.set_xlabel(histogram_dict_list[0]["variable"])
+    ax.set_ylabel("events")
+    ax.set_xlim(bin_left_edges[0], bin_right_edges[-1])
+    ax.set_ylim([0, y_max * 1.1])  # 10% headroom
 
     if not os.path.exists(figure_path.parent):
         os.mkdir(figure_path.parent)
     log.debug("saving figure as %s", figure_path)
-    plt.savefig(figure_path)
-    plt.clf()
+    fig.savefig(figure_path)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,53 @@
+import numpy as np
+import pytest
+
+import cabinetry
+from util import create_ntuples
+
+
+@pytest.fixture
+def ntuple_creator():
+    return create_ntuples.run
+
+
+@pytest.mark.no_cover
+def test_integration(tmp_path, ntuple_creator):
+    """The purpose of this integration test is to check whether the
+    steps run without error and whether the fit result is as expected.
+    """
+    ntuple_creator(str(tmp_path) + "/")
+
+    cabinetry_config = cabinetry.configuration.read("config_example.yml")
+    histo_folder = str(tmp_path) + "/histograms/"
+    cabinetry.template_builder.create_histograms(
+        cabinetry_config, histo_folder, method="uproot"
+    )
+    cabinetry.template_postprocessor.run(cabinetry_config, histo_folder)
+    workspace_path = "workspaces/example_workspace.json"
+    ws = cabinetry.workspace.build(cabinetry_config, histo_folder)
+    cabinetry.workspace.save(ws, workspace_path)
+    ws = cabinetry.workspace.load(workspace_path)
+    bestfit, uncertainty, _, twice_nll = cabinetry.fit.fit(ws)
+
+    bestfit_expected = [
+        1.00520446,
+        0.98118674,
+        1.02070816,
+        0.98229396,
+        -0.21494591,
+        0.04238099,
+        0.85726033,
+    ]
+    uncertainty_expected = [
+        0.04095113,
+        0.03727586,
+        0.03649927,
+        0.04248655,
+        0.97692647,
+        0.16042208,
+        0.40949858,
+    ]
+    twice_nll_expected = 16.274739734197926
+    assert np.allclose(bestfit, bestfit_expected)
+    assert np.allclose(uncertainty, uncertainty_expected)
+    assert np.allclose(twice_nll, twice_nll_expected)

--- a/util/create_ntuples.py
+++ b/util/create_ntuples.py
@@ -4,11 +4,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
-output_directory = "ntuples/"
-if not os.path.exists(output_directory):
-    os.mkdir(output_directory)
-
-
 def toy_distribution(noncentral, multiplier, offset, num_events):
     return (
         np.random.noncentral_chisquare(5, noncentral, num_events) * multiplier + offset
@@ -151,7 +146,7 @@ def plot_distributions(data, weights, labels, pseudodata, bins):
     plt.savefig("stacked.png", dpi=200)
 
 
-if __name__ == "__main__":
+def run(output_directory):
     # configuration
     num_events = 5000
     yield_s = 125
@@ -188,3 +183,10 @@ if __name__ == "__main__":
     # visualize results
     bins = np.linspace(0, 1200, 24 + 1)
     plot_distributions(d_read, w_read, l_read, pseudodata, bins)
+
+
+if __name__ == "__main__":
+    output_directory = "ntuples/"
+    if not os.path.exists(output_directory):
+        os.mkdir(output_directory)
+    run(output_directory)


### PR DESCRIPTION
Adding an integration test based on the example in `example.py`. This integration test is not included in the determination of coverage.

Renaming and slightly refactoring the ntuple creation script, and updating the matplotlib backend to properly clean up the figure between tests.