### PR TITLE
docs: providing documentation on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,4 +21,4 @@ python:
       path: .
       extra_requirements:
         - docs
-          contrib
+        - contrib

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,24 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+          contrib

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # cabinetry
 
 [![CI status](https://github.com/alexander-held/cabinetry/workflows/CI/badge.svg)](https://github.com/alexander-held/cabinetry/actions?query=workflow%3ACI)
+[![Documentation Status](https://readthedocs.org/projects/cabinetry/badge/?version=latest)](https://cabinetry.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/alexander-held/cabinetry/branch/master/graph/badge.svg)](https://codecov.io/gh/alexander-held/cabinetry)
 [![PyPI version](https://badge.fury.io/py/cabinetry.svg)](https://badge.fury.io/py/cabinetry)
 [![python version](https://img.shields.io/pypi/pyversions/cabinetry.svg)](https://pypi.org/project/cabinetry/)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,12 +12,16 @@
 `cabinetry` is a tool to build and steer (profile likelihood) template fits with applications in high energy physics in mind.
 It acts as an interface to many powerful tools to make it easier for an analyzer to run their statistical inference pipeline.
 
-This documentation can be built and viewed via
+This documentation can be viewed `on Read the Docs <https://cabinetry.readthedocs.io/>`_ or locally via
 
 .. code-block:: bash
 
    sphinx-build docs docs/_build
    open docs/_build/index.html
+
+It contains a description of the `cabinetry` configuration file schema, as well as the public facing API.
+
+See the `README on github <https://github.com/alexander-held/cabinetry/blob/master/README.md>`_ for an example of using `cabinetry`.
 
 Acknowledgements
 ----------------


### PR DESCRIPTION
Setting up readthedocs https://docs.readthedocs.io/en/stable/index.html to host `cabinetry` documentation.