### PR TITLE
feat: expressions for variables and weights

### DIFF
--- a/config_example.yml
+++ b/config_example.yml
@@ -44,7 +44,7 @@ Systematics:
 
   - Name: "WeightBasedModeling"
     Up:
-      Weight: "1.0*weight_up"
+      Weight: "weight_up"
     Down:
       Weight: "0.7*weight"
     Samples: "Background"

--- a/config_example.yml
+++ b/config_example.yml
@@ -44,9 +44,9 @@ Systematics:
 
   - Name: "WeightBasedModeling"
     Up:
-      Weight: "weight_up"
+      Weight: "1.0*weight_up"
     Down:
-      Weight: "weight_down"
+      Weight: "1.0*weight_down"
     Samples: "Background"
     Type: "NormPlusShape"
 

--- a/config_example.yml
+++ b/config_example.yml
@@ -46,7 +46,7 @@ Systematics:
     Up:
       Weight: "1.0*weight_up"
     Down:
-      Weight: "1.0*weight_down"
+      Weight: "0.7*weight"
     Samples: "Background"
     Type: "NormPlusShape"
 

--- a/src/cabinetry/contrib/histogram_creation.py
+++ b/src/cabinetry/contrib/histogram_creation.py
@@ -38,7 +38,13 @@ def from_uproot(
     observables = tree.arrays(variable, cut=selection_filter, library="np")[variable]
 
     if weight is not None:
-        weights = tree.arrays(weight, cut=selection_filter, library="np")[weight]
+        try:
+            # if the weight is just a number, no branch needs to be read
+            weights = np.ones_like(observables) * float(weight)
+        except ValueError:
+            # evaluate the expression with uproot4
+            weights = tree.arrays(weight, cut=selection_filter, library="np")[weight]
+
     else:
         weights = np.ones_like(observables)
 

--- a/src/cabinetry/contrib/histogram_creation.py
+++ b/src/cabinetry/contrib/histogram_creation.py
@@ -35,10 +35,10 @@ def from_uproot(
     # extract observable and weights
     # need the last [variable] to select the right entry out of the dict
     # this only reads the observable branch and branches needed for the cut into memory
-    observables = tree[variable].arrays(cut=selection_filter, library="np")[variable]
+    observables = tree.arrays(variable, cut=selection_filter, library="np")[variable]
 
     if weight is not None:
-        weights = tree[weight].arrays(cut=selection_filter, library="np")[weight]
+        weights = tree.arrays(weight, cut=selection_filter, library="np")[weight]
     else:
         weights = np.ones_like(observables)
 

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -240,8 +240,8 @@ def create_histograms(
                             pos_in_file,
                             variable,
                             bins,
-                            weight,
-                            selection_filter,
+                            weight=weight,
+                            selection_filter=selection_filter,
                         )
 
                     elif method == "ServiceX":

--- a/tests/contrib/test_histogram_creation.py
+++ b/tests/contrib/test_histogram_creation.py
@@ -8,11 +8,13 @@ def test_from_uproot(tmp_path, utils):
     treename = "tree"
     varname = "var"
     var_array = [1.1, 2.3, 3.0, 3.2]
-    weightname = "weight"
+    weightname_write = "weight"
     weight_array = [1.0, 1.0, 2.0, 1.0]
     bins = [1, 2, 3, 4]
     # create something to read
-    utils.create_ntuple(fname, treename, varname, var_array, weightname, weight_array)
+    utils.create_ntuple(
+        fname, treename, varname, var_array, weightname_write, weight_array
+    )
 
     # read - no weights or selection
     yields, stdev = histogram_creation.from_uproot(fname, treename, varname, bins)
@@ -28,11 +30,20 @@ def test_from_uproot(tmp_path, utils):
     assert np.allclose(stdev, [1, 1, 1])
 
     # read - with weight
+    weightname_apply = "weight*2"
     yields, stdev = histogram_creation.from_uproot(
-        fname, treename, varname, bins, weight=weightname
+        fname, treename, varname, bins, weight=weightname_apply
     )
-    assert np.allclose(yields, [1, 1, 3])
-    assert np.allclose(stdev, [1, 1, 2.23606798])
+    assert np.allclose(yields, [2, 2, 6])
+    assert np.allclose(stdev, [2, 2, 4.47213595])
+
+    # read - with weight that is only a float
+    weight_float = "2.0"
+    yields, stdev = histogram_creation.from_uproot(
+        fname, treename, varname, bins, weight=weight_float
+    )
+    assert np.allclose(yields, [2, 2, 4])
+    assert np.allclose(stdev, [2, 2, 2.82842712])
 
 
 def test__bin_data():


### PR DESCRIPTION
`uproot4` supports parsing python expressions in `TTree.arrays` through `uproot4.compute.python.ComputePython`. This small update makes use of this functionality to support parsing expressions (and calculating the results) for the variable to bin in (`Region` setting) and all weight settings.