### PR TITLE
feat: json schema for config

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,10 +40,6 @@ jobs:
         black --check --diff --verbose .
     - name: Run example
       run: |
-        ls -al
-        pwd
-        ls -al src/cabinetry/schemas
-        python -c "import cabinetry; print(cabinetry.__path__)"
         python util/create_ntuples.py
         python example.py
     - name: Test with pytest and generate coverage report

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,6 +40,8 @@ jobs:
         black --check --diff --verbose .
     - name: Run example
       run: |
+        ls -al
+        python -c "import cabinetry; print(cabinetry.__path__)"
         python util/create_ntuples.py
         python example.py
     - name: Test with pytest and generate coverage report

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,6 +41,8 @@ jobs:
     - name: Run example
       run: |
         ls -al
+        pwd
+        ls -al src/cabinetry/schemas
         python -c "import cabinetry; print(cabinetry.__path__)"
         python util/create_ntuples.py
         python example.py

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install cabinetry and dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install -e .[test]
+        python -m pip install .[test]
     - name: Static code analysis with flake8 and mypy
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,8 @@ build
 # sphinx
 docs/_build
 
+# json schemas
+!src/cabinetry/schemas/*json
+
 # reference for tests
 !tests/contrib/reference/*pdf

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,5 +47,8 @@ ignore_missing_imports = True
 [mypy-iminuit]
 ignore_missing_imports = True
 
+[mypy-jsonschema]
+ignore_missing_imports = True
+
 [pytype]
 inputs = src/cabinetry

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     url="https://github.com/alexander-held/cabinetry",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
-    package_data={"cabinetry": ["py.typed", "schemas/config.json"]},
+    package_data={"cabinetry": ["py.typed"]},
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         "pyhf>=0.3.2",
         "iminuit>1.4.0",
         "boost_histogram",
+        "jsonschema",
     ],
     extras_require=extras_require,
 )

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     url="https://github.com/alexander-held/cabinetry",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
-    package_data={"cabinetry": ["py.typed"]},
+    package_data={"cabinetry": ["py.typed", "schemas/config.json"]},
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Programming Language :: Python :: 3.6",

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -7,11 +7,6 @@ from typing import Any, Dict, List, Union
 import jsonschema
 import yaml
 
-
-REQUIRED_CONFIG_KEYS = ["General", "Samples", "Regions", "NormFactors"]
-
-OPTIONAL_CONFIG_KEYS = ["Systematics"]
-
 log = logging.getLogger(__name__)
 
 

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -1,7 +1,10 @@
+import json
 import logging
 from pathlib import Path
+import pkgutil
 from typing import Any, Dict, List, Union
 
+import jsonschema
 import yaml
 
 
@@ -29,7 +32,8 @@ def read(file_path_string: str) -> Dict[str, Any]:
 
 
 def validate(config: Dict[str, Any]) -> bool:
-    """test whether the config is valid
+    """check whether the config satisfies the json schema, and perform additional
+    checks to validate it
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
@@ -44,6 +48,13 @@ def validate(config: Dict[str, Any]) -> bool:
     Returns:
         bool: whether the validation was successful
     """
+    # load json schema for config and validate against it
+    schema_text = pkgutil.get_data(__name__, "schemas/config.json")
+    if schema_text is None:
+        raise FileNotFoundError("could not load config schema")
+    config_schema = json.loads(schema_text)
+    jsonschema.validate(instance=config, schema=config_schema)
+
     config_keys = config.keys()
 
     # check whether all required keys exist

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -55,28 +55,9 @@ def validate(config: Dict[str, Any]) -> bool:
     config_schema = json.loads(schema_text)
     jsonschema.validate(instance=config, schema=config_schema)
 
-    config_keys = config.keys()
-
-    # check whether all required keys exist
-    for required_key in REQUIRED_CONFIG_KEYS:
-        if required_key not in config_keys:
-            raise ValueError(f"missing required key in config: {required_key}")
-
-    # check whether all keys are known
-    for key in config_keys:
-        if key not in (REQUIRED_CONFIG_KEYS + OPTIONAL_CONFIG_KEYS):
-            raise ValueError(f"unknown key found: {key}")
-
     # check that there is exactly one data sample
     if sum([sample.get("Data", False) for sample in config["Samples"]]) != 1:
         raise NotImplementedError("can only handle cases with exactly one data sample")
-
-    # check that NormFactors have necessary values defined
-    for nf in config.get("NormFactors", []):
-        if not nf.get("Name", False):
-            raise ValueError(f"need to specify Name for NormFactor {nf}")
-        if not nf.get("Samples", False):
-            raise ValueError(f"need to specify Samples for NormFactor {nf}")
 
     # should also check here for conflicting settings
     ...

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -168,7 +168,7 @@
             "description": "a systematic uncertainty",
             "$$target": "#/definitions/systematic",
             "type": "object",
-            "required": ["Name", "Samples", "Type"],
+            "required": ["Name", "Samples", "Type", "Up", "Down"],
             "properties": {
                 "Name": {
                     "description": "name of the systematic uncertainty",

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -1,0 +1,245 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://github.com/alexander-held/cabinetry/blob/master/src/cabinetry/schemas/config.json",
+    "title": "cabinetry config schema",
+    "description": "full schema for the cabinetry configuration file",
+    "type": "object",
+    "required": ["General", "Regions", "Samples", "NormFactors"],
+    "properties": {
+        "General": {
+            "$ref": "#/definitions/general"
+        },
+        "Regions": {
+            "description": "list of regions",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "#/definitions/region"
+            },
+            "uniqueItems": true
+        },
+        "Samples": {
+            "description": "list of samples",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "#/definitions/sample"
+            },
+            "uniqueItems": true
+        },
+        "NormFactors": {
+            "description": "list of normalization factors",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "#/definitions/normfactor"
+            },
+            "uniqueItems": true
+        },
+        "Systematics": {
+            "description": "list of systematics",
+            "type": "array",
+            "minItems": 0,
+            "items": {
+                "$ref": "#/definitions/systematic"
+            },
+            "uniqueItems": true
+        }
+    },
+    "definitions": {
+        "general": {
+            "title": "General",
+            "$$target": "#/definitions/general",
+            "description": "general settings",
+            "type": "object",
+            "required": ["Measurement", "POI"],
+            "properties": {
+                "Measurement": {
+                    "description": "name of measurement",
+                    "type": "string"
+                },
+                "POI": {
+                    "description": "name of parameter of interest",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "region": {
+            "title": "Region",
+            "description": "a region of phase space",
+            "$$target": "#/definitions/region",
+            "type": "object",
+            "required": ["Name", "Filter", "Variable", "Binning"],
+            "properties": {
+                "Name": {
+                    "description": "name of the region",
+                    "type": "string"
+                },
+                "Filter": {
+                    "description": "selection criteria to apply",
+                    "type": "string"
+                },
+                "Variable": {
+                    "description": "variable to bin in",
+                    "type": "string"
+                },
+                "Binning": {
+                    "description": "binning to use in histograms",
+                    "type": "array",
+                    "minItems": 2,
+                    "items": {
+                        "description": "bins",
+                        "type": "number"
+                    },
+                    "uniqueItems": true
+                }
+            },
+            "additionalProperties": false
+        },
+        "sample": {
+            "title": "Sample",
+            "description": "a sample of a specific process or data",
+            "$$target": "#/definitions/sample",
+            "type": "object",
+            "required": ["Name", "Path", "Tree"],
+            "properties": {
+                "Name": {
+                    "description": "name of the sample",
+                    "type": "string"
+                },
+                "Path": {
+                    "description": "path to file containing sample",
+                    "type": "string"
+                },
+                "Tree": {
+                    "description": "name of tree",
+                    "type": "string"
+                },
+                "Weight": {
+                    "description": "weight to apply to events",
+                    "type": "string"
+                },
+                "Data": {
+                    "description": "if it is a data sample",
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
+        },
+        "normfactor": {
+            "title": "NormFactor",
+            "description": "a normalization factor affecting one or more samples",
+            "$$target": "#/definitions/normfactor",
+            "type": "object",
+            "required": ["Name", "Samples"],
+            "properties": {
+                "Name": {
+                    "description": "name of the normalization factor",
+                    "type": "string"
+                },
+                "Samples": {
+                    "$ref": "#/definitions/samples_setting"
+                },
+                "Nominal": {
+                    "description": "nominal value",
+                    "type": "number"
+                },
+                "Bounds": {
+                    "description": "lower and upper bound",
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": {
+                        "description": "bounds",
+                        "type": "number"
+                    },
+                    "uniqueItems": true
+                },
+                "Fixed": {
+                    "description": "if the normalization factor is a constant",
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
+        },
+        "systematic": {
+            "title": "Systematic",
+            "description": "a systematic uncertainty",
+            "$$target": "#/definitions/systematic",
+            "type": "object",
+            "required": ["Name", "Samples", "Type"],
+            "properties": {
+                "Name": {
+                    "description": "name of the systematic uncertainty",
+                    "type": "string"
+                },
+                "Samples": {
+                    "$ref": "#/definitions/samples_setting"
+                },
+                "Type": {
+                    "description": "type of systematic uncertainty",
+                    "type": "string",
+                    "enum": ["Normalization", "NormPlusShape"]
+                },
+                "Up": {
+                    "$ref": "#/definitions/template"
+                },
+                "Down": {
+                    "$ref": "#/definitions/template"
+                }
+            },
+            "additionalProperties": false
+        },
+        "template": {
+            "title": "Template",
+            "$$target": "#/definitions/template",
+            "description": "a systematics template (up/down)",
+            "type": "object",
+            "properties": {
+                "Path": {
+                    "description": "path to file",
+                    "type": "string"
+                },
+                "Tree": {
+                    "description": "name of tree",
+                    "type": "string"
+                },
+                "Weight": {
+                    "description": "weight to apply",
+                    "type": "string"
+                },
+                "Normalization": {
+                    "description": "normalization uncertainty to apply",
+                    "type": "number"
+                },
+                "Symmetrize": {
+                    "description": "whether to apply symmetrization",
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
+        },
+        "samples_setting": {
+            "title": "Sample setting",
+            "$$target": "#/definitions/samples_setting",
+            "oneOf": [
+                {
+                    "description": "single affected sample",
+                    "type": "string"
+                },
+                {
+                    "description": "multiple affected samples",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "description": "single affected sample",
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                }
+            ]
+        }
+    },
+    "additionalProperties": false
+}

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://github.com/alexander-held/cabinetry/blob/master/src/cabinetry/schemas/config.json",
+    "$id": "https://raw.githubusercontent.com/alexander-held/cabinetry/master/src/cabinetry/schemas/config.json",
     "title": "cabinetry config schema",
     "description": "full schema for the cabinetry configuration file",
     "type": "object",


### PR DESCRIPTION
Adding a JSON schema https://json-schema.org/ for the `cabinetry` configuration. When reading a config file, it is validated against the schema.

Switching from using `pip install -e .` to `pip install .` in the CI to make sure it fails if required package data is not included.