### PR TITLE
feat: generic two-sided systematics

### DIFF
--- a/config_example.yml
+++ b/config_example.yml
@@ -42,6 +42,14 @@ Systematics:
     Samples: "Background"
     Type: "NormPlusShape"
 
+  - Name: "WeightBasedModeling"
+    Up:
+      Weight: "weight_up"
+    Down:
+      Weight: "weight_down"
+    Samples: "Background"
+    Type: "NormPlusShape"
+
 NormFactors:
   - Name: "Signal_norm"
     Samples: "Signal"

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -120,7 +120,9 @@ def sample_affected_by_modifier(sample, modifier):
     return affected
 
 
-def histogram_is_needed(region, sample, systematic):
+def histogram_is_needed(
+    region: dict, sample: dict, systematic: dict, template: str
+) -> bool:
     """determine whether for a given sample-region-systematic pairing, there is
     an associated histogram
 
@@ -128,6 +130,7 @@ def histogram_is_needed(region, sample, systematic):
         region (dict): containing all region information
         sample (dict): containing all sample information
         systematic (dict): containing all systematic information
+        template (str): which template is considered: "Nominal", "Up", "Down"
 
     Raises:
         NotImplementedError: non-supported systematic variations based on histograms are requested
@@ -151,6 +154,10 @@ def histogram_is_needed(region, sample, systematic):
             elif systematic["Type"] == "NormPlusShape":
                 # for a variation defined via a template, a histogram is needed (if sample is affected)
                 histo_needed = sample_affected_by_modifier(sample, systematic)
+                # if symmetrization is specified for the template under consideration, a histogram
+                # is not needed (since it will later on be obtained via symmetrization)
+                if systematic.get(template, {}).get("Symmetrize", False):
+                    histo_needed = False
             else:
                 raise NotImplementedError("other systematics not yet implemented")
 

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -74,7 +74,9 @@ class Histogram(bh.Histogram):
         return cls.from_arrays(bins, yields, stdev)
 
     @classmethod
-    def from_config(cls, histo_folder, region, sample, systematic, modified=True):
+    def from_config(
+        cls, histo_folder, region, sample, systematic, modified=True, template="Nominal"
+    ):
         """load a histogram, given a folder the histogram is located in and the
         relevant information from the config: region, sample, systematic
 
@@ -84,12 +86,13 @@ class Histogram(bh.Histogram):
             sample (dict): containing all sample information
             systematic (dict): containing all systematic information
             modified (bool, optional): whether to load the modified histogram (after post-processing), defaults to True
+            template (str): which template (nominal/up/down) to consider, defaults to "Nominal"
 
         Returns:
             cabinetry.histo.Histogram: the loaded histogram
         """
         # find the histogram name given config information, and then load the histogram
-        histo_name = build_name(region, sample, systematic)
+        histo_name = build_name(region, sample, systematic, template)
         histo_path = Path(histo_folder) / histo_name
         return cls.from_path(histo_path, modified)
 
@@ -192,17 +195,22 @@ class Histogram(bh.Histogram):
         return normalization_ratio
 
 
-def build_name(region, sample, systematic):
+def build_name(
+    region: dict, sample: dict, systematic: dict, template: str = "Nominal"
+) -> str:
     """construct a unique name for each histogram
 
     Args:
         region (dict): containing all region information
         sample (dict): containing all sample information
         systematic (dict): containing all systematic information
+        template (str): which template (nominal/up/down) to consider, defaults to "Nominal"
 
     Returns:
         str: unique name for the histogram
     """
     name = region["Name"] + "_" + sample["Name"] + "_" + systematic["Name"]
+    if template != "Nominal":
+        name += "_" + template
     name = name.replace(" ", "-")
     return name

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import Optional
 
 import numpy as np
 
@@ -10,37 +11,54 @@ from . import histo
 log = logging.getLogger(__name__)
 
 
-def _get_ntuple_path(region, sample, systematic):
+def _check_for_override(systematic: dict, template: str, option: str) -> Optional[str]:
+    """Given a systematic and a string specifying which template is currently under consideration,
+    check whether the systematic defines an override for an option. Return the override if it
+    exists, otherwise return None.
+
+    Args:
+        systematic (dict): containing all systematic information
+        template (str): template to consider: "Nominal", "Up", "Down"
+        option (str): the option for which the presence of an override is checked
+
+    Returns:
+        Optional[str]: either None if no override exists, or the override
+    """
+    return systematic.get(template, {}).get(option, None)
+
+
+def _get_ntuple_path(
+    region: dict, sample: dict, systematic: dict, template: str
+) -> Path:
     """determine the path to ntuples from which a histogram has to be built
+    for non-nominal templates, override the nominal path if an alternative is
+    specified for the template
 
     Args:
         region (dict): containing all region information
         sample (dict): containing all sample information
         systematic (dict): containing all systematic information
-
-    Raises:
-        NotImplementedError: if ntuple path treatment is not yet implemented
+        template (str): which template is considered: "Nominal", "Up", "Down"
 
     Returns:
         pathlib.Path: path where the ntuples are located
     """
-    if systematic["Name"] == "nominal":
-        path_str = sample["Path"]
-    elif systematic["Type"] == "NormPlusShape":
-        path_str = systematic["Up"]["Path"]
-    else:
-        raise NotImplementedError("ntuple path treatment not yet defined")
+    path_str = sample["Path"]
+    # check whether a systematic is being processed
+    if systematic.get("Name", "nominal") != "nominal":
+        # determine whether the template has an override specified
+        path_str_override = _check_for_override(systematic, template, "Path")
+        if path_str_override is not None:
+            path_str = path_str_override
     path = Path(path_str)
     return path
 
 
-def _get_variable(region, sample, systematic):
+def _get_variable(region: dict) -> str:
     """construct the variable the histogram will be binned in
 
     Args:
         region (dict): containing all region information
-        sample (dict): containing all sample information
-        systematic (dict): containing all systematic information
 
     Returns:
         str: name of variable to bin histogram in
@@ -49,60 +67,81 @@ def _get_variable(region, sample, systematic):
     return axis_variable
 
 
-def _get_filter(region, sample, systematic):
+def _get_filter(
+    region: dict, sample: dict, systematic: dict, template: str
+) -> Optional[str]:
     """construct the filter to be applied for event selection
+    for non-nominal templates, override the nominal filter if an alternative is
+    specified for the template
 
     Args:
         region (dict): containing all region information
         sample (dict): containing all sample information
         systematic (dict): containing all systematic information
+        template (str): which template is considered: "Nominal", "Up", "Down"
 
     Returns:
-        str: expression for the filter to be used, or None for no filtering
+        Optional[str]: expression for the filter to be used, or None for no filtering
     """
     selection_filter = region.get("Filter", None)
+    # check whether a systematic is being processed
+    if systematic.get("Name", "nominal") != "nominal":
+        # determine whether the template has an override specified
+        selection_filter_override = _check_for_override(systematic, template, "Filter")
+        if selection_filter_override is not None:
+            selection_filter = selection_filter_override
     return selection_filter
 
 
-def _get_weight(region, sample, systematic):
+def _get_weight(region: dict, sample: dict, systematic: dict, template: str) -> str:
     """find the weight to be used for the events in the histogram
+    for non-nominal templates, override the nominal weight if an alternative is
+    specified for the template
 
     Args:
         region (dict): containing all region information
         sample (dict): containing all sample information
         systematic (dict): containing all systematic information
+        template (str): which template is considered: "Nominal", "Up", "Down"
 
     Returns:
         str: weight used for events when filled into histograms
     """
     weight = sample.get("Weight", None)
+    # check whether a systematic is being processed
+    if systematic.get("Name", "nominal") != "nominal":
+        # determine whether the template has an override specified
+        weight_override = _check_for_override(systematic, template, "Weight")
+        if weight_override is not None:
+            weight = weight_override
     return weight
 
 
-def _get_position_in_file(sample, systematic):
+def _get_position_in_file(sample: dict, systematic: dict, template: str) -> str:
     """the file might have some substructure, this specifies where in the file
     the data is
+    for non-nominal templates, override the nominal position if an alternative is
+    specified for the template
 
     Args:
         sample (dict): containing all sample information
         systematic (dict): containing all systematic information
-
-    Raises:
-        NotImplementedError: if finding the position in file is not yet implemented
+        template (str): which template is considered: "Nominal", "Up", "Down"
 
     Returns:
-        str: where in the file to find the data, (right now the name of a tree)
+        str: where in the file to find the data (right now the name of a tree)
     """
-    if systematic["Name"] == "nominal":
-        position = sample["Tree"]
-    elif systematic["Type"] == "NormPlusShape":
-        position = systematic["Up"]["Tree"]
-    else:
-        raise NotImplementedError("ntuple path treatment not yet defined")
+    position = sample["Tree"]
+    # check whether a systematic is being processed
+    if systematic.get("Name", "nominal") != "nominal":
+        # determine whether the template has an override specified
+        position_override = _check_for_override(systematic, template, "Tree")
+        if position_override is not None:
+            position = position_override
     return position
 
 
-def _get_binning(region):
+def _get_binning(region: dict) -> np.ndarray:
     """determine the binning to be used in a given region
     should eventually also support other ways of specifying bins,
     such as the amount of bins and the range to bin in
@@ -122,7 +161,9 @@ def _get_binning(region):
     return np.asarray(region["Binning"])
 
 
-def create_histograms(config, folder_path_str, method="uproot"):
+def create_histograms(
+    config: dict, folder_path_str: str, method: str = "uproot"
+) -> None:
     """generate all required histograms specified by a configuration file
     a tool providing histograms should provide bin yields and statistical
     uncertainties, as well as the bin edges
@@ -145,52 +186,66 @@ def create_histograms(config, folder_path_str, method="uproot"):
             log.debug(f"  reading sample {sample['Name']}")
 
             for systematic in [{"Name": "nominal"}] + config["Systematics"]:
-                # determine whether a histogram is needed for this
-                # specific combination of sample-region-systematic
-                histo_needed = configuration.histogram_is_needed(
-                    region, sample, systematic
-                )
-
-                if not histo_needed:
-                    # no further action is needed, continue with the next region-sample-systematic combination
-                    continue
 
                 log.debug(f"  variation {systematic['Name']}")
-                ntuple_path = _get_ntuple_path(region, sample, systematic)
-                pos_in_file = _get_position_in_file(sample, systematic)
-                variable = _get_variable(region, sample, systematic)
-                selection_filter = _get_filter(region, sample, systematic)
-                weight = _get_weight(region, sample, systematic)
-                bins = _get_binning(region)
 
-                # obtain the histogram
-                if method == "uproot":
-                    from cabinetry.contrib import histogram_creation
+                # determine how many templates need to be considered
+                if systematic["Name"] == "nominal":
+                    # only nominal template is needed
+                    templates = ["Nominal"]
+                else:
+                    # systematics can have up and down template
+                    templates = ["Up", "Down"]
 
-                    yields, stdev = histogram_creation.from_uproot(
-                        ntuple_path,
-                        pos_in_file,
-                        variable,
-                        bins,
-                        weight,
-                        selection_filter,
+                for template in templates:
+
+                    # determine whether a histogram is needed for this
+                    # specific combination of sample-region-systematic-template
+                    histo_needed = configuration.histogram_is_needed(
+                        region, sample, systematic, template
                     )
 
-                elif method == "ServiceX":
-                    raise NotImplementedError("ServiceX not yet implemented")
+                    if not histo_needed:
+                        # no further action is needed, continue with the next region-sample-systematic combination
+                        continue
 
-                else:
-                    raise NotImplementedError("unknown backend")
+                    ntuple_path = _get_ntuple_path(region, sample, systematic, template)
+                    pos_in_file = _get_position_in_file(sample, systematic, template)
+                    variable = _get_variable(region)
+                    selection_filter = _get_filter(region, sample, systematic, template)
+                    weight = _get_weight(region, sample, systematic, template)
+                    bins = _get_binning(region)
 
-                # store information in a Histogram instance
-                histogram = histo.Histogram.from_arrays(bins, yields, stdev)
+                    # obtain the histogram
+                    if method == "uproot":
+                        from cabinetry.contrib import histogram_creation
 
-                # generate a name for the histogram
-                histogram_name = histo.build_name(region, sample, systematic)
+                        yields, stdev = histogram_creation.from_uproot(
+                            ntuple_path,
+                            pos_in_file,
+                            variable,
+                            bins,
+                            weight,
+                            selection_filter,
+                        )
 
-                # check the histogram for common issues
-                histogram.validate(histogram_name)
+                    elif method == "ServiceX":
+                        raise NotImplementedError("ServiceX not yet implemented")
 
-                # save it
-                histo_path = Path(folder_path_str) / histogram_name
-                histogram.save(histo_path)
+                    else:
+                        raise NotImplementedError("unknown backend")
+
+                    # store information in a Histogram instance
+                    histogram = histo.Histogram.from_arrays(bins, yields, stdev)
+
+                    # generate a name for the histogram
+                    histogram_name = histo.build_name(
+                        region, sample, systematic, template
+                    )
+
+                    # check the histogram for common issues
+                    histogram.validate(histogram_name)
+
+                    # save it
+                    histo_path = Path(folder_path_str) / histogram_name
+                    histogram.save(histo_path)

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -176,7 +176,6 @@ def get_NormPlusShape_modifiers(region, sample, systematic, histogram_folder):
         # normalize templates to same yield as nominal
         histo_yield_up = list(histogram_up.yields / norm_effect_up)
         histo_yield_down = list(histogram_down.yields / norm_effect_down)
-        print("norm_down", norm_effect_down)
 
     # add the normsys
     modifiers = []

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -28,14 +28,14 @@ def _get_data_sample(config):
 
 
 def get_yield_for_sample(
-    sample: dict, region: dict, histogram_folder: str, systematic: Optional[dict] = None
+    region: dict, sample: dict, histogram_folder: str, systematic: Optional[dict] = None
 ) -> list:
     """get the yield for a specific sample, by figuring out its name and then
     obtaining the yield from the correct histogram
 
     Args:
-        sample (dict): specific sample to use
         region (dict): specific region to use
+        sample (dict): specific sample to use
         histogram_folder (str): path to folder containing histograms
         systematic (dict, optional): specific systematic variation to use, defaults to None -> {"Name": "nominal"}
 
@@ -53,14 +53,14 @@ def get_yield_for_sample(
 
 
 def get_unc_for_sample(
-    sample: dict, region: dict, histogram_folder: str, systematic: Optional[dict] = None
+    region: dict, sample: dict, histogram_folder: str, systematic: Optional[dict] = None
 ) -> list:
     """get the uncertainty of a specific sample, by figuring out its name and then
     obtaining the stdev from the correct histogram
 
     Args:
-        sample (dict): specific sample to use
         region (dict): specific region to use
+        sample (dict): specific sample to use
         histogram_folder (str): path to folder containing histograms
         systematic (dict, optional): specific systematic variation to use, defaults to None -> {"Name": "nominal"}
 
@@ -189,13 +189,13 @@ def get_NormPlusShape_modifiers(region, sample, systematic, histogram_folder):
     return modifiers
 
 
-def get_sys_modifiers(config, sample, region, histogram_folder):
+def get_sys_modifiers(config, region, sample, histogram_folder):
     """get the list of all systematic modifiers acting on a sample
 
     Args:
         config (dict): cabinetry configuration
-        sample (dict): specific sample to get modifiers for
         region (dict): region considered
+        sample (dict): specific sample to get modifiers for
         histogram_folder (str): path to folder containing histograms
 
     Raises:
@@ -248,7 +248,7 @@ def get_channels(config, histogram_folder):
                 continue
 
             # yield of the samples
-            histo_yield = get_yield_for_sample(sample, region, histogram_folder)
+            histo_yield = get_yield_for_sample(region, sample, histogram_folder)
             current_sample = {}
             current_sample.update({"name": sample["Name"]})
             current_sample.update({"data": histo_yield})
@@ -257,7 +257,7 @@ def get_channels(config, histogram_folder):
             modifiers = []
 
             # gammas
-            stat_unc = get_unc_for_sample(sample, region, histogram_folder)
+            stat_unc = get_unc_for_sample(region, sample, histogram_folder)
             gammas = {}
             gammas.update({"name": "staterror_" + region["Name"].replace(" ", "-")})
             gammas.update({"type": "staterror"})
@@ -270,7 +270,7 @@ def get_channels(config, histogram_folder):
 
             # check if systematic uncertainties affect the samples, add modifiers as needed
             sys_modifier_list = get_sys_modifiers(
-                config, sample, region, histogram_folder
+                config, region, sample, histogram_folder
             )
             modifiers += sys_modifier_list
 
@@ -338,7 +338,7 @@ def get_observations(config, histogram_folder):
     observations = []
     observation = {}
     for region in config["Regions"]:
-        histo_yield = get_yield_for_sample(data_sample, region, histogram_folder)
+        histo_yield = get_yield_for_sample(region, data_sample, histogram_folder)
         observation.update({"name": region["Name"]})
         observation.update({"data": histo_yield})
         observations.append(observation)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -30,24 +30,26 @@ def test_integration(tmp_path, ntuple_creator):
     bestfit, uncertainty, _, best_twice_nll = cabinetry.fit.fit(ws)
 
     bestfit_expected = [
-        1.005119,
-        0.981114,
-        1.020708,
-        0.982209,
-        -0.213536,
-        0.042937,
-        0.857655,
+        1.00124934,
+        0.98903044,
+        1.01966220,
+        0.98309447,
+        -0.08539741,
+        -0.36008148,
+        -0.59091951,
+        1.71110973,
     ]
     uncertainty_expected = [
-        0.040951,
-        0.037276,
-        0.036499,
-        0.042487,
-        0.976741,
-        0.160393,
-        0.407588,
+        0.04112787,
+        0.03806766,
+        0.03650754,
+        0.04249824,
+        0.98724460,
+        0.48031552,
+        0.62231780,
+        0.90353740,
     ]
-    best_twice_nll_expected = 16.274739734197926
+    best_twice_nll_expected = 17.199087
     assert np.allclose(bestfit, bestfit_expected)
     assert np.allclose(uncertainty, uncertainty_expected)
     assert np.allclose(best_twice_nll, best_twice_nll_expected)

--- a/tests/test_template_postprocessor.py
+++ b/tests/test_template_postprocessor.py
@@ -32,7 +32,15 @@ def test_apply_postprocessing():
 
 
 def test_run(tmp_path):
-    config = {"Samples": [{"Name": "signal"}], "Regions": [{"Name": "region_1"}]}
+    # should test systematics here as well, but the logic is the same as in
+    # template_builder.create_histograms(), where it gets tested
+    config = {
+        "Regions": [{"Name": "region_1"}],
+        "Samples": [{"Name": "signal"}],
+        "Systematics": [
+            {"Name": "var", "Samples": "background", "Type": "Normalization"}
+        ],
+    }
 
     # create an input histogram
     histo_path = tmp_path / "region_1_signal_nominal.npz"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -20,13 +20,13 @@ def test__get_data_sample():
 def test_get_yield_for_sample(mock_histogram):
     expected_yields = [1.0, 2.0]
     yields = workspace.get_yield_for_sample(
-        {"Name": "signal"}, {"Name": "region"}, "path"
+        {"Name": "region"}, {"Name": "signal"}, "path"
     )
     assert yields == expected_yields
 
     # non-nominal
     yields_non_nominal = workspace.get_yield_for_sample(
-        {"Name": "signal"}, {"Name": "region"}, "path", systematic={"Name": "variation"}
+        {"Name": "region"}, {"Name": "signal"}, "path", systematic={"Name": "variation"}
     )
     assert yields_non_nominal == expected_yields
 
@@ -48,12 +48,12 @@ def test_get_yield_for_sample(mock_histogram):
 )
 def test_get_unc_for_sample(mock_histogram):
     expected_unc = [0.1, 0.1]
-    unc = workspace.get_unc_for_sample({"Name": "signal"}, {"Name": "region"}, "path")
+    unc = workspace.get_unc_for_sample({"Name": "region"}, {"Name": "signal"}, "path")
     assert unc == expected_unc
 
     # non-nominal
     unc_non_nominal = workspace.get_unc_for_sample(
-        {"Name": "signal"}, {"Name": "region"}, "path", systematic={"Name": "variation"}
+        {"Name": "region"}, {"Name": "signal"}, "path", systematic={"Name": "variation"}
     )
     assert unc_non_nominal == expected_unc
 
@@ -124,7 +124,7 @@ def test_get_sys_modifiers():
     sample = {"Name": "Signal"}
     region = {}
     # needs to be expanded to include histogram loading
-    modifiers = workspace.get_sys_modifiers(config_example, sample, region, None)
+    modifiers = workspace.get_sys_modifiers(config_example, region, sample, None)
     expected_modifiers = [
         {"name": "sys", "type": "normsys", "data": {"hi": 1.1, "lo": 0.95}}
     ]
@@ -139,7 +139,7 @@ def test_get_sys_modifiers():
     with pytest.raises(
         NotImplementedError, match="not supporting other systematic types yet"
     ):
-        workspace.get_sys_modifiers(config_example_unsupported, sample, region, None)
+        workspace.get_sys_modifiers(config_example_unsupported, region, sample, None)
 
 
 @mock.patch("cabinetry.workspace.get_unc_for_sample", return_value=[0.1, 0.1])

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -233,7 +233,7 @@ def test_get_observations(mock_get_yield):
     expected_obs = [{"name": "test_region", "data": [1.0, 2.0]}]
     assert obs == expected_obs
     assert mock_get_yield.call_args_list == [
-        ((config["Samples"][0], config["Regions"][0], "path"),)
+        ((config["Regions"][0], config["Samples"][0], "path"),)
     ]
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -174,10 +174,10 @@ def test_get_channels(mock_get_yield, mock_get_unc):
     ]
     assert channels == expected_channels
     assert mock_get_yield.call_args_list == [
-        ((example_config["Samples"][0], example_config["Regions"][0], "path"),)
+        ((example_config["Regions"][0], example_config["Samples"][0], "path"),)
     ]
     assert mock_get_unc.call_args_list == [
-        ((example_config["Samples"][0], example_config["Regions"][0], "path"),)
+        ((example_config["Regions"][0], example_config["Samples"][0], "path"),)
     ]
 
 


### PR DESCRIPTION
Refactoring the template management to support a more generic set of systematics built from two templates without symmetrization. The new approach in the config is to use the same selections / weights / samples as in the associated nominal sample, but then to override them in the template definition. The override is specified in dicts associated to each template.

Expanding the config and ntuple creation script to test the new behavior. The ntuple script will have to be refactored in the future to scale better to more complex inputs.