### PR TITLE
refactor: specification of systematics templates

### DIFF
--- a/config_example.yml
+++ b/config_example.yml
@@ -37,6 +37,8 @@ Systematics:
     Up:
       Path: "ntuples/prediction.root"
       Tree: "background_varied"
+    Down:
+      Symmetrize: True
     Samples: "Background"
     Type: "NormPlusShape"
 

--- a/config_example.yml
+++ b/config_example.yml
@@ -29,14 +29,17 @@ Samples:
 
 Systematics:
   - Name: "Luminosity"
-    OverallDown: -0.05
-    OverallUp: 0.05
+    Up:
+      Normalization: 0.05
+    Down:
+      Normalization: -0.05
     Samples: ["Signal", "Background"]
-    Type: "Overall"
+    Type: "Normalization"
 
   - Name: "Modeling"
-    PathUp: "ntuples/prediction.root"
-    TreeUp: "background_varied"
+    Up:
+      Path: "ntuples/prediction.root"
+      Tree: "background_varied"
     Samples: "Background"
     Type: "NormPlusShape"
 

--- a/config_example.yml
+++ b/config_example.yml
@@ -12,20 +12,17 @@ Samples:
   - Name: "Data"
     Tree: "pseudodata"
     Path: "ntuples/data.root"
-    Color: "#000000"
     Data: True
 
   - Name: "Background"
     Tree: "background"
     Path: "ntuples/prediction.root"
     Weight: "weight"
-    Color: "#F55EE33"
 
   - Name: "Signal"
     Tree: "signal"
     Path: "ntuples/prediction.root"
     Weight: "weight"
-    Color: "#FFAA55"
 
 Systematics:
   - Name: "Luminosity"

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -131,7 +131,7 @@ def histogram_is_needed(region, sample, systematic):
             histo_needed = False
         else:
             # handle non-nominal, non-data histograms
-            if systematic["Type"] == "Overall":
+            if systematic["Type"] == "Normalization":
                 # no histogram needed for normalization variation
                 histo_needed = False
             elif systematic["Type"] == "NormPlusShape":

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -111,6 +111,15 @@ class Histogram(bh.Histogram):
         """
         return np.sqrt(self.view().variance)
 
+    @stdev.setter
+    def stdev(self, value):
+        """update the variance (by specifying the standard deviation)
+
+        Args:
+            value (numpy.ndarray): the standard deviation
+        """
+        self.view().variance = value ** 2
+
     @property
     def bins(self):
         """get the bin edges

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -27,7 +27,7 @@ def _get_ntuple_path(region, sample, systematic):
     if systematic["Name"] == "nominal":
         path_str = sample["Path"]
     elif systematic["Type"] == "NormPlusShape":
-        path_str = systematic["PathUp"]
+        path_str = systematic["Up"]["Path"]
     else:
         raise NotImplementedError("ntuple path treatment not yet defined")
     path = Path(path_str)
@@ -96,7 +96,7 @@ def _get_position_in_file(sample, systematic):
     if systematic["Name"] == "nominal":
         position = sample["Tree"]
     elif systematic["Type"] == "NormPlusShape":
-        position = systematic["TreeUp"]
+        position = systematic["Up"]["Tree"]
     else:
         raise NotImplementedError("ntuple path treatment not yet defined")
     return position

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -20,7 +20,7 @@ def _fix_stat_unc(histogram, name):
     nan_pos = np.where(np.isnan(histogram.stdev))[0]
     if len(nan_pos) > 0:
         log.debug(f"fixing ill-defined stat. unc. for {name}")
-        histogram.view().variance = np.nan_to_num(histogram.stdev ** 2, nan=0.0)
+        histogram.stdev = np.nan_to_num(histogram.stdev, nan=0.0)
 
 
 def apply_postprocessing(histogram, name):

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -92,8 +92,8 @@ def get_NF_modifiers(config, sample):
     return modifiers
 
 
-def get_OverallSys_modifier(systematic):
-    """construct an OverallSys modifier
+def get_Normalization_modifier(systematic):
+    """construct a normalization modifier (OverallSys in HistFactory)
     While this can be built without any histogram reference, it might be useful
     to build a histogram for this anyway and possibly use it here.
 
@@ -109,8 +109,8 @@ def get_OverallSys_modifier(systematic):
     modifier.update(
         {
             "data": {
-                "hi": 1 + systematic["OverallUp"],
-                "lo": 1 + systematic["OverallDown"],
+                "hi": 1 + systematic["Up"]["Normalization"],
+                "lo": 1 + systematic["Down"]["Normalization"],
             }
         }
     )
@@ -197,12 +197,12 @@ def get_sys_modifiers(config, sample, region, histogram_folder):
     modifiers = []
     for systematic in config.get("Systematics", []):
         if configuration.sample_affected_by_modifier(sample, systematic):
-            if systematic["Type"] == "Overall":
+            if systematic["Type"] == "Normalization":
                 # OverallSys (norm uncertainty with Gaussian constraint)
                 log.debug(
                     f"adding OverallSys {systematic['Name']} to sample {sample['Name']}",
                 )
-                modifiers.append(get_OverallSys_modifier(systematic))
+                modifiers.append(get_Normalization_modifier(systematic))
             elif systematic["Type"] == "NormPlusShape":
                 # two modifiers are needed - an OverallSys for the norm effect,
                 # and a HistoSys for the shape variation

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -143,22 +143,25 @@ def get_NormPlusShape_modifiers(region, sample, systematic, histogram_folder):
         histogram_folder, region, sample, {"Name": "nominal"}, modified=True
     )
 
-    # need to add support for two-sided variations that do not require symmetrization here
-    # if symmetrization is desired, should support different implementations
+    if systematic["Down"]["Symmetrize"]:
+        # need to add support for two-sided variations that do not require symmetrization here
+        # if symmetrization is desired, should support different implementations
 
-    # symmetrization according to "method 1" from issue #26: first normalization, then symmetrization
+        # symmetrization according to "method 1" from issue #26: first normalization, then symmetrization
 
-    # normalize the variation to the same yield as nominal
-    norm_effect = histogram_variation.normalize_to_yield(histogram_nominal)
-    histo_yield_up = histogram_variation.yields.tolist()
-    log.debug(
-        f"normalization impact of systematic {systematic['Name']} on sample {sample['Name']}"
-        f" in region {region['Name']} is {norm_effect:.3f}"
-    )
-    # need another histogram that corresponds to the "down" variation, which is 2*nominal - up
-    histo_yield_down = (
-        2 * histogram_nominal.yields - histogram_variation.yields
-    ).tolist()
+        # normalize the variation to the same yield as nominal
+        norm_effect = histogram_variation.normalize_to_yield(histogram_nominal)
+        histo_yield_up = histogram_variation.yields.tolist()
+        log.debug(
+            f"normalization impact of systematic {systematic['Name']} on sample {sample['Name']}"
+            f" in region {region['Name']} is {norm_effect:.3f}"
+        )
+        # need another histogram that corresponds to the "down" variation, which is 2*nominal - up
+        histo_yield_down = (
+            2 * histogram_nominal.yields - histogram_variation.yields
+        ).tolist()
+    else:
+        raise NotImplementedError("only symmetrization is currently supported")
 
     # add the normsys
     modifiers = []

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -94,14 +94,14 @@ def test_sample_affected_by_modifier(sample_and_modifier, affected):
 
 
 @pytest.mark.parametrize(
-    "reg_sam_sys, needed",
+    "reg_sam_sys, is_needed",
     [
         # nominal
         (({}, {}, {"Name": "nominal"}), True),
         # non-nominal data
         (({}, {"Data": True}, {"Name": "var"}), False),
         # overall normalization variation
-        (({}, {}, {"Type": "Overall"}), False),
+        (({}, {}, {"Type": "Normalization"}), False),
         # normalization + shape variation on affected sample
         (
             ({}, {"Name": "Signal"}, {"Type": "NormPlusShape", "Samples": "Signal"}),
@@ -118,8 +118,8 @@ def test_sample_affected_by_modifier(sample_and_modifier, affected):
         ),
     ],
 )
-def test_histogram_is_needed(reg_sam_sys, needed):
-    assert configuration.histogram_is_needed(*reg_sam_sys) is needed
+def test_histogram_is_needed(reg_sam_sys, is_needed):
+    assert configuration.histogram_is_needed(*reg_sam_sys) is is_needed
 
     # non-supported systematic
     with pytest.raises(

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -16,7 +16,11 @@ def test__get_ntuple_path():
     assert template_builder._get_ntuple_path(
         {},
         {},
-        {"Name": "variation", "Type": "NormPlusShape", "PathUp": "test/path.root"},
+        {
+            "Name": "variation",
+            "Type": "NormPlusShape",
+            "Up": {"Path": "test/path.root"},
+        },
     ) == Path("test/path.root")
 
     with pytest.raises(
@@ -53,7 +57,8 @@ def test__get_position_in_file():
 
     assert (
         template_builder._get_position_in_file(
-            {}, {"Name": "variation", "Type": "NormPlusShape", "TreeUp": "up_tree"}
+            {},
+            {"Name": "variation", "Type": "NormPlusShape", "Up": {"Tree": "up_tree"}},
         )
         == "up_tree"
     )

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -38,14 +38,18 @@ def test_get_NF_modifiers():
     assert workspace.get_NF_modifiers(example_config, sample) == expected_modifier
 
 
-def test_get_OverallSys_modifier():
-    systematic = {"Name": "sys", "OverallUp": 0.1, "OverallDown": -0.05}
+def test_get_Normalization_modifier():
+    systematic = {
+        "Name": "sys",
+        "Up": {"Normalization": 0.1},
+        "Down": {"Normalization": -0.05},
+    }
     expected_modifier = {
         "name": "sys",
         "type": "normsys",
         "data": {"hi": 1.1, "lo": 0.95},
     }
-    assert workspace.get_OverallSys_modifier(systematic) == expected_modifier
+    assert workspace.get_Normalization_modifier(systematic) == expected_modifier
 
 
 def test_get_sys_modifiers():
@@ -53,10 +57,10 @@ def test_get_sys_modifiers():
         "Systematics": [
             {
                 "Name": "sys",
-                "Type": "Overall",
+                "Type": "Normalization",
                 "Samples": "Signal",
-                "OverallUp": 0.1,
-                "OverallDown": -0.05,
+                "Up": {"Normalization": 0.1},
+                "Down": {"Normalization": -0.05},
             }
         ]
     }


### PR DESCRIPTION
Switching the config layout from being a flat list of options per systematic to a new version where each template is specified via its own dict. This allows to re-use the same names for the same types of options.

Example:
A sample has an option `Path` pointing to where the relevant input file is located. A systematic with two templates `Up` and `Down` has the following structure to point to the two paths:

YAML:
```yaml
Up:
  Path: ...
Down:
  Path: ...
```

JSON:
```json
{
  "Down": {
    "Path": "..."
  }, 
  "Up": {
    "Path": "..."
  }
}
```

This approach is a small step towards #51, as additional templates can be specified via a list of dicts in the same manner.

Additional things done in this PR:
- Renaming OverallSys to Normalization.
- Removing the color options from the config, as they currently serve no purpose.
- Adding setter for Histogram.stdev