### PR TITLE
refactor: switch to boost-histogram

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 from setuptools import setup, find_packages
 
-extras_require = {
-    "contrib": ["matplotlib", "uproot", "boost_histogram", "uproot4", "awkward1"]
-}
+extras_require = {"contrib": ["matplotlib", "uproot", "uproot4", "awkward1"]}
 extras_require["test"] = sorted(
     set(
         extras_require["contrib"]
@@ -46,6 +44,6 @@ setup(
         "Topic :: Scientific/Engineering :: Physics",
     ],
     python_requires=">=3.6",
-    install_requires=["numpy", "pyyaml", "pyhf>=0.3.2", "iminuit"],
+    install_requires=["numpy", "pyyaml", "pyhf>=0.3.2", "iminuit", "boost_histogram"],
     extras_require=extras_require,
 )

--- a/src/cabinetry/contrib/histogram_creation.py
+++ b/src/cabinetry/contrib/histogram_creation.py
@@ -31,8 +31,8 @@ def from_uproot(
     else:
         weights = np.ones_like(observables)
 
-    yields, sumw2 = _bin_data(observables, weights, bins)
-    return yields, sumw2
+    yields, stdev = _bin_data(observables, weights, bins)
+    return yields, stdev
 
 
 def _bin_data(observables, weights, bins):
@@ -52,5 +52,5 @@ def _bin_data(observables, weights, bins):
     hist = bh.Histogram(bh.axis.Variable(bins), storage=bh.storage.Weight())
     hist.fill(observables, weight=weights)
     yields = hist.view().value
-    sumw2 = np.sqrt(hist.view().variance)
-    return yields, sumw2
+    stdev = np.sqrt(hist.view().variance)
+    return yields, stdev

--- a/src/cabinetry/contrib/histogram_drawing.py
+++ b/src/cabinetry/contrib/histogram_drawing.py
@@ -8,17 +8,17 @@ import numpy as np
 log = logging.getLogger(__name__)
 
 
-def _total_yield_uncertainty(sumw2_list):
+def _total_yield_uncertainty(stdev_list):
     """calculate the absolute statistical uncertainty of a stack of MC
     via sum in quadrature
 
     Args:
-        sumw2_list (list): list of absolute stat. uncertainty per sample
+        stdev_list (list): list of absolute stat. uncertainty per sample
 
     Returns:
         np.array: absolute stat. uncertainty of stack of samples
     """
-    tot_unc = np.sqrt(np.sum(np.power(sumw2_list, 2), axis=0))
+    tot_unc = np.sqrt(np.sum(np.power(stdev_list, 2), axis=0))
     return tot_unc
 
 
@@ -30,16 +30,16 @@ def data_MC_matplotlib(histogram_dict_list, figure_path):
         figure_path (pathlib.Path): path where figure should be saved
     """
     mc_histograms_yields = []
-    mc_histograms_sumw2 = []
+    mc_histograms_stdev = []
     mc_labels = []
     for h in histogram_dict_list:
         if h["isData"]:
             data_histogram_yields = h["hist"]["yields"]
-            data_histogram_sumw2 = h["hist"]["sumw2"]
+            data_histogram_stdev = h["hist"]["stdev"]
             data_label = h["label"]
         else:
             mc_histograms_yields.append(h["hist"]["yields"])
-            mc_histograms_sumw2.append(h["hist"]["sumw2"])
+            mc_histograms_stdev.append(h["hist"]["stdev"])
             mc_labels.append(h["label"])
 
     # get the highest single bin from the sum of MC
@@ -76,7 +76,7 @@ def data_MC_matplotlib(histogram_dict_list, figure_path):
         total_yield += mc_sample_yield
 
     # add total MC uncertainty
-    mc_stack_unc = _total_yield_uncertainty(mc_histograms_sumw2)
+    mc_stack_unc = _total_yield_uncertainty(mc_histograms_stdev)
     ax.bar(
         bin_centers,
         2 * mc_stack_unc,
@@ -93,7 +93,7 @@ def data_MC_matplotlib(histogram_dict_list, figure_path):
     ax.errorbar(
         bin_centers,
         data_histogram_yields,
-        yerr=data_histogram_sumw2,
+        yerr=data_histogram_stdev,
         fmt="o",
         c="k",
         label=data_label,

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -1,19 +1,17 @@
-"""
-it might make sense to allow serialization of histograms in various
-different formats, so saving and loading should go through this wrapper
-"""
 import logging
 import os
 from pathlib import Path
 
+import boost_histogram as bh
 import numpy as np
 
 
 log = logging.getLogger(__name__)
 
 
-class Histogram:
-    """class to hold histogram information
+class Histogram(bh.Histogram):
+    """class to hold histogram information, extends functionality provided
+    by boost_histogram.Histogram
     """
 
     def __init__(self, yields, sumw2, bins):

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -96,14 +96,29 @@ class Histogram(bh.Histogram):
 
     @property
     def yields(self):
+        """get the yields per histogram bin
+
+        Returns:
+            numpy.ndarray: yields per bin
+        """
         return self.view().value
 
     @property
     def sumw2(self):
+        """get the stat. uncertainty per histogram bin
+
+        Returns:
+            numpy.ndarray: stat. uncertainty per bin
+        """
         return np.sqrt(self.view().variance)
 
     @property
     def bins(self):
+        """get the bin edges
+
+        Returns:
+            numpy.ndarray: bin edges
+        """
         return self.axes[0].edges
 
     def save(self, histo_path):

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -185,7 +185,7 @@ def create_histograms(config, folder_path_str, method="uproot"):
                     raise NotImplementedError("unknown backend")
 
                 # store information in a Histogram instance
-                histogram = histo.Histogram(yields, sumw2, bins)
+                histogram = histo.Histogram.from_arrays(bins, yields, sumw2)
 
                 # generate a name for the histogram
                 histogram_name = histo.build_name(region, sample, systematic)

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -169,7 +169,7 @@ def create_histograms(config, folder_path_str, method="uproot"):
                 if method == "uproot":
                     from cabinetry.contrib import histogram_creation
 
-                    yields, sumw2 = histogram_creation.from_uproot(
+                    yields, stdev = histogram_creation.from_uproot(
                         ntuple_path,
                         pos_in_file,
                         variable,
@@ -185,7 +185,7 @@ def create_histograms(config, folder_path_str, method="uproot"):
                     raise NotImplementedError("unknown backend")
 
                 # store information in a Histogram instance
-                histogram = histo.Histogram.from_arrays(bins, yields, sumw2)
+                histogram = histo.Histogram.from_arrays(bins, yields, stdev)
 
                 # generate a name for the histogram
                 histogram_name = histo.build_name(region, sample, systematic)

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -20,7 +20,7 @@ def _fix_stat_unc(histogram, name):
     nan_pos = np.where(np.isnan(histogram.sumw2))[0]
     if len(nan_pos) > 0:
         log.debug("fixing ill-defined stat. unc. for %s", name)
-        histogram.sumw2 = np.nan_to_num(histogram.sumw2, nan=0.0)
+        histogram.view().variance = np.nan_to_num(histogram.sumw2 ** 2, nan=0.0)
 
 
 def apply_postprocessing(histogram, name):

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -17,10 +17,10 @@ def _fix_stat_unc(histogram, name):
         histogram (cabinetry.histo.Histogram): the histogram to fix
         name (str): histogram name for logging
     """
-    nan_pos = np.where(np.isnan(histogram.sumw2))[0]
+    nan_pos = np.where(np.isnan(histogram.stdev))[0]
     if len(nan_pos) > 0:
         log.debug("fixing ill-defined stat. unc. for %s", name)
-        histogram.view().variance = np.nan_to_num(histogram.sumw2 ** 2, nan=0.0)
+        histogram.view().variance = np.nan_to_num(histogram.stdev ** 2, nan=0.0)
 
 
 def apply_postprocessing(histogram, name):

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -60,7 +60,7 @@ def data_MC(config, histogram_folder, figure_folder, prefit=True, method="matplo
                         "hist": {
                             "bins": histogram.bins,
                             "yields": histogram.yields,
-                            "sumw2": histogram.sumw2,
+                            "stdev": histogram.stdev,
                         },
                         "variable": region["Variable"],
                     }

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -58,9 +58,9 @@ def data_MC(config, histogram_folder, figure_folder, prefit=True, method="matplo
                         "label": sample["Name"],
                         "isData": is_data,
                         "hist": {
+                            "bins": histogram.bins,
                             "yields": histogram.yields,
                             "sumw2": histogram.sumw2,
-                            "bins": histogram.bins,
                         },
                         "variable": region["Variable"],
                     }

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -52,7 +52,7 @@ def get_unc_for_sample(
     sample, region, histogram_folder, systematic={"Name": "nominal"}
 ):
     """get the uncertainty of a specific sample, by figuring out its name and then
-    obtaining the sumw2 from the correct histogram
+    obtaining the stdev from the correct histogram
 
     Args:
         sample (dict): specific sample to use
@@ -66,7 +66,7 @@ def get_unc_for_sample(
     histogram = histo.Histogram.from_config(
         histogram_folder, region, sample, systematic, modified=True
     )
-    histo_yield = histogram.sumw2.tolist()
+    histo_yield = histogram.stdev.tolist()
     return histo_yield
 
 

--- a/tests/contrib/test_histogram_creation.py
+++ b/tests/contrib/test_histogram_creation.py
@@ -15,30 +15,30 @@ def test_from_uproot(tmp_path, utils):
     utils.create_ntuple(fname, treename, varname, var_array, weightname, weight_array)
 
     # read - no weights or selection
-    yields, sumw2 = histogram_creation.from_uproot(fname, treename, varname, bins)
+    yields, stdev = histogram_creation.from_uproot(fname, treename, varname, bins)
     assert np.allclose(yields, [1, 1, 2])
-    assert np.allclose(sumw2, [1, 1, 1.41421356])
+    assert np.allclose(stdev, [1, 1, 1.41421356])
 
     # read - with selection cut
     selection = "var < 3.1"
-    yields, sumw2 = histogram_creation.from_uproot(
+    yields, stdev = histogram_creation.from_uproot(
         fname, treename, varname, bins, selection_filter=selection
     )
     assert np.allclose(yields, [1, 1, 1])
-    assert np.allclose(sumw2, [1, 1, 1])
+    assert np.allclose(stdev, [1, 1, 1])
 
     # read - with weight
-    yields, sumw2 = histogram_creation.from_uproot(
+    yields, stdev = histogram_creation.from_uproot(
         fname, treename, varname, bins, weight=weightname
     )
     assert np.allclose(yields, [1, 1, 3])
-    assert np.allclose(sumw2, [1, 1, 2.23606798])
+    assert np.allclose(stdev, [1, 1, 2.23606798])
 
 
 def test__bin_data():
     data = [1.1, 2.2, 2.9, 2.5, 1.4]
     weights = [1.0, 1.1, 0.9, 0.8, 1.5]
     bins = [1, 2, 3]
-    yields, sumw2 = histogram_creation._bin_data(data, weights, bins)
+    yields, stdev = histogram_creation._bin_data(data, weights, bins)
     assert np.allclose(yields, [2.5, 2.8])
-    assert np.allclose(sumw2, [1.80277564, 1.63095064])
+    assert np.allclose(stdev, [1.80277564, 1.63095064])

--- a/tests/contrib/test_histogram_drawing.py
+++ b/tests/contrib/test_histogram_drawing.py
@@ -6,10 +6,10 @@ from cabinetry import histo
 
 
 def test__total_yield_uncertainty():
-    sumw2_list = [[0.1, 0.2, 0.1], [0.3, 0.2, 0.1]]
+    stdev_list = [[0.1, 0.2, 0.1], [0.3, 0.2, 0.1]]
     expected_uncertainties = [0.31622777, 0.28284271, 0.14142136]
     assert np.allclose(
-        histogram_drawing._total_yield_uncertainty(sumw2_list), expected_uncertainties
+        histogram_drawing._total_yield_uncertainty(stdev_list), expected_uncertainties
     )
 
 
@@ -17,17 +17,17 @@ def test_data_MC_matplotlib(tmp_path):
     fname = tmp_path / "subdir" / "fig.pdf"
     bg_hist = {
         "yields": np.asarray([12.5, 14]),
-        "sumw2": np.asarray([0.4, 0.5]),
+        "stdev": np.asarray([0.4, 0.5]),
         "bins": np.asarray([1, 2, 3]),
     }
     sig_hist = {
         "yields": np.asarray([2, 5]),
-        "sumw2": np.asarray([0.1, 0.2]),
+        "stdev": np.asarray([0.1, 0.2]),
         "bins": np.asarray([1, 2, 3]),
     }
     data_hist = {
         "yields": np.asarray([13, 15]),
-        "sumw2": np.asarray([3.61, 3.87]),
+        "stdev": np.asarray([3.61, 3.87]),
         "bins": np.asarray([1, 2, 3]),
     }
     histo_dict_list = [

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -46,6 +46,20 @@ class ExampleHistograms:
         sumw2 = [0.1, float("NaN")]
         return bins, yields, sumw2
 
+    @staticmethod
+    def wrong_bin_number():
+        bins = [1, 2, 3]
+        yields = [1.0]
+        sumw2 = [0.1]
+        return bins, yields, sumw2
+
+    @staticmethod
+    def yields_sumw2_mismatch():
+        bins = [1, 2, 3]
+        yields = [1.0, 2.0]
+        sumw2 = [0.1]
+        return bins, yields, sumw2
+
 
 @pytest.fixture
 def example_histograms():
@@ -71,6 +85,16 @@ def test_Histogram_from_arrays(example_histograms):
     assert np.allclose(h.yields, yields)
     assert np.allclose(h.sumw2, sumw2)
     assert np.allclose(h.bins, bins)
+
+    with pytest.raises(
+        ValueError, match="bin edges need one more entry than yields"
+    ) as e_info:
+        histo.Histogram.from_arrays(*example_histograms.wrong_bin_number())
+
+    with pytest.raises(
+        ValueError, match="yields and sumw2 need to have the same shape"
+    ) as e_info:
+        histo.Histogram.from_arrays(*example_histograms.yields_sumw2_mismatch())
 
 
 def test_Histogram_from_path(tmp_path, caplog, example_histograms, histogram_helpers):

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -15,50 +15,50 @@ class ExampleHistograms:
     def normal():
         bins = [1, 2, 3]
         yields = [1.0, 2.0]
-        sumw2 = [0.1, 0.2]
-        return bins, yields, sumw2
+        stdev = [0.1, 0.2]
+        return bins, yields, stdev
 
     @staticmethod
     def single_bin():
         bins = [1, 2]
         yields = [1.0]
-        sumw2 = [0.1]
-        return bins, yields, sumw2
+        stdev = [0.1]
+        return bins, yields, stdev
 
     @staticmethod
     def empty_bin():
         bins = [1, 2, 3]
         yields = [1.0, 0.0]
-        sumw2 = [0.1, 0.2]
-        return bins, yields, sumw2
+        stdev = [0.1, 0.2]
+        return bins, yields, stdev
 
     @staticmethod
-    def nan_sumw2_empty_bin():
+    def nan_stdev_empty_bin():
         bins = [1, 2, 3]
         yields = [1.0, 0.0]
-        sumw2 = [0.1, float("NaN")]
-        return bins, yields, sumw2
+        stdev = [0.1, float("NaN")]
+        return bins, yields, stdev
 
     @staticmethod
-    def nan_sumw2_nonempty_bin():
+    def nan_stdev_nonempty_bin():
         bins = [1, 2, 3]
         yields = [1.0, 2.0]
-        sumw2 = [0.1, float("NaN")]
-        return bins, yields, sumw2
+        stdev = [0.1, float("NaN")]
+        return bins, yields, stdev
 
     @staticmethod
     def wrong_bin_number():
         bins = [1, 2, 3]
         yields = [1.0]
-        sumw2 = [0.1]
-        return bins, yields, sumw2
+        stdev = [0.1]
+        return bins, yields, stdev
 
     @staticmethod
-    def yields_sumw2_mismatch():
+    def yields_stdev_mismatch():
         bins = [1, 2, 3]
         yields = [1.0, 2.0]
-        sumw2 = [0.1]
-        return bins, yields, sumw2
+        stdev = [0.1]
+        return bins, yields, stdev
 
 
 @pytest.fixture
@@ -70,7 +70,7 @@ class HistogramHelpers:
     @staticmethod
     def assert_equal(h1, h2):
         assert np.allclose(h1.yields, h2.yields)
-        assert np.allclose(h1.sumw2, h2.sumw2)
+        assert np.allclose(h1.stdev, h2.stdev)
         assert np.allclose(h1.bins, h2.bins)
 
 
@@ -80,10 +80,10 @@ def histogram_helpers():
 
 
 def test_Histogram_from_arrays(example_histograms):
-    bins, yields, sumw2 = example_histograms.normal()
-    h = histo.Histogram.from_arrays(bins, yields, sumw2)
+    bins, yields, stdev = example_histograms.normal()
+    h = histo.Histogram.from_arrays(bins, yields, stdev)
     assert np.allclose(h.yields, yields)
-    assert np.allclose(h.sumw2, sumw2)
+    assert np.allclose(h.stdev, stdev)
     assert np.allclose(h.bins, bins)
 
     with pytest.raises(
@@ -92,9 +92,9 @@ def test_Histogram_from_arrays(example_histograms):
         histo.Histogram.from_arrays(*example_histograms.wrong_bin_number())
 
     with pytest.raises(
-        ValueError, match="yields and sumw2 need to have the same shape"
+        ValueError, match="yields and stdev need to have the same shape"
     ) as e_info:
-        histo.Histogram.from_arrays(*example_histograms.yields_sumw2_mismatch())
+        histo.Histogram.from_arrays(*example_histograms.yields_stdev_mismatch())
 
 
 def test_Histogram_from_path(tmp_path, caplog, example_histograms, histogram_helpers):
@@ -170,7 +170,7 @@ def test_Histogram_validate(caplog, example_histograms):
     caplog.clear()
 
     # check for ill-defined stat uncertainty warning
-    histo.Histogram.from_arrays(*example_histograms.nan_sumw2_empty_bin()).validate(
+    histo.Histogram.from_arrays(*example_histograms.nan_stdev_empty_bin()).validate(
         name
     )
     assert "test_histo has empty bins: [1]" in [rec.message for rec in caplog.records]
@@ -180,7 +180,7 @@ def test_Histogram_validate(caplog, example_histograms):
     caplog.clear()
 
     # check for ill-defined stat uncertainty warning with non-zero bin
-    histo.Histogram.from_arrays(*example_histograms.nan_sumw2_nonempty_bin()).validate(
+    histo.Histogram.from_arrays(*example_histograms.nan_stdev_nonempty_bin()).validate(
         name
     )
     assert "test_histo has bins with ill-defined stat. unc.: [1]" in [

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -112,7 +112,7 @@ def test_create_histograms(tmp_path, caplog, utils):
     )
 
     assert np.allclose(saved_histo.yields, [1, 1, 2])
-    assert np.allclose(saved_histo.sumw2, [1, 1, 1.41421356])
+    assert np.allclose(saved_histo.stdev, [1, 1, 1.41421356])
     assert np.allclose(saved_histo.bins, bins)
 
     assert "  reading sample sample" in [rec.message for rec in caplog.records]

--- a/tests/test_template_postprocessor.py
+++ b/tests/test_template_postprocessor.py
@@ -8,8 +8,11 @@ from cabinetry import template_postprocessor
 @pytest.mark.parametrize(
     "test_histo, fixed_sumw2",
     [
-        (histo.Histogram([], [float("nan"), 0.2], []), [0.0, 0.2]),
-        (histo.Histogram([], [0.1, 0.2], []), [0.1, 0.2]),
+        (
+            histo.Histogram.from_arrays([1, 2, 3], [1, 2], [float("nan"), 0.2]),
+            [0.0, 0.2],
+        ),
+        (histo.Histogram.from_arrays([1, 2, 3], [1, 2], [0.1, 0.2]), [0.1, 0.2],),
     ],
 )
 def test__fix_stat_unc(test_histo, fixed_sumw2):
@@ -19,7 +22,7 @@ def test__fix_stat_unc(test_histo, fixed_sumw2):
 
 
 def test_apply_postprocessing():
-    histogram = histo.Histogram([], [float("nan"), 0.2], [])
+    histogram = histo.Histogram.from_arrays([1, 2, 3], [1, 1], [float("nan"), 0.2])
     name = "test_histo"
     fixed_sumw2 = [0.0, 0.2]
     fixed_histogram = template_postprocessor.apply_postprocessing(histogram, name)
@@ -33,9 +36,7 @@ def test_run(tmp_path):
 
     # create an input histogram
     histo_path = tmp_path / "region_1_signal_nominal.npz"
-    histogram = histo.Histogram(
-        np.asarray([1.0, 2.0]), np.asarray([1.0, 1.0]), np.asarray([0.0, 1.0, 2.0])
-    )
+    histogram = histo.Histogram.from_arrays([0.0, 1.0, 2.0], [1.0, 2.0], [1.0, 1.0])
     histogram.save(histo_path)
 
     template_postprocessor.run(config, tmp_path)

--- a/tests/test_template_postprocessor.py
+++ b/tests/test_template_postprocessor.py
@@ -6,7 +6,7 @@ from cabinetry import template_postprocessor
 
 
 @pytest.mark.parametrize(
-    "test_histo, fixed_sumw2",
+    "test_histo, fixed_stdev",
     [
         (
             histo.Histogram.from_arrays([1, 2, 3], [1, 2], [float("nan"), 0.2]),
@@ -15,20 +15,20 @@ from cabinetry import template_postprocessor
         (histo.Histogram.from_arrays([1, 2, 3], [1, 2], [0.1, 0.2]), [0.1, 0.2],),
     ],
 )
-def test__fix_stat_unc(test_histo, fixed_sumw2):
+def test__fix_stat_unc(test_histo, fixed_stdev):
     name = "test_histo"
     template_postprocessor._fix_stat_unc(test_histo, name)
-    assert np.allclose(test_histo.sumw2, fixed_sumw2)
+    assert np.allclose(test_histo.stdev, fixed_stdev)
 
 
 def test_apply_postprocessing():
     histogram = histo.Histogram.from_arrays([1, 2, 3], [1, 1], [float("nan"), 0.2])
     name = "test_histo"
-    fixed_sumw2 = [0.0, 0.2]
+    fixed_stdev = [0.0, 0.2]
     fixed_histogram = template_postprocessor.apply_postprocessing(histogram, name)
-    assert np.allclose(fixed_histogram.sumw2, fixed_sumw2)
+    assert np.allclose(fixed_histogram.stdev, fixed_stdev)
     # the original histogram should be unchanged
-    np.testing.assert_equal(histogram.sumw2, [float("nan"), 0.2])
+    np.testing.assert_equal(histogram.stdev, [float("nan"), 0.2])
 
 
 def test_run(tmp_path):
@@ -42,5 +42,5 @@ def test_run(tmp_path):
     template_postprocessor.run(config, tmp_path)
     modified_histo = histo.Histogram.from_path(histo_path, modified=True)
     assert np.allclose(modified_histo.yields, histogram.yields)
-    assert np.allclose(modified_histo.sumw2, histogram.sumw2)
+    assert np.allclose(modified_histo.stdev, histogram.stdev)
     assert np.allclose(modified_histo.bins, histogram.bins)

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -10,7 +10,7 @@ from cabinetry.contrib import histogram_drawing
 class MockHistogram:
     bins = []
     yields = []
-    sumw2 = []
+    stdev = []
 
 
 @pytest.mark.parametrize(
@@ -64,7 +64,7 @@ def test_data_MC(mock_load, mock_draw, tmp_path):
                     {
                         "label": "sample_1",
                         "isData": False,
-                        "hist": {"yields": [], "sumw2": [], "bins": []},
+                        "hist": {"bins": [], "yields": [], "stdev": []},
                         "variable": "x",
                     }
                 ],

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -7,6 +7,12 @@ from cabinetry import visualize
 from cabinetry.contrib import histogram_drawing
 
 
+class MockHistogram:
+    bins = []
+    yields = []
+    sumw2 = []
+
+
 @pytest.mark.parametrize(
     "test_input, expected",
     [
@@ -22,7 +28,7 @@ def test__build_figure_name(test_input, expected):
 
 @mock.patch("cabinetry.contrib.histogram_drawing.data_MC_matplotlib")
 @mock.patch(
-    "cabinetry.histo.Histogram.from_config", return_value=histo.Histogram([], [], [])
+    "cabinetry.histo.Histogram.from_config", return_value=MockHistogram(),
 )
 def test_data_MC(mock_load, mock_draw, tmp_path):
     """contrib.histogram_drawing is only imported depending on the keyword argument,

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -90,9 +90,7 @@ def test_get_channels(tmp_path):
 
     # create a histogram for testing
     histo_path = tmp_path / "region_1_signal_nominal.npz"
-    histogram = histo.Histogram(
-        np.asarray([1.0, 2.0]), np.asarray([1.0, 1.0]), np.asarray([0.0, 1.0, 2.0])
-    )
+    histogram = histo.Histogram.from_arrays([0.0, 1.0, 2.0], [1.0, 2.0], [1.0, 1.0])
     histogram.save(histo_path)
 
     channels = workspace.get_channels(example_config, tmp_path)
@@ -127,9 +125,7 @@ def test_get_observations(tmp_path):
     histo_path = tmp_path / "test_region_Data_nominal.npz"
 
     # build a test histogram and save it
-    histogram = histo.Histogram(
-        np.asarray([1.0, 2.0]), np.asarray([1.0, 1.0]), np.asarray([0.0, 1.0, 2.0])
-    )
+    histogram = histo.Histogram.from_arrays([0.0, 1.0, 2.0], [1.0, 2.0], [1.0, 1.0])
     histogram.save(histo_path)
 
     # create observations list from config


### PR DESCRIPTION
Inherit `cabinetry.histo.Histogram` from `boost_histogram.Histogram`. Switching to [boost-histogram](https://github.com/scikit-hep/boost-histogram) should make the histogram API more familiar to users who already know it from elsewhere, and will be useful to make use of [hist](https://github.com/scikit-hep/hist) in the future.

Renaming `sumw2` to `stdev`, the old name was wrong (the sum of weights squared is the variance).