### PR TITLE
style: flake8 plugins

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         flake8 src/cabinetry --count --select=E9,F63,F7,F82 --show-source --statistics
         # check for additional issues flagged by flake8, the GitHub editor is 127 chars wide
-        flake8 src/cabinetry --count --max-complexity=10 --max-line-length=127 --statistics --exclude=src/cabinetry/__init__.py
+        flake8 src/cabinetry --count --max-complexity=10 --max-line-length=127 --statistics --exclude=src/cabinetry/__init__.py --import-order-style google --application-import-names cabinetry,util
     - name: Format with Black
       run: |
         black --check --diff --verbose .

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ extras_require["test"] = sorted(
             "pydocstyle",
             "check-manifest",
             "flake8",
+            "flake8-bugbear",
+            "flake8-import-order",
             "black;python_version>='3.6'",  # Black is Python3 only
         ]
     )

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+
 import yaml
 
 

--- a/src/cabinetry/contrib/matplotlib_visualize.py
+++ b/src/cabinetry/contrib/matplotlib_visualize.py
@@ -3,8 +3,8 @@ import os
 from pathlib import Path
 from typing import List
 
-import matplotlib.pyplot as plt
 import matplotlib as mpl
+import matplotlib.pyplot as plt
 import numpy as np
 
 

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -144,9 +144,7 @@ def create_histograms(config, folder_path_str, method="uproot"):
         for sample in config["Samples"]:
             log.debug(f"  reading sample {sample['Name']}")
 
-            for isyst, systematic in enumerate(
-                ([{"Name": "nominal"}] + config["Systematics"])
-            ):
+            for systematic in [{"Name": "nominal"}] + config["Systematics"]:
                 # determine whether a histogram is needed for this
                 # specific combination of sample-region-systematic
                 histo_needed = configuration.histogram_is_needed(

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -1,7 +1,8 @@
 import copy
 import logging
-import numpy as np
 from pathlib import Path
+
+import numpy as np
 
 from . import histo
 

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import pyhf
 
@@ -28,8 +28,8 @@ def _get_data_sample(config):
 
 
 def get_yield_for_sample(
-    sample, region, histogram_folder, systematic={"Name": "nominal"}
-):
+    sample: dict, region: dict, histogram_folder: str, systematic: Optional[dict] = None
+) -> list:
     """get the yield for a specific sample, by figuring out its name and then
     obtaining the yield from the correct histogram
 
@@ -37,11 +37,14 @@ def get_yield_for_sample(
         sample (dict): specific sample to use
         region (dict): specific region to use
         histogram_folder (str): path to folder containing histograms
-        systematic (dict, optional): specific systematic variation to use, defaults to {"Name": "nominal"}
+        systematic (dict, optional): specific systematic variation to use, defaults to None -> {"Name": "nominal"}
 
     Returns:
         list: yields per bin for the sample
     """
+    if systematic is None:
+        systematic = {"Name": "nominal"}
+
     histogram = histo.Histogram.from_config(
         histogram_folder, region, sample, systematic, modified=True
     )
@@ -50,8 +53,8 @@ def get_yield_for_sample(
 
 
 def get_unc_for_sample(
-    sample, region, histogram_folder, systematic={"Name": "nominal"}
-):
+    sample: dict, region: dict, histogram_folder: str, systematic: Optional[dict] = None
+) -> list:
     """get the uncertainty of a specific sample, by figuring out its name and then
     obtaining the stdev from the correct histogram
 
@@ -59,11 +62,14 @@ def get_unc_for_sample(
         sample (dict): specific sample to use
         region (dict): specific region to use
         histogram_folder (str): path to folder containing histograms
-        systematic (dict, optional): specific systematic variation to use, defaults to {"Name": "nominal"}
+        systematic (dict, optional): specific systematic variation to use, defaults to None -> {"Name": "nominal"}
 
     Returns:
         list: statistical uncertainty of yield per bin for the sample
     """
+    if systematic is None:
+        systematic = {"Name": "nominal"}
+
     histogram = histo.Histogram.from_config(
         histogram_folder, region, sample, systematic, modified=True
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
-import uproot
 import pytest
+import uproot
 
 
 class Utils:

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -1,5 +1,4 @@
 import logging
-from pathlib import Path
 
 import numpy as np
 import pytest

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -1,6 +1,6 @@
+import logging
 from pathlib import Path
 
-import logging
 import numpy as np
 import pytest
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,8 +1,7 @@
-import numpy as np
 import pytest
 
-from cabinetry import workspace
 from cabinetry import histo
+from cabinetry import workspace
 
 
 def test__get_data_sample():
@@ -150,7 +149,7 @@ def test_get_measurement():
         "NormFactors": [{"Name": "NF"}],
     }
     expected_measurement_no_NF_settings = [
-        {"name": "fit", "config": {"poi": "mu", "parameters": [{"name": "NF",}],},}
+        {"name": "fit", "config": {"poi": "mu", "parameters": [{"name": "NF"}]}}
     ]
     assert (
         workspace.get_measurements(example_config_no_NF_settings)


### PR DESCRIPTION
Adding `flake8-bugbear` and `flake8-import-order` to the CI and setup as [recommended by Scikit-HEP](https://scikit-hep.org/developer/style#flake8). This also fixes the warnings from those plugins.

Improving workspace unit testing to cover the new behavior introduced to fix the style issues.