### PR TITLE
chore: moving options to setup.cfg

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,9 +30,9 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 src/cabinetry --count --select=E9,F63,F7,F82 --show-source --statistics
-        # check for additional issues flagged by flake8, the GitHub editor is 127 chars wide
-        flake8 src/cabinetry --count --max-complexity=10 --max-line-length=127 --statistics --exclude=src/cabinetry/__init__.py --import-order-style google --application-import-names cabinetry,util
+        flake8 src/cabinetry --select=E9,F63,F7,F82 --show-source
+        # check for additional issues flagged by flake8
+        flake8
     - name: Format with Black
       run: |
         black --check --diff --verbose .
@@ -42,7 +42,7 @@ jobs:
         python example.py
     - name: Test with pytest and generate coverage report
       run: |
-        pytest --cov=src/cabinetry --cov-report=xml --cov-report=term-missing --cov-branch tests
+        pytest --cov-report=xml
     - name: Upload coverage to codecov
       if: matrix.python-version == 3.7
       uses: codecov/codecov-action@v1

--- a/example.py
+++ b/example.py
@@ -14,7 +14,7 @@ logging.getLogger("matplotlib").setLevel(logging.WARNING)
 if __name__ == "__main__":
     # check whether input data exists
     if not os.path.exists("ntuples/"):
-        print(f"run util/create_ntuples.py to create input data")
+        print("run util/create_ntuples.py to create input data")
         raise SystemExit
 
     # import example config file

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,32 @@
+[tool:pytest]
+addopts = --cov=cabinetry --cov-report html --cov-report term-missing --cov-branch
+
+[flake8]
+max-complexity = 10
+max-line-length = 127
+exclude = src/cabinetry/__init__.py, docs/conf.py
+count = True
+statistics = True
+import-order-style = google
+application-import-names = cabinetry, util
+
+[mypy-boost_histogram]
+ignore_missing_imports = True
+
+[mypy-numpy]
+ignore_missing_imports = True
+
+[mypy-uproot4]
+ignore_missing_imports = True
+
+[mypy-pyhf]
+ignore_missing_imports = True
+
+[mypy-matplotlib]
+ignore_missing_imports = True
+
+[mypy-matplotlib.pyplot]
+ignore_missing_imports = True
+
+[mypy-iminuit]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 extras_require = {"contrib": ["matplotlib", "uproot", "uproot4", "awkward1"]}
 extras_require["test"] = sorted(

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -23,7 +23,7 @@ def test_validate():
     assert configuration.validate(config_valid)
 
     config_missing_key = {"General": []}
-    with pytest.raises(ValueError, match="missing required key in config") as e_info:
+    with pytest.raises(ValueError, match="missing required key in config"):
         configuration.validate(config_missing_key)
 
     config_unknown_key = {
@@ -33,7 +33,7 @@ def test_validate():
         "Samples": [],
         "unknown": [],
     }
-    with pytest.raises(ValueError, match="unknown key found") as e_info:
+    with pytest.raises(ValueError, match="unknown key found"):
         configuration.validate(config_unknown_key)
 
     config_multiple_data_samples = {
@@ -44,7 +44,7 @@ def test_validate():
     }
     with pytest.raises(
         NotImplementedError, match="can only handle cases with exactly one data sample"
-    ) as e_info:
+    ):
         configuration.validate(config_multiple_data_samples)
 
     config_missing_NF_name = {

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -143,4 +143,4 @@ def test_histogram_is_needed(reg_sam_sys, is_needed):
     with pytest.raises(
         NotImplementedError, match="other systematics not yet implemented"
     ):
-        configuration.histogram_is_needed({}, {}, {"Type": "unknown"}, "")
+        configuration.histogram_is_needed({}, {}, {"Type": "unknown"})

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -142,5 +142,5 @@ def test_histogram_is_needed(reg_sam_sys, is_needed):
     # non-supported systematic
     with pytest.raises(
         NotImplementedError, match="other systematics not yet implemented"
-    ) as e_info:
-        configuration.histogram_is_needed({}, {}, {"Type": "unknown"})
+    ):
+        configuration.histogram_is_needed({}, {}, {"Type": "unknown"}, "")

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -85,14 +85,12 @@ def test_Histogram_from_arrays(example_histograms):
     assert np.allclose(h.stdev, stdev)
     assert np.allclose(h.bins, bins)
 
-    with pytest.raises(
-        ValueError, match="bin edges need one more entry than yields"
-    ) as e_info:
+    with pytest.raises(ValueError, match="bin edges need one more entry than yields"):
         histo.Histogram.from_arrays(*example_histograms.wrong_bin_number())
 
     with pytest.raises(
         ValueError, match="yields and stdev need to have the same shape"
-    ) as e_info:
+    ):
         histo.Histogram.from_arrays(*example_histograms.yields_stdev_mismatch())
 
 

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -25,7 +25,7 @@ def test__get_ntuple_path():
 
     with pytest.raises(
         NotImplementedError, match="ntuple path treatment not yet defined"
-    ) as e_info:
+    ):
         assert template_builder._get_ntuple_path(
             {}, {}, {"Name": "unknown_variation_type", "Type": "unknown"}
         )
@@ -65,7 +65,7 @@ def test__get_position_in_file():
 
     with pytest.raises(
         NotImplementedError, match="ntuple path treatment not yet defined"
-    ) as e_info:
+    ):
         template_builder._get_position_in_file(
             {}, {"Name": "unknown_variation", "Type": "unknown"}
         )
@@ -75,7 +75,7 @@ def test__get_binning():
     np.testing.assert_equal(
         template_builder._get_binning({"Binning": [1, 2, 3]}), [1, 2, 3]
     )
-    with pytest.raises(NotImplementedError, match="cannot determine binning") as e_info:
+    with pytest.raises(NotImplementedError, match="cannot determine binning"):
         assert template_builder._get_binning({})
 
 
@@ -99,13 +99,11 @@ def test_create_histograms(tmp_path, caplog, utils):
     template_builder.create_histograms(config, tmp_path, method="uproot")
 
     # ServiceX is not yet implemented
-    with pytest.raises(
-        NotImplementedError, match="ServiceX not yet implemented"
-    ) as e_info:
+    with pytest.raises(NotImplementedError, match="ServiceX not yet implemented"):
         assert template_builder.create_histograms(config, tmp_path, method="ServiceX")
 
     # other backends
-    with pytest.raises(NotImplementedError, match="unknown backend") as e_info:
+    with pytest.raises(NotImplementedError, match="unknown backend"):
         assert template_builder.create_histograms(config, tmp_path, method="unknown")
 
     saved_histo = histo.Histogram.from_config(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -138,7 +138,7 @@ def test_get_sys_modifiers():
     }
     with pytest.raises(
         NotImplementedError, match="not supporting other systematic types yet"
-    ) as e_info:
+    ):
         workspace.get_sys_modifiers(config_example_unsupported, sample, region, None)
 
 

--- a/util/create_ntuples.py
+++ b/util/create_ntuples.py
@@ -1,7 +1,8 @@
 import os
-import uproot
-import numpy as np
+
 import matplotlib.pyplot as plt
+import numpy as np
+import uproot
 
 
 def toy_distribution(noncentral, multiplier, offset, num_events):
@@ -49,7 +50,9 @@ def create_lepton_charge(n_events):
     return charge
 
 
-def create_file(file_name, distributions, weights, labels):
+def create_file(file_name, distributions, weights, labels, extra_weights=None):
+    if extra_weights is None:
+        extra_weights = []
     n_events = len(weights[0])
     with uproot.recreate(file_name) as f:
         # write the predicted processes

--- a/util/create_ntuples.py
+++ b/util/create_ntuples.py
@@ -50,9 +50,7 @@ def create_lepton_charge(n_events):
     return charge
 
 
-def create_file(file_name, distributions, weights, labels, extra_weights=None):
-    if extra_weights is None:
-        extra_weights = []
+def create_file(file_name, distributions, weights, labels):
     n_events = len(weights[0])
     with uproot.recreate(file_name) as f:
         # write the predicted processes


### PR DESCRIPTION
Creating `setup.cfg` to store configuration for `pytest`, `flake8` and `mypy`. With `pytest` 6.0 it will be possible to move the options to `pyproject.toml` instead, see https://docs.pytest.org/en/latest/customize.html#pyproject-toml. 