### PR TITLE
refactor: f-strings for logging

### DIFF
--- a/example.py
+++ b/example.py
@@ -14,7 +14,7 @@ logging.getLogger("matplotlib").setLevel(logging.WARNING)
 if __name__ == "__main__":
     # check whether input data exists
     if not os.path.exists("ntuples/"):
-        print("run util/create_histograms.py to create input data")
+        print(f"run util/create_histograms.py to create input data")
         raise SystemExit
 
     # import example config file

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -20,7 +20,7 @@ def read(file_path_string):
         dict: cabinetry configuration
     """
     file_path = Path(file_path_string)
-    log.info("opening config file %s", file_path)
+    log.info(f"opening config file {file_path}")
     config = yaml.safe_load(file_path.read_text())
     validate(config)
     return config
@@ -65,12 +65,12 @@ def print_overview(config):
     Args:
         config (dict): cabinetry configuration
     """
-    log.info("the config contains:")
-    log.info("  %i Sample(s)", len(config["Samples"]))
-    log.info("  %i Regions(s)", len(config["Regions"]))
-    log.info("  %i NormFactor(s)", len(config["NormFactors"]))
+    log.info(f"the config contains:")
+    log.info(f"  {len(config['Samples'])} Sample(s)")
+    log.info(f"  {len(config['Regions'])} Regions(s)")
+    log.info(f"  {len(config['NormFactors'])} NormFactor(s)")
     if "Systematics" in config.keys():
-        log.info("  %i Systematic(s)", len(config["Systematics"]))
+        log.info(f"  {len(config['Systematics'])} Systematic(s)")
 
 
 def _convert_samples_to_list(samples):

--- a/src/cabinetry/contrib/histogram_drawing.py
+++ b/src/cabinetry/contrib/histogram_drawing.py
@@ -107,5 +107,5 @@ def data_MC_matplotlib(histogram_dict_list, figure_path):
 
     if not os.path.exists(figure_path.parent):
         os.mkdir(figure_path.parent)
-    log.debug("saving figure as %s", figure_path)
+    log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -38,7 +38,7 @@ def print_results(bestfit, uncertainty, labels):
     max_label_length = max([len(label) for label in labels])
     for i, label in enumerate(labels):
         l_with_spacer = label + " " * (max_label_length - len(label))
-        log.info("%s: %f +/- %f", l_with_spacer, bestfit[i], uncertainty[i])
+        log.info(f"{l_with_spacer}: {bestfit[i]:.6f} +/- {uncertainty[i]:.6f}")
 
 
 def fit(spec):
@@ -55,7 +55,7 @@ def fit(spec):
             - list: parameter names
             - float: -2 log(likelihood) at best-fit point
     """
-    log.info("performing unconstrained fit")
+    log.info(f"performing unconstrained fit")
 
     workspace = pyhf.Workspace(spec)
     model = workspace.model()
@@ -70,4 +70,5 @@ def fit(spec):
     labels = get_parameter_names(model)
 
     print_results(bestfit, uncertainty, labels)
+    log.debug(f"-2 log(L) = {twice_nll:.6f} at the best-fit point")
     return bestfit, uncertainty, labels, twice_nll

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -62,10 +62,9 @@ class Histogram(bh.Histogram):
             histo_path_modified = histo_path.parent / (histo_path.name + "_modified")
             if not histo_path_modified.with_suffix(".npz").exists():
                 log.warning(
-                    "the modified histogram %s does not exist",
-                    histo_path_modified.with_suffix(".npz"),
+                    f"the modified histogram {histo_path_modified.with_suffix('.npz')} does not exist",
                 )
-                log.warning("loading the un-modified histogram instead!")
+                log.warning(f"loading the un-modified histogram instead!")
             else:
                 histo_path = histo_path_modified
         histogram_npz = np.load(histo_path.with_suffix(".npz"))
@@ -127,7 +126,7 @@ class Histogram(bh.Histogram):
         Args:
             histo_path (pathlib.Path): where to save the histogram
         """
-        log.debug("saving histogram to %s", histo_path.with_suffix(".npz"))
+        log.debug(f"saving histogram to {histo_path.with_suffix('.npz')}")
 
         # create output directory if it does not exist yet
         if not os.path.exists(histo_path.parent):
@@ -151,21 +150,19 @@ class Histogram(bh.Histogram):
         # input should never need it
         empty_bins = np.where(np.atleast_1d(self.yields) == 0.0)[0]
         if len(empty_bins) > 0:
-            log.warning("%s has empty bins: %s", name, empty_bins)
+            log.warning(f"{name} has empty bins: {empty_bins}")
 
         # check for ill-defined stat. unc.
         nan_pos = np.where(np.isnan(self.stdev))[0]
         if len(nan_pos) > 0:
-            log.warning("%s has bins with ill-defined stat. unc.: %s", name, nan_pos)
+            log.warning(f"{name} has bins with ill-defined stat. unc.: {nan_pos}")
 
         # check whether there are any bins with ill-defined stat. uncertainty
         # but non-empty yield, those deserve a closer look
         not_empty_but_nan = [b for b in nan_pos if b not in empty_bins]
         if len(not_empty_but_nan) > 0:
             log.warning(
-                "%s has non-empty bins with ill-defined stat. unc.: %s",
-                name,
-                not_empty_but_nan,
+                f"{name} has non-empty bins with ill-defined stat. unc.: {not_empty_but_nan}",
             )
 
     def normalize_to_yield(self, reference_histogram):

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -136,13 +136,13 @@ def create_histograms(config, folder_path_str, method="uproot"):
         NotImplementedError: when requesting the ServiceX backend
         NotImplementedError: when requesting another unknown backend
     """
-    log.info("creating histograms")
+    log.info(f"creating histograms")
 
     for region in config["Regions"]:
-        log.debug("  in region %s", region["Name"])
+        log.debug(f"  in region {region['Name']}")
 
         for sample in config["Samples"]:
-            log.debug("  reading sample %s", sample["Name"])
+            log.debug(f"  reading sample {sample['Name']}")
 
             for isyst, systematic in enumerate(
                 ([{"Name": "nominal"}] + config["Systematics"])
@@ -157,7 +157,7 @@ def create_histograms(config, folder_path_str, method="uproot"):
                     # no further action is needed, continue with the next region-sample-systematic combination
                     continue
 
-                log.debug("  variation %s", systematic["Name"])
+                log.debug(f"  variation {systematic['Name']}")
                 ntuple_path = _get_ntuple_path(region, sample, systematic)
                 pos_in_file = _get_position_in_file(sample, systematic)
                 variable = _get_variable(region, sample, systematic)

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -19,7 +19,7 @@ def _fix_stat_unc(histogram, name):
     """
     nan_pos = np.where(np.isnan(histogram.stdev))[0]
     if len(nan_pos) > 0:
-        log.debug("fixing ill-defined stat. unc. for %s", name)
+        log.debug(f"fixing ill-defined stat. unc. for {name}")
         histogram.view().variance = np.nan_to_num(histogram.stdev ** 2, nan=0.0)
 
 
@@ -48,7 +48,7 @@ def run(config, histogram_folder):
         config (dict): cabinetry configuration
         histogram_folder (str): folder containing the histograms
     """
-    log.info("applying post-processing to histograms")
+    log.info(f"applying post-processing to histograms")
     # loop over all histograms
     for region in config["Regions"]:
         for sample in config["Samples"]:

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -44,7 +44,7 @@ def data_MC(config, histogram_folder, figure_folder, prefit=True, method="matplo
         NotImplementedError: when trying to plot with a method that is not supported
         NotImplementedError: when trying to visualize post-fit distributions, not supported yet
     """
-    log.info("visualizing histogram")
+    log.info(f"visualizing histogram")
     for region in config["Regions"]:
         histogram_dict_list = []
         for sample in config["Samples"]:

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -84,7 +84,7 @@ def get_NF_modifiers(config, sample):
     for NormFactor in config["NormFactors"]:
         if configuration.sample_affected_by_modifier(sample, NormFactor):
             log.debug(
-                "adding NormFactor %s to sample %s", NormFactor["Name"], sample["Name"]
+                f"adding NormFactor {NormFactor['Name']} to sample {sample['Name']}"
             )
             modifiers.append(
                 {"data": None, "name": NormFactor["Name"], "type": "normfactor"}
@@ -152,11 +152,7 @@ def get_NormPlusShape_modifiers(region, sample, systematic, histogram_folder):
     norm_effect = histogram_variation.normalize_to_yield(histogram_nominal)
     histo_yield_up = histogram_variation.yields.tolist()
     log.debug(
-        "normalization impact of systematic %s on sample %s in region %s is %f",
-        systematic["Name"],
-        sample["Name"],
-        region["Name"],
-        norm_effect,
+        f"normalization impact of systematic {systematic['Name']} on sample {sample['Name']} in region {region['Name']} is {norm_effect}",
     )
     # need another histogram that corresponds to the "down" variation, which is 2*nominal - up
     histo_yield_down = (
@@ -203,18 +199,14 @@ def get_sys_modifiers(config, sample, region, histogram_folder):
             if systematic["Type"] == "Overall":
                 # OverallSys (norm uncertainty with Gaussian constraint)
                 log.debug(
-                    "adding OverallSys %s to sample %s",
-                    systematic["Name"],
-                    sample["Name"],
+                    f"adding OverallSys {systematic['Name']} to sample {sample['Name']}",
                 )
                 modifiers.append(get_OverallSys_modifier(systematic))
             elif systematic["Type"] == "NormPlusShape":
                 # two modifiers are needed - an OverallSys for the norm effect,
                 # and a HistoSys for the shape variation
                 log.debug(
-                    "adding OverallSys and HistoSys %s to sample %s",
-                    systematic["Name"],
-                    sample["Name"],
+                    f"adding OverallSys and HistoSys {systematic['Name']} to sample {sample['Name']}",
                 )
                 modifiers += get_NormPlusShape_modifiers(
                     region, sample, systematic, histogram_folder
@@ -332,7 +324,7 @@ def build(config, histogram_folder, with_validation=True):
     Returns:
         dict: pyhf-compatible HistFactory workspace
     """
-    log.info("building workspace")
+    log.info(f"building workspace")
 
     ws = {}  # the workspace
 
@@ -374,7 +366,7 @@ def save(ws, file_path_string):
         file_path_string (str): path to the file to save the workspace in
     """
     file_path = Path(file_path_string)
-    log.debug("saving workspace to %s", file_path)
+    log.debug(f"saving workspace to {file_path}")
     # create output directory if it does not exist yet
     if not os.path.exists(file_path.parent):
         os.mkdir(file_path.parent)


### PR DESCRIPTION
Switching to f-strings for logging, even though [logging internally uses %-format strings](https://docs.python.org/3/howto/logging-cookbook.html#formatting-styles). The f-string format is more readable.