### PR TITLE
style: flake8 string fixes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,8 +31,8 @@ jobs:
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 src/cabinetry --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 src/cabinetry --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=src/cabinetry/__init__.py
+        # check for additional issues flagged by flake8, the GitHub editor is 127 chars wide
+        flake8 src/cabinetry --count --max-complexity=10 --max-line-length=127 --statistics --exclude=src/cabinetry/__init__.py
     - name: Format with Black
       run: |
         black --check --diff --verbose .

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -65,7 +65,7 @@ def print_overview(config):
     Args:
         config (dict): cabinetry configuration
     """
-    log.info(f"the config contains:")
+    log.info("the config contains:")
     log.info(f"  {len(config['Samples'])} Sample(s)")
     log.info(f"  {len(config['Regions'])} Regions(s)")
     log.info(f"  {len(config['NormFactors'])} NormFactor(s)")

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -55,7 +55,7 @@ def fit(spec):
             - list: parameter names
             - float: -2 log(likelihood) at best-fit point
     """
-    log.info(f"performing unconstrained fit")
+    log.info("performing unconstrained fit")
 
     workspace = pyhf.Workspace(spec)
     model = workspace.model()

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -64,7 +64,7 @@ class Histogram(bh.Histogram):
                 log.warning(
                     f"the modified histogram {histo_path_modified.with_suffix('.npz')} does not exist",
                 )
-                log.warning(f"loading the un-modified histogram instead!")
+                log.warning("loading the un-modified histogram instead!")
             else:
                 histo_path = histo_path_modified
         histogram_npz = np.load(histo_path.with_suffix(".npz"))

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -136,7 +136,7 @@ def create_histograms(config, folder_path_str, method="uproot"):
         NotImplementedError: when requesting the ServiceX backend
         NotImplementedError: when requesting another unknown backend
     """
-    log.info(f"creating histograms")
+    log.info("creating histograms")
 
     for region in config["Regions"]:
         log.debug(f"  in region {region['Name']}")

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -48,7 +48,7 @@ def run(config, histogram_folder):
         config (dict): cabinetry configuration
         histogram_folder (str): folder containing the histograms
     """
-    log.info(f"applying post-processing to histograms")
+    log.info("applying post-processing to histograms")
     # loop over all histograms
     for region in config["Regions"]:
         for sample in config["Samples"]:

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -44,7 +44,7 @@ def data_MC(config, histogram_folder, figure_folder, prefit=True, method="matplo
         NotImplementedError: when trying to plot with a method that is not supported
         NotImplementedError: when trying to visualize post-fit distributions, not supported yet
     """
-    log.info(f"visualizing histogram")
+    log.info("visualizing histogram")
     for region in config["Regions"]:
         histogram_dict_list = []
         for sample in config["Samples"]:

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -152,7 +152,8 @@ def get_NormPlusShape_modifiers(region, sample, systematic, histogram_folder):
     norm_effect = histogram_variation.normalize_to_yield(histogram_nominal)
     histo_yield_up = histogram_variation.yields.tolist()
     log.debug(
-        f"normalization impact of systematic {systematic['Name']} on sample {sample['Name']} in region {region['Name']} is {norm_effect}",
+        f"normalization impact of systematic {systematic['Name']} on sample {sample['Name']}"
+        f" in region {region['Name']} is {norm_effect:.3f}"
     )
     # need another histogram that corresponds to the "down" variation, which is 2*nominal - up
     histo_yield_down = (
@@ -324,7 +325,7 @@ def build(config, histogram_folder, with_validation=True):
     Returns:
         dict: pyhf-compatible HistFactory workspace
     """
-    log.info(f"building workspace")
+    log.info("building workspace")
 
     ws = {}  # the workspace
 


### PR DESCRIPTION
Fixing warnings from `flake8` due to the switch to f-strings in #58. Also updating the CI such that any warnings from `flake8` will now fail it.