### PR TITLE
docs: config schema

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,5 +1,5 @@
 API
-=========
+===
 
 .. contents::
     :local:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,6 +5,8 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx_rtd_theme",
+    "sphinx_copybutton",
+    "sphinx-jsonschema",
 ]
 
 import sphinx_rtd_theme

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -2,9 +2,9 @@ Configuration schema
 ====================
 
 The configuration schema for `cabinetry` is given below.
-It is defined via a `json schema <https://json-schema.org/>`_ that can be found in `src/cabinetry/schemas/config.json <https://github.com/alexander-held/cabinetry/blob/master/src/cabinetry/schemas/config.json>`_.
+It is defined via a `json schema <https://json-schema.org/>`_ that can be found at `src/cabinetry/schemas/config.json <https://github.com/alexander-held/cabinetry/blob/master/src/cabinetry/schemas/config.json>`_.
 
-The "General" block holds general settings, followed by blocks that take lists of objects: regions, samples, normalization factors, and systematics.
+The `General` block holds general settings, followed by blocks that take lists of objects: regions, samples, normalization factors, and systematics.
 The `Regions`, `Samples` and `NormFactors` blocks are required, while `Systematics` is optional.
 Settings shown in bold are required.
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,0 +1,33 @@
+Config schema
+=============
+
+The config schema is given below.
+The "General" block holds general settings, followed by blocks that take lists of objects: regions, samples, normalization factors, and systematics.
+
+.. jsonschema:: ../src/cabinetry/schemas/config.json#/properties/General
+.. jsonschema:: ../src/cabinetry/schemas/config.json#/properties/Regions
+.. jsonschema:: ../src/cabinetry/schemas/config.json#/properties/Samples
+.. jsonschema:: ../src/cabinetry/schemas/config.json#/properties/NormFactors
+.. jsonschema:: ../src/cabinetry/schemas/config.json#/properties/Systematics
+
+Details about the setting blocks:
+---------------------------------
+
+.. jsonschema:: ../src/cabinetry/schemas/config.json#/definitions/general
+
+.. jsonschema:: ../src/cabinetry/schemas/config.json#/definitions/region
+
+.. jsonschema:: ../src/cabinetry/schemas/config.json#/definitions/sample
+
+.. jsonschema:: ../src/cabinetry/schemas/config.json#/definitions/normfactor
+
+.. jsonschema:: ../src/cabinetry/schemas/config.json#/definitions/systematic
+
+Common options:
+---------------
+
+.. jsonschema:: ../src/cabinetry/schemas/config.json#/definitions/template
+
+.. jsonschema:: ../src/cabinetry/schemas/config.json#/definitions/samples_setting
+
+

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,8 +1,12 @@
-Config schema
-=============
+Configuration schema
+====================
 
-The config schema is given below.
+The configuration schema for `cabinetry` is given below.
+It is defined via a `json schema <https://json-schema.org/>`_ that can be found in `src/cabinetry/schemas/config.json <https://github.com/alexander-held/cabinetry/blob/master/src/cabinetry/schemas/config.json>`_.
+
 The "General" block holds general settings, followed by blocks that take lists of objects: regions, samples, normalization factors, and systematics.
+The `Regions`, `Samples` and `NormFactors` blocks are required, while `Systematics` is optional.
+Settings shown in bold are required.
 
 .. jsonschema:: ../src/cabinetry/schemas/config.json#/properties/General
 .. jsonschema:: ../src/cabinetry/schemas/config.json#/properties/Regions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@
    :hidden:
    :maxdepth: 1
 
-
+   config
    api
    license
 

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,12 @@ extras_require["test"] = sorted(
         ]
     )
 )
+extras_require["docs"] = sorted(
+    set("sphinx", "sphinx-copybutton", "sphinx-jsonschema", "sphinx-rtd-theme")
+)
+
 extras_require["develop"] = sorted(
-    set(extras_require["test"] + ["pre-commit", "twine"])
+    set(extras_require["test"] + extras_require["docs"] + ["pre-commit", "twine"])
 )
 extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras_require["test"] = sorted(
     )
 )
 extras_require["docs"] = sorted(
-    set("sphinx", "sphinx-copybutton", "sphinx-jsonschema", "sphinx-rtd-theme")
+    set(["sphinx", "sphinx-copybutton", "sphinx-jsonschema", "sphinx-rtd-theme"])
 )
 
 extras_require["develop"] = sorted(


### PR DESCRIPTION
Adding the config schema introduced in #69 to the docs built with sphinx, plus minor cleanup of the docs.