### PR TITLE
feat: norm factor settings

### DIFF
--- a/config_example.yml
+++ b/config_example.yml
@@ -47,4 +47,4 @@ NormFactors:
     Samples: "Signal"
     Nominal: 1
     Bounds: [0, 5]
-    Fixed: True
+    Fixed: False

--- a/config_example.yml
+++ b/config_example.yml
@@ -44,7 +44,7 @@ Systematics:
 
 NormFactors:
   - Name: "Signal_norm"
-    Nominal: 1
-    Min: 0
-    Max: 5
     Samples: "Signal"
+    Nominal: 1
+    Bounds: [0, 5]
+    Fixed: True

--- a/example.py
+++ b/example.py
@@ -14,7 +14,7 @@ logging.getLogger("matplotlib").setLevel(logging.WARNING)
 if __name__ == "__main__":
     # check whether input data exists
     if not os.path.exists("ntuples/"):
-        print(f"run util/create_histograms.py to create input data")
+        print(f"run util/create_ntuples.py to create input data")
         raise SystemExit
 
     # import example config file

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -26,7 +26,7 @@ def read(file_path_string):
     return config
 
 
-def validate(config):
+def validate(config: dict) -> bool:
     """test whether the config is valid
 
     Args:
@@ -36,22 +36,34 @@ def validate(config):
         ValueError: when missing required keys
         ValueError: when unknown keys are found
         NotImplementedError: when more than one data sample is found
+        ValueError: when missing a name for a NormFactor
+        ValueError: when missing a samples for a NormFactor
+
+    Returns:
+        bool: whether the validation was successful
     """
     config_keys = config.keys()
 
     # check whether all required keys exist
     for required_key in REQUIRED_CONFIG_KEYS:
         if required_key not in config_keys:
-            raise ValueError("missing required key in config:", required_key)
+            raise ValueError(f"missing required key in config: {required_key}")
 
     # check whether all keys are known
     for key in config_keys:
         if key not in (REQUIRED_CONFIG_KEYS + OPTIONAL_CONFIG_KEYS):
-            raise ValueError("unknown key found:", key)
+            raise ValueError(f"unknown key found: {key}")
 
     # check that there is exactly one data sample
     if sum([sample.get("Data", False) for sample in config["Samples"]]) != 1:
         raise NotImplementedError("can only handle cases with exactly one data sample")
+
+    # check that NormFactors have necessary values defined
+    for nf in config.get("NormFactors", []):
+        if not nf.get("Name", False):
+            raise ValueError(f"need to specify Name for NormFactor {nf}")
+        if not nf.get("Samples", False):
+            raise ValueError(f"need to specify Samples for NormFactor {nf}")
 
     # should also check here for conflicting settings
 

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -66,6 +66,7 @@ def validate(config: dict) -> bool:
             raise ValueError(f"need to specify Samples for NormFactor {nf}")
 
     # should also check here for conflicting settings
+    ...
 
     # if no issues are found
     return True

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -15,9 +15,9 @@ def test_read(mock_validation):
 
 def test_validate():
     config_valid = {
-        "General": "",
-        "Regions": "",
-        "NormFactors": "",
+        "General": [],
+        "Regions": [],
+        "NormFactors": [],
         "Samples": [{"Data": True}],
     }
     assert configuration.validate(config_valid)
@@ -27,25 +27,43 @@ def test_validate():
         configuration.validate(config_missing_key)
 
     config_unknown_key = {
-        "General": "",
-        "Regions": "",
-        "NormFactors": "",
-        "Samples": "",
+        "General": [],
+        "Regions": [],
+        "NormFactors": [],
+        "Samples": [],
         "unknown": [],
     }
     with pytest.raises(ValueError, match="unknown key found") as e_info:
         configuration.validate(config_unknown_key)
 
     config_multiple_data_samples = {
-        "General": "",
-        "Regions": "",
-        "NormFactors": "",
+        "General": [],
+        "Regions": [],
+        "NormFactors": [],
         "Samples": [{"Data": True}, {"Data": True}],
     }
     with pytest.raises(
         NotImplementedError, match="can only handle cases with exactly one data sample"
     ) as e_info:
         configuration.validate(config_multiple_data_samples)
+
+    config_missing_NF_name = {
+        "General": [],
+        "Regions": [],
+        "NormFactors": [{"Samples": []}],
+        "Samples": [{"Data": True}],
+    }
+    with pytest.raises(ValueError, match="need to specify Name for NormFactor"):
+        configuration.validate(config_missing_NF_name)
+
+    config_missing_NF_samples = {
+        "General": [],
+        "Regions": [],
+        "NormFactors": [{"Name": "NF"}],
+        "Samples": [{"Data": True}],
+    }
+    with pytest.raises(ValueError, match="need to specify Samples for NormFactor"):
+        configuration.validate(config_missing_NF_samples)
 
 
 def test_print_overview(caplog):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -17,7 +17,7 @@ def test_validate():
     config_valid = {
         "General": [],
         "Regions": [],
-        "NormFactors": [],
+        "NormFactors": [{"Name": "NF", "Samples": "signal"}],
         "Samples": [{"Data": True}],
     }
     assert configuration.validate(config_valid)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -30,22 +30,22 @@ def test_integration(tmp_path, ntuple_creator):
     bestfit, uncertainty, _, best_twice_nll = cabinetry.fit.fit(ws)
 
     bestfit_expected = [
-        1.00520446,
-        0.98118674,
-        1.02070816,
-        0.98229396,
-        -0.21494591,
-        0.04238099,
-        0.85726033,
+        1.005119,
+        0.981114,
+        1.020708,
+        0.982209,
+        -0.213536,
+        0.042937,
+        0.857655,
     ]
     uncertainty_expected = [
-        0.04095113,
-        0.03727586,
-        0.03649927,
-        0.04248655,
-        0.97692647,
-        0.16042208,
-        0.40949858,
+        0.040951,
+        0.037276,
+        0.036499,
+        0.042487,
+        0.976741,
+        0.160393,
+        0.407588,
     ]
     best_twice_nll_expected = 16.274739734197926
     assert np.allclose(bestfit, bestfit_expected)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -144,6 +144,19 @@ def test_get_measurement():
     ]
     assert workspace.get_measurements(example_config) == expected_measurement
 
+    # no norm factor settings
+    example_config_no_NF_settings = {
+        "General": {"Measurement": "fit", "POI": "mu"},
+        "NormFactors": [{"Name": "NF"}],
+    }
+    expected_measurement_no_NF_settings = [
+        {"name": "fit", "config": {"poi": "mu", "parameters": [{"name": "NF",}],},}
+    ]
+    assert (
+        workspace.get_measurements(example_config_no_NF_settings)
+        == expected_measurement_no_NF_settings
+    )
+
 
 def test_get_observations(tmp_path):
     histo_path = tmp_path / "test_region_Data_nominal.npz"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -88,7 +88,7 @@ def test_get_sys_modifiers():
 def test_get_channels(tmp_path):
     example_config = {
         "Regions": [{"Name": "region_1"}],
-        "Samples": [{"Name": "signal"}],
+        "Samples": [{"Name": "signal"}, {"Data": True}],
         "NormFactors": [],
     }
 
@@ -120,8 +120,28 @@ def test_get_channels(tmp_path):
 
 
 def test_get_measurement():
-    example_config = {"General": {"Measurement": "fit", "POI": "mu"}}
-    expected_measurement = [{"name": "fit", "config": {"poi": "mu", "parameters": []}}]
+    example_config = {
+        "General": {"Measurement": "fit", "POI": "mu"},
+        "NormFactors": [
+            {"Name": "NF", "Nominal": 1.0, "Bounds": [0.0, 5.0], "Fixed": False}
+        ],
+    }
+    expected_measurement = [
+        {
+            "name": "fit",
+            "config": {
+                "poi": "mu",
+                "parameters": [
+                    {
+                        "name": "NF",
+                        "inits": [1.0],
+                        "bounds": [[0.0, 5.0]],
+                        "fixed": False,
+                    }
+                ],
+            },
+        }
+    ]
     assert workspace.get_measurements(example_config) == expected_measurement
 
 


### PR DESCRIPTION
Propagating norm factor settings from the config to the `pyhf` workspace. The available settings are:
- nominal value ("Nominal")
- parameter boundaries ("Bounds"), as a list `[lower_bound, upper_bound]`
- whether to hold the norm factor constant ("Fixed")

The last setting is not yet propagated through `pyhf` to the fit, see https://github.com/scikit-hep/pyhf/issues/739 and https://github.com/scikit-hep/pyhf/pull/846.

Also adding some more config checks to ensure relevant options are specified in the config. Those checks need to be expanded in future updates.