### PR TITLE
feat: type hints

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,12 +27,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install -e .[test]
-    - name: Lint with flake8
+    - name: Static code analysis with flake8 and mypy
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 src/cabinetry --select=E9,F63,F7,F82 --show-source
         # check for additional issues flagged by flake8
         flake8
+        # run mypy for type checking
+        mypy
     - name: Format with Black
       run: |
         black --check --diff --verbose .

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ coverage.xml
 dist
 build
 
+# typing
+.pytype
+
 # editors
 .vscode
 *.swp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,16 @@ repos:
     hooks:
     -   id: black
         language_version: python3
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.782
+    hooks:
+    -   id: mypy
+        files: src/cabinetry
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+    -   id: flake8
+        additional_dependencies: [flake8-bugbear, flake8-import-order]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.1.0
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,11 +4,27 @@ addopts = --cov=cabinetry --cov-report html --cov-report term-missing --cov-bran
 [flake8]
 max-complexity = 10
 max-line-length = 127
-exclude = src/cabinetry/__init__.py, docs/conf.py
+exclude = docs/conf.py
 count = True
 statistics = True
 import-order-style = google
 application-import-names = cabinetry, util
+
+[mypy]
+files = src/cabinetry
+pretty = True
+show_error_context = True
+show_error_codes = True
+# strict = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+warn_redundant_casts = True
+# warn_return_any = True
+warn_unreachable = True
+strict_equality = True
 
 [mypy-boost_histogram]
 ignore_missing_imports = True
@@ -30,3 +46,6 @@ ignore_missing_imports = True
 
 [mypy-iminuit]
 ignore_missing_imports = True
+
+[pytype]
+inputs = src/cabinetry

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ extras_require["test"] = sorted(
             "flake8",
             "flake8-bugbear",
             "flake8-import-order",
+            "mypy",
             "black;python_version>='3.6'",  # Black is Python3 only
         ]
     )

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     url="https://github.com/alexander-held/cabinetry",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
+    package_data={"cabinetry": ["py.typed"]},
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Programming Language :: Python :: 3.6",

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -1,9 +1,10 @@
-from . import configuration
-from . import template_builder
-from . import template_postprocessor
-from . import workspace
-from . import visualize
-from . import fit
+from . import configuration  # NOQA
+from . import fit  # NOQA
+from . import systematic  # NOQA
+from . import template_builder  # NOQA
+from . import template_postprocessor  # NOQA
+from . import visualize  # NOQA
+from . import workspace  # NOQA
 
 
 __version__ = "0.0.4"

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -1,6 +1,5 @@
 from . import configuration  # NOQA
 from . import fit  # NOQA
-from . import systematic  # NOQA
 from . import template_builder  # NOQA
 from . import template_postprocessor  # NOQA
 from . import visualize  # NOQA

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import Any, Dict, List, Union
 
 import yaml
 
@@ -11,14 +12,14 @@ OPTIONAL_CONFIG_KEYS = ["Systematics"]
 log = logging.getLogger(__name__)
 
 
-def read(file_path_string):
+def read(file_path_string: str) -> Dict[str, Any]:
     """read a config file from a provided path and return it
 
     Args:
         file_path_string (str): path to config file
 
     Returns:
-        dict: cabinetry configuration
+        Dict[str, Any]: cabinetry configuration
     """
     file_path = Path(file_path_string)
     log.info(f"opening config file {file_path}")
@@ -27,11 +28,11 @@ def read(file_path_string):
     return config
 
 
-def validate(config: dict) -> bool:
+def validate(config: Dict[str, Any]) -> bool:
     """test whether the config is valid
 
     Args:
-        config (dict): cabinetry configuration
+        config (Dict[str, Any]): cabinetry configuration
 
     Raises:
         ValueError: when missing required keys
@@ -73,11 +74,11 @@ def validate(config: dict) -> bool:
     return True
 
 
-def print_overview(config):
+def print_overview(config: Dict[str, Any]) -> None:
     """output a compact summary of a config file
 
     Args:
-        config (dict): cabinetry configuration
+        config (Dict[str, Any]): cabinetry configuration
     """
     log.info("the config contains:")
     log.info(f"  {len(config['Samples'])} Sample(s)")
@@ -87,7 +88,7 @@ def print_overview(config):
         log.info(f"  {len(config['Systematics'])} Systematic(s)")
 
 
-def _convert_samples_to_list(samples):
+def _convert_samples_to_list(samples: Union[str, List[str]]) -> List[str]:
     """the config can allow for two ways of specifying samples, a single sample:
     "Samples": "ABC"
     or a list of samples:
@@ -95,7 +96,7 @@ def _convert_samples_to_list(samples):
     for consistent treatment, convert the single sample into a single-element list
 
     Args:
-        samples (string/list): name of single sample or list of sample names
+        samples (Union[str, List[str]]): name of single sample or list of sample names
 
     Returns:
         list: name(s) of sample(s)
@@ -105,12 +106,14 @@ def _convert_samples_to_list(samples):
     return samples
 
 
-def sample_affected_by_modifier(sample, modifier):
+def sample_affected_by_modifier(
+    sample: Dict[str, Any], modifier: Dict[str, Any]
+) -> bool:
     """check if a sample is affected by a given modifier (Systematic, NormFactor)
 
     Args:
-        sample (dict): containing all sample information
-        modifier (dict): containing all modifier information (a Systematic of a NormFactor)
+        sample (Dict[str, Any]): containing all sample information
+        modifier (Dict[str, Any]): containing all modifier information (a Systematic of a NormFactor)
 
     Returns:
         bool: True if sample is affected, False otherwise
@@ -121,15 +124,18 @@ def sample_affected_by_modifier(sample, modifier):
 
 
 def histogram_is_needed(
-    region: dict, sample: dict, systematic: dict, template: str
+    region: Dict[str, Any],
+    sample: Dict[str, Any],
+    systematic: Dict[str, Any],
+    template: str,
 ) -> bool:
     """determine whether for a given sample-region-systematic pairing, there is
     an associated histogram
 
     Args:
-        region (dict): containing all region information
-        sample (dict): containing all sample information
-        systematic (dict): containing all systematic information
+        region (Dict[str, Any]): containing all region information
+        sample (Dict[str, Any]): containing all sample information
+        systematic (Dict[str, Any]): containing all systematic information
         template (str): which template is considered: "Nominal", "Up", "Down"
 
     Raises:

--- a/src/cabinetry/contrib/histogram_creation.py
+++ b/src/cabinetry/contrib/histogram_creation.py
@@ -1,11 +1,19 @@
+from pathlib import Path
+from typing import Optional, Tuple
+
 import boost_histogram as bh
 import numpy as np
 import uproot4 as uproot
 
 
 def from_uproot(
-    ntuple_path, pos_in_file, variable, bins, weight=None, selection_filter=None
-):
+    ntuple_path: Path,
+    pos_in_file: str,
+    variable: str,
+    bins: np.ndarray,
+    weight: Optional[str] = None,
+    selection_filter: Optional[str] = None,
+) -> Tuple[np.ndarray, np.ndarray]:
     """read an ntuple with uproot, the resulting arrays are then filled into a histogram
 
     Args:
@@ -13,12 +21,15 @@ def from_uproot(
         pos_in_file (str): name of tree within ntuple
         variable (str): variable to bin histogram in
         bins (numpy.ndarray): bin edges for histogram
-        weight (str): event weight to extract, defaults to None (no weights applied)
-        selection_filter (str, optional): filter to be applied on events, defaults to None (no filter)
+        weight (Optional[str], optional): event weight to extract, defaults to None (no weights applied)
+        selection_filter (Optional[str], optional): filter to be applied on events, defaults to None (no filter)
 
     Returns:
-        (numpy.ndarray, numpy.ndarray): tuple of yields and stat. uncertainties for all bins
+        Tuple[np.ndarray, np.ndarray]:
+            - yield per bin
+            - stat. uncertainty per bin
     """
+
     tree = uproot.open(str(ntuple_path) + ":" + pos_in_file)
 
     # extract observable and weights
@@ -35,7 +46,9 @@ def from_uproot(
     return yields, stdev
 
 
-def _bin_data(observables, weights, bins):
+def _bin_data(
+    observables: np.ndarray, weights: np.ndarray, bins: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray]:
     """create a histogram from unbinned data, providing yields, statistical uncertainties
     and the bin edges
 
@@ -45,9 +58,9 @@ def _bin_data(observables, weights, bins):
         bins (numpy.ndarray): bin edges for histogram
 
     Returns:
-        tuple: a tuple containing
-            - numpy.ndarray: yields per bin
-            - numpy.ndarray: and stat. uncertainty per bin
+        Tuple[np.ndarray, np.ndarray]:
+            - yield per bin
+            - stat. uncertainty per bin
     """
     hist = bh.Histogram(bh.axis.Variable(bins), storage=bh.storage.Weight())
     hist.fill(observables, weight=weights)

--- a/src/cabinetry/contrib/matplotlib_visualize.py
+++ b/src/cabinetry/contrib/matplotlib_visualize.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import List
+from typing import Any, Dict, List
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -11,12 +11,12 @@ import numpy as np
 log = logging.getLogger(__name__)
 
 
-def _total_yield_uncertainty(stdev_list):
+def _total_yield_uncertainty(stdev_list: List[np.ndarray]) -> np.ndarray:
     """calculate the absolute statistical uncertainty of a stack of MC
     via sum in quadrature
 
     Args:
-        stdev_list (list): list of absolute stat. uncertainty per sample
+        stdev_list (List[np.ndarray]): list of absolute stat. uncertainty per sample
 
     Returns:
         np.array: absolute stat. uncertainty of stack of samples
@@ -25,11 +25,11 @@ def _total_yield_uncertainty(stdev_list):
     return tot_unc
 
 
-def data_MC(histogram_dict_list, figure_path):
+def data_MC(histogram_dict_list: List[Dict[str, Any]], figure_path: Path) -> None:
     """draw a data/MC histogram
 
     Args:
-        histogram_dict_list (list[dict]): list of samples (with info stored in one dict per sample)
+        histogram_dict_list (List[Dict[str, Any]]): list of samples (with info stored in one dict per sample)
         figure_path (pathlib.Path): path where figure should be saved
     """
     mc_histograms_yields = []

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Tuple
+from typing import Any, Dict, List, Tuple
 
 import iminuit
 import numpy as np
@@ -9,7 +9,7 @@ import pyhf
 log = logging.getLogger(__name__)
 
 
-def get_parameter_names(model):
+def get_parameter_names(model: pyhf.pdf.Model) -> List[str]:
     """get the labels of all fit parameters, expanding vectors that act on
     one bin per vector entry (gammas)
 
@@ -17,7 +17,7 @@ def get_parameter_names(model):
         model (pyhf.pdf.Model): a HistFactory-style model in pyhf format
 
     Returns:
-        list: names of fit parameters
+        List[str]: names of fit parameters
     """
     labels = []
     for parname in model.config.par_order:
@@ -30,13 +30,15 @@ def get_parameter_names(model):
     return labels
 
 
-def print_results(bestfit, uncertainty, labels):
+def print_results(
+    bestfit: np.ndarray, uncertainty: np.ndarray, labels: List[str]
+) -> None:
     """print the best-fit parameter results and associated uncertainties
 
     Args:
         bestfit (numpy.ndarray): best-fit results of parameters
         uncertainty (numpy.ndarray): uncertainties of best-fit parameter results
-        labels (list): parameter labels
+        labels (List[str]): parameter labels
     """
     max_label_length = max([len(label) for label in labels])
     for i, label in enumerate(labels):
@@ -44,19 +46,19 @@ def print_results(bestfit, uncertainty, labels):
         log.info(f"{l_with_spacer}: {bestfit[i]:.6f} +/- {uncertainty[i]:.6f}")
 
 
-def fit(spec):
+def fit(spec: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray, List[str], float]:
     """perform an unconstrained maximum likelihood fit with pyhf and report
     the results of the fit
 
     Args:
-        spec (dict): a pyhf workspace
+        spec (Dict[str, Any]): a pyhf workspace specificaton
 
     Returns:
-        tuple: a tuple containing
-            - numpy.ndarray: best-fit positions of parameters
-            - numpy.ndarray: parameter uncertainties
-            - list: parameter names
-            - float: -2 log(likelihood) at best-fit point
+        Tuple[np.ndarray, np.ndarray, List[str], float]:
+            - best-fit positions of parameters
+            - parameter uncertainties
+            - parameter names
+            - -2 log(likelihood) at best-fit point
     """
     log.info("performing unconstrained fit")
 
@@ -77,21 +79,23 @@ def fit(spec):
     return bestfit, uncertainty, labels, best_twice_nll
 
 
-def custom_fit(spec: dict,) -> Tuple[np.ndarray, np.ndarray, list, float, np.ndarray]:
+def custom_fit(
+    spec: Dict[str, Any]
+) -> Tuple[np.ndarray, np.ndarray, List[str], float, np.ndarray]:
     """Perform an unconstrained maximum likelihood fit with iminuit and report
     the result. Compared to fit(), this does not use the pyhf.infer API for more
     control over the minimization, and it returns the correlation matrix.
 
     Args:
-        spec (dict): a pyhf workspace
+        spec (Dict[str, Any]): a pyhf workspace specificaton
 
     Returns:
-        tuple: a tuple containing
-            - numpy.ndarray: best-fit positions of parameters
-            - numpy.ndarray: parameter uncertainties
-            - list: parameter names
-            - float: -2 log(likelihood) at best-fit point
-            - numpy.ndarray: correlation matrix
+        Tuple[np.ndarray, np.ndarray, List[str], float, numpy.ndarray]:
+            - best-fit positions of parameters
+            - parameter uncertainties
+            - parameter names
+            - -2 log(likelihood) at best-fit point
+            - correlation matrix
     """
     pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=True))
 
@@ -106,7 +110,7 @@ def custom_fit(spec: dict,) -> Tuple[np.ndarray, np.ndarray, list, float, np.nda
 
     labels = get_parameter_names(model)
 
-    def twice_nll_func(pars):
+    def twice_nll_func(pars: np.ndarray) -> np.float64:
         twice_nll = -2 * model.logpdf(pars, data)
         return twice_nll[0]
 

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -1,12 +1,15 @@
 import logging
 import os
 from pathlib import Path
+from typing import Any, Dict, List, Type, TypeVar, Union
 
 import boost_histogram as bh
 import numpy as np
 
 
 log = logging.getLogger(__name__)
+
+H = TypeVar("H", bound="Histogram")
 
 
 class Histogram(bh.Histogram):
@@ -15,14 +18,19 @@ class Histogram(bh.Histogram):
     """
 
     @classmethod
-    def from_arrays(cls, bins, yields, stdev):
+    def from_arrays(
+        cls: Type[H],
+        bins: Union[List[Union[int, float]], np.ndarray],
+        yields: Union[List[Union[int, float]], np.ndarray],
+        stdev: Union[List[Union[int, float]], np.ndarray],
+    ) -> H:
         """construct a histogram from arrays of yields and uncertainties, the input
-        can be lists or numpy.ndarrays
+        can be lists of ints or floats, or numpy.ndarrays
 
         Args:
-            bins (Union[list, numpy.ndarray]): edges of histogram bins
-            yields (Union[list, numpy.ndarray]): yield per histogram bin
-            stdev (Union[list, numpy.ndarray]): statistical uncertainty of yield per bin
+            bins (Union[List[Union[int, float]], np.ndarray]): edges of histogram bins
+            yields (Union[List[Union[int, float]], np.ndarray]): yield per histogram bin
+            stdev (Union[List[Union[int, float]], np.ndarray]): statistical uncertainty of yield per bin
 
         Raises:
             ValueError: when amount of bins specified via bin edges and bin contents do not match
@@ -46,7 +54,7 @@ class Histogram(bh.Histogram):
         return out
 
     @classmethod
-    def from_path(cls, histo_path, modified=True):
+    def from_path(cls: Type[H], histo_path: Path, modified: bool = True) -> H:
         """build a histogram from disk
         try to load the "modified" version of the histogram by default
         (which received post-processing)
@@ -75,16 +83,22 @@ class Histogram(bh.Histogram):
 
     @classmethod
     def from_config(
-        cls, histo_folder, region, sample, systematic, modified=True, template="Nominal"
-    ):
+        cls: Type[H],
+        histo_folder: str,
+        region: Dict[str, Any],
+        sample: Dict[str, Any],
+        systematic: Dict[str, Any],
+        modified: bool = True,
+        template: str = "Nominal",
+    ) -> H:
         """load a histogram, given a folder the histogram is located in and the
         relevant information from the config: region, sample, systematic
 
         Args:
             histo_folder (str): folder containing all histograms
-            region (dict): containing all region information
-            sample (dict): containing all sample information
-            systematic (dict): containing all systematic information
+            region (Dict[str, Any]): containing all region information
+            sample (Dict[str, Any]): containing all sample information
+            systematic (Dict[str, Any]): containing all systematic information
             modified (bool, optional): whether to load the modified histogram (after post-processing), defaults to True
             template (str): which template (nominal/up/down) to consider, defaults to "Nominal"
 
@@ -97,7 +111,7 @@ class Histogram(bh.Histogram):
         return cls.from_path(histo_path, modified)
 
     @property
-    def yields(self):
+    def yields(self) -> np.ndarray:
         """get the yields per histogram bin
 
         Returns:
@@ -106,7 +120,7 @@ class Histogram(bh.Histogram):
         return self.view().value
 
     @property
-    def stdev(self):
+    def stdev(self) -> np.ndarray:
         """get the stat. uncertainty per histogram bin
 
         Returns:
@@ -115,7 +129,7 @@ class Histogram(bh.Histogram):
         return np.sqrt(self.view().variance)
 
     @stdev.setter
-    def stdev(self, value):
+    def stdev(self, value: np.ndarray) -> None:
         """update the variance (by specifying the standard deviation)
 
         Args:
@@ -124,7 +138,7 @@ class Histogram(bh.Histogram):
         self.view().variance = value ** 2
 
     @property
-    def bins(self):
+    def bins(self) -> np.ndarray:
         """get the bin edges
 
         Returns:
@@ -132,7 +146,7 @@ class Histogram(bh.Histogram):
         """
         return self.axes[0].edges
 
-    def save(self, histo_path):
+    def save(self, histo_path: Path) -> None:
         """save a histogram to disk
 
         Args:
@@ -150,7 +164,7 @@ class Histogram(bh.Histogram):
             bins=self.bins,
         )
 
-    def validate(self, name):
+    def validate(self, name: str) -> None:
         """run consistency checks on a histogram, checking for empty bins
         and ill-defined statistical uncertainties
 
@@ -177,7 +191,7 @@ class Histogram(bh.Histogram):
                 f"{name} has non-empty bins with ill-defined stat. unc.: {not_empty_but_nan}",
             )
 
-    def normalize_to_yield(self, reference_histogram):
+    def normalize_to_yield(self, reference_histogram: H) -> np.float64:
         """normalize a histogram to match the yield of a reference, and return the
         normalization factor
 
@@ -196,14 +210,17 @@ class Histogram(bh.Histogram):
 
 
 def build_name(
-    region: dict, sample: dict, systematic: dict, template: str = "Nominal"
+    region: Dict[str, Any],
+    sample: Dict[str, Any],
+    systematic: Dict[str, Any],
+    template: str = "Nominal",
 ) -> str:
     """construct a unique name for each histogram
 
     Args:
-        region (dict): containing all region information
-        sample (dict): containing all sample information
-        systematic (dict): containing all systematic information
+        region (Dict[str, Any]): containing all region information
+        sample (Dict[str, Any]): containing all sample information
+        systematic (Dict[str, Any]): containing all systematic information
         template (str): which template (nominal/up/down) to consider, defaults to "Nominal"
 
     Returns:

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -20,17 +20,17 @@ class Histogram(bh.Histogram):
     @classmethod
     def from_arrays(
         cls: Type[H],
-        bins: Union[List[Union[int, float]], np.ndarray],
-        yields: Union[List[Union[int, float]], np.ndarray],
-        stdev: Union[List[Union[int, float]], np.ndarray],
+        bins: Union[List[float], np.ndarray],
+        yields: Union[List[float], np.ndarray],
+        stdev: Union[List[float], np.ndarray],
     ) -> H:
         """construct a histogram from arrays of yields and uncertainties, the input
         can be lists of ints or floats, or numpy.ndarrays
 
         Args:
-            bins (Union[List[Union[int, float]], np.ndarray]): edges of histogram bins
-            yields (Union[List[Union[int, float]], np.ndarray]): yield per histogram bin
-            stdev (Union[List[Union[int, float]], np.ndarray]): statistical uncertainty of yield per bin
+            bins (Union[List[float], np.ndarray]): edges of histogram bins
+            yields (Union[List[float], np.ndarray]): yield per histogram bin
+            stdev (Union[List[float], np.ndarray]): statistical uncertainty of yield per bin
 
         Raises:
             ValueError: when amount of bins specified via bin edges and bin contents do not match

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import numpy as np
 
@@ -11,13 +11,15 @@ from . import histo
 log = logging.getLogger(__name__)
 
 
-def _check_for_override(systematic: dict, template: str, option: str) -> Optional[str]:
+def _check_for_override(
+    systematic: Dict[str, Any], template: str, option: str
+) -> Optional[str]:
     """Given a systematic and a string specifying which template is currently under consideration,
     check whether the systematic defines an override for an option. Return the override if it
     exists, otherwise return None.
 
     Args:
-        systematic (dict): containing all systematic information
+        systematic (Dict[str, Any]): containing all systematic information
         template (str): template to consider: "Nominal", "Up", "Down"
         option (str): the option for which the presence of an override is checked
 
@@ -28,16 +30,19 @@ def _check_for_override(systematic: dict, template: str, option: str) -> Optiona
 
 
 def _get_ntuple_path(
-    region: dict, sample: dict, systematic: dict, template: str
+    region: Dict[str, Any],
+    sample: Dict[str, Any],
+    systematic: Dict[str, Any],
+    template: str,
 ) -> Path:
     """determine the path to ntuples from which a histogram has to be built
     for non-nominal templates, override the nominal path if an alternative is
     specified for the template
 
     Args:
-        region (dict): containing all region information
-        sample (dict): containing all sample information
-        systematic (dict): containing all systematic information
+        region (Dict[str, Any]): containing all region information
+        sample (Dict[str, Any]): containing all sample information
+        systematic (Dict[str, Any]): containing all systematic information
         template (str): which template is considered: "Nominal", "Up", "Down"
 
     Returns:
@@ -54,11 +59,11 @@ def _get_ntuple_path(
     return path
 
 
-def _get_variable(region: dict) -> str:
+def _get_variable(region: Dict[str, Any]) -> str:
     """construct the variable the histogram will be binned in
 
     Args:
-        region (dict): containing all region information
+        region (Dict[str, Any]): containing all region information
 
     Returns:
         str: name of variable to bin histogram in
@@ -68,16 +73,19 @@ def _get_variable(region: dict) -> str:
 
 
 def _get_filter(
-    region: dict, sample: dict, systematic: dict, template: str
+    region: Dict[str, Any],
+    sample: Dict[str, Any],
+    systematic: Dict[str, Any],
+    template: str,
 ) -> Optional[str]:
     """construct the filter to be applied for event selection
     for non-nominal templates, override the nominal filter if an alternative is
     specified for the template
 
     Args:
-        region (dict): containing all region information
-        sample (dict): containing all sample information
-        systematic (dict): containing all systematic information
+        region (Dict[str, Any]): containing all region information
+        sample (Dict[str, Any]): containing all sample information
+        systematic (Dict[str, Any]): containing all systematic information
         template (str): which template is considered: "Nominal", "Up", "Down"
 
     Returns:
@@ -93,19 +101,24 @@ def _get_filter(
     return selection_filter
 
 
-def _get_weight(region: dict, sample: dict, systematic: dict, template: str) -> str:
+def _get_weight(
+    region: Dict[str, Any],
+    sample: Dict[str, Any],
+    systematic: Dict[str, Any],
+    template: str,
+) -> Optional[str]:
     """find the weight to be used for the events in the histogram
     for non-nominal templates, override the nominal weight if an alternative is
     specified for the template
 
     Args:
-        region (dict): containing all region information
-        sample (dict): containing all sample information
-        systematic (dict): containing all systematic information
+        region (Dict[str, Any]): containing all region information
+        sample (Dict[str, Any]): containing all sample information
+        systematic (Dict[str, Any]): containing all systematic information
         template (str): which template is considered: "Nominal", "Up", "Down"
 
     Returns:
-        str: weight used for events when filled into histograms
+        Optional[str]: weight used for events when filled into histograms, or None for no weight
     """
     weight = sample.get("Weight", None)
     # check whether a systematic is being processed
@@ -117,15 +130,17 @@ def _get_weight(region: dict, sample: dict, systematic: dict, template: str) -> 
     return weight
 
 
-def _get_position_in_file(sample: dict, systematic: dict, template: str) -> str:
+def _get_position_in_file(
+    sample: Dict[str, Any], systematic: Dict[str, Any], template: str
+) -> str:
     """the file might have some substructure, this specifies where in the file
     the data is
     for non-nominal templates, override the nominal position if an alternative is
     specified for the template
 
     Args:
-        sample (dict): containing all sample information
-        systematic (dict): containing all systematic information
+        sample (Dict[str, Any]): containing all sample information
+        systematic (Dict[str, Any]): containing all systematic information
         template (str): which template is considered: "Nominal", "Up", "Down"
 
     Returns:
@@ -141,13 +156,13 @@ def _get_position_in_file(sample: dict, systematic: dict, template: str) -> str:
     return position
 
 
-def _get_binning(region: dict) -> np.ndarray:
+def _get_binning(region: Dict[str, Any]) -> np.ndarray:
     """determine the binning to be used in a given region
     should eventually also support other ways of specifying bins,
     such as the amount of bins and the range to bin in
 
     Args:
-        region (dict): containing all region information
+        region (Dict[str, Any]): containing all region information
 
     Raises:
         NotImplementedError: when the binning is not explicitly defined
@@ -162,14 +177,14 @@ def _get_binning(region: dict) -> np.ndarray:
 
 
 def create_histograms(
-    config: dict, folder_path_str: str, method: str = "uproot"
+    config: Dict[str, Any], folder_path_str: str, method: str = "uproot"
 ) -> None:
     """generate all required histograms specified by a configuration file
     a tool providing histograms should provide bin yields and statistical
     uncertainties, as well as the bin edges
 
     Args:
-        config (dict): cabinetry configuration
+        config (Dict[str, Any]): cabinetry configuration
         folder_path_str (str): folder to save the histograms to
         method (str, optional): backend to use for histogram production, defaults to "uproot"
 

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 from pathlib import Path
+from typing import Any, Dict
 
 import numpy as np
 
@@ -11,7 +12,7 @@ from . import histo
 log = logging.getLogger(__name__)
 
 
-def _fix_stat_unc(histogram, name):
+def _fix_stat_unc(histogram: histo.H, name: str) -> None:
     """replace nan stat. unc. by zero for a histogram, modifies the
     histogram handed over in the argument
 
@@ -25,7 +26,7 @@ def _fix_stat_unc(histogram, name):
         histogram.stdev = np.nan_to_num(histogram.stdev, nan=0.0)
 
 
-def apply_postprocessing(histogram, name):
+def apply_postprocessing(histogram: histo.H, name: str) -> histo.H:
     """Create a new modified histogram, currently only calling the
     stat. uncertainty fix. The histogram in the function argument
     stays unchanged.
@@ -43,12 +44,12 @@ def apply_postprocessing(histogram, name):
     return adjusted_histogram
 
 
-def run(config, histogram_folder):
+def run(config: Dict[str, Any], histogram_folder: str) -> None:
     """apply post-processing as needed for all histograms
     this is very similar to template_builder.create_histograms() and should be refactored
 
     Args:
-        config (dict): cabinetry configuration
+        config (Dict[str, Any]): cabinetry configuration
         histogram_folder (str): folder containing the histograms
     """
     log.info("applying post-processing to histograms")

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import List
+from typing import Any, Dict, List
 
 import numpy as np
 
@@ -10,17 +10,17 @@ from . import histo
 log = logging.getLogger(__name__)
 
 
-def _build_figure_name(region, is_prefit):
+def _build_figure_name(region_name: str, is_prefit: bool) -> str:
     """construct a name for the file a figure is saved as
 
     Args:
-        region (dict): the region shown in the figure
+        region_name (str): name of the region shown in the figure
         is_prefit (bool): whether the figure shows the pre- or post-fit model
 
     Returns:
         str: name of the file the figure should be saved to
     """
-    figure_name = region.replace(" ", "-")
+    figure_name = region_name.replace(" ", "-")
     if is_prefit:
         figure_name += "_" + "prefit"
     else:
@@ -29,11 +29,17 @@ def _build_figure_name(region, is_prefit):
     return figure_name
 
 
-def data_MC(config, histogram_folder, figure_folder, prefit=True, method="matplotlib"):
+def data_MC(
+    config: Dict[str, Any],
+    histogram_folder: str,
+    figure_folder: str,
+    prefit: bool = True,
+    method: str = "matplotlib",
+) -> None:
     """draw a data/MC histogram, control whether it is pre- or postfit with a flag
 
     Args:
-        config (dict): cabinetry configuration
+        config (Dict[str, Any]): cabinetry configuration
         histogram_folder (str): path to the folder containing template histograms
         figure_folder (str): path to the folder to save figures in
         prefit (bool, optional): show the pre- or post-fit model, defaults to True


### PR DESCRIPTION
Adding type hints to `cabinetry`. For now they cover function arguments and return values. Checking is done mostly with `mypy`, for which configuration is added to `setup.cfg`. Two settings there are commented out, to be uncommented later when the remaining warnings can be resolved (those warnings are harmless for now).

Adding `mypy` to the CI for type checks.

Adding `mypy` and `flake8` to `pre-commit`.

The type hints uncovered some mistakes in the docstrings, which are fixed.

Besides `mypy`, `pytype` was also used to analyze `cabinetry`. `pytype` discovered another issue that `mypy` did not flag, but is slower to run. Should consider adding it to the CI eventually.

see also https://www.python.org/dev/peps/pep-0484/, https://www.python.org/dev/peps/pep-0526