### PR TITLE
refactor: use new pyhf optimizer API

### DIFF
--- a/example.py
+++ b/example.py
@@ -37,10 +37,14 @@ if __name__ == "__main__":
 
     # run a fit
     ws = cabinetry.workspace.load(workspace_path)
-    cabinetry.fit.fit(ws)
+    bestfit, uncertainty, labels, _, corr_mat = cabinetry.fit.fit(ws)
+
+    # visualize pulls and correlation matrix
+    figure_folder = "figures/"
+    cabinetry.visualize.pulls(bestfit, uncertainty, labels, "figures/")
+    cabinetry.visualize.correlation_matrix(corr_mat, labels, "figures/")
 
     # visualize templates and data
-    figure_folder = "figures/"
     cabinetry.visualize.data_MC(
-        cabinetry_config, histo_folder, figure_folder, prefit=True, method="matplotlib"
+        cabinetry_config, histo_folder, figure_folder, prefit=True
     )

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     install_requires=[
         "numpy",
         "pyyaml",
-        "pyhf>=0.3.2",
+        "pyhf>=0.5.0",
         "iminuit>1.4.0",
         "boost_histogram",
         "jsonschema",

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "pyyaml",
         "pyhf>=0.5.0",
         "iminuit>1.4.0",
-        "boost_histogram",
+        "boost_histogram<0.10.1",
         "jsonschema",
     ],
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "pyyaml",
         "pyhf>=0.5.0",
         "iminuit>1.4.0",
-        "boost_histogram<0.10.1",
+        "boost_histogram!=0.10.1",
         "jsonschema",
     ],
     extras_require=extras_require,

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -46,7 +46,9 @@ def print_results(
         log.info(f"{l_with_spacer}: {bestfit[i]:.6f} +/- {uncertainty[i]:.6f}")
 
 
-def fit(spec: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray, List[str], float]:
+def fit(
+    spec: Dict[str, Any]
+) -> Tuple[np.ndarray, np.ndarray, List[str], float, np.ndarray]:
     """perform an unconstrained maximum likelihood fit with pyhf and report
     the results of the fit
 
@@ -54,11 +56,12 @@ def fit(spec: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray, List[str], float]
         spec (Dict[str, Any]): a pyhf workspace specificaton
 
     Returns:
-        Tuple[np.ndarray, np.ndarray, List[str], float]:
+        Tuple[np.ndarray, np.ndarray, List[str], float, np.ndarray]:
             - best-fit positions of parameters
             - parameter uncertainties
             - parameter names
             - -2 log(likelihood) at best-fit point
+            - correlation matrix
     """
     log.info("performing unconstrained fit")
 
@@ -74,11 +77,12 @@ def fit(spec: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray, List[str], float]
     bestfit = result[:, 0]
     uncertainty = result[:, 1]
     best_twice_nll = float(result_obj.fun)  # convert 0-dim np.ndarray to float
+    corr_mat = result_obj.minuit.np_matrix(correlation=True)
     labels = get_parameter_names(model)
 
     print_results(bestfit, uncertainty, labels)
     log.debug(f"-2 log(L) = {best_twice_nll:.6f} at the best-fit point")
-    return bestfit, uncertainty, labels, best_twice_nll
+    return bestfit, uncertainty, labels, best_twice_nll, corr_mat
 
 
 def custom_fit(
@@ -86,13 +90,13 @@ def custom_fit(
 ) -> Tuple[np.ndarray, np.ndarray, List[str], float, np.ndarray]:
     """Perform an unconstrained maximum likelihood fit with iminuit and report
     the result. Compared to fit(), this does not use the pyhf.infer API for more
-    control over the minimization, and it returns the correlation matrix.
+    control over the minimization.
 
     Args:
         spec (Dict[str, Any]): a pyhf workspace specificaton
 
     Returns:
-        Tuple[np.ndarray, np.ndarray, List[str], float, numpy.ndarray]:
+        Tuple[np.ndarray, np.ndarray, List[str], float, np.ndarray]:
             - best-fit positions of parameters
             - parameter uncertainties
             - parameter names

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -67,11 +67,13 @@ def fit(spec: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray, List[str], float]
     data = workspace.data(model)
 
     pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=True))
-    result, best_twice_nll = pyhf.infer.mle.fit(
-        data, model, return_uncertainties=True, return_fitted_val=True
+    result, result_obj = pyhf.infer.mle.fit(
+        data, model, return_uncertainties=True, return_result_obj=True
     )
+
     bestfit = result[:, 0]
     uncertainty = result[:, 1]
+    best_twice_nll = float(result_obj.fun)  # convert 0-dim np.ndarray to float
     labels = get_parameter_names(model)
 
     print_results(bestfit, uncertainty, labels)

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 
@@ -115,8 +115,8 @@ def pulls(
     bestfit: np.ndarray,
     uncertainty: np.ndarray,
     labels: List[str],
-    exclude_list: List[str],
     figure_folder: str,
+    exclude_list: Optional[List[str]] = None,
     method: str = "matplotlib",
 ) -> None:
     """produce a pull plot of parameter results and uncertainties
@@ -125,24 +125,27 @@ def pulls(
         bestfit (np.ndarray): best-fit results for parameters
         uncertainty (np.ndarray): parameter uncertainties
         labels (List[str]): parameter names
-        exclude_list (List[str]): list of parameters to exclude from plot
         figure_folder (str): path to the folder to save figures in
+        exclude_list (Optional[List[str]], optional): list of parameters to exclude from plot, defaults to None
+            (nothing excluded)
         method (str, optional): what backend to use for plotting, defaults to "matplotlib"
 
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
     """
     figure_path = Path(figure_folder) / "pulls.pdf"
+    labels_np = np.asarray(labels)
 
     # filter out parameters
-    mask = [True if label not in exclude_list else False for label in labels]
-    bestfit = bestfit[mask]
-    uncertainty = uncertainty[mask]
-    labels = np.asarray(labels)[mask]
+    if exclude_list is not None:
+        mask = [True if label not in exclude_list else False for label in labels_np]
+        bestfit = bestfit[mask]
+        uncertainty = uncertainty[mask]
+        labels_np = labels_np[mask]
 
     if method == "matplotlib":
         from cabinetry.contrib import matplotlib_visualize
 
-        matplotlib_visualize.pulls(bestfit, uncertainty, labels, figure_path)
+        matplotlib_visualize.pulls(bestfit, uncertainty, labels_np, figure_path)
     else:
         raise NotImplementedError(f"unknown backend: {method}")

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -64,11 +64,12 @@ def test_print_results(caplog):
 # due to different numpy versions used in dependencies
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_fit(example_spec):
-    bestfit, uncertainty, labels, best_twice_nll = fit.fit(example_spec)
+    bestfit, uncertainty, labels, best_twice_nll, corr_mat = fit.fit(example_spec)
     assert np.allclose(bestfit, [0.99998772, 9.16255687])
     assert np.allclose(uncertainty, [0.04954955, 0.61348804])
     assert labels == ["staterror_Signal-Region", "Signal strength"]
     assert np.allclose(best_twice_nll, 3.83054341)
+    assert np.allclose(corr_mat, [[1.0, -0.73366055], [-0.73366055, 1.0]])
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -27,7 +27,7 @@ def test_integration(tmp_path, ntuple_creator):
     ws = cabinetry.workspace.build(cabinetry_config, histo_folder)
     cabinetry.workspace.save(ws, workspace_path)
     ws = cabinetry.workspace.load(workspace_path)
-    bestfit, uncertainty, _, best_twice_nll = cabinetry.fit.fit(ws)
+    bestfit, uncertainty, _, best_twice_nll, corr_mat = cabinetry.fit.fit(ws)
 
     bestfit_expected = [
         1.00124934,
@@ -50,6 +50,89 @@ def test_integration(tmp_path, ntuple_creator):
         0.90353740,
     ]
     best_twice_nll_expected = 17.199087
+    corr_mat_expected = [
+        [
+            1.0,
+            0.05741159,
+            0.01948892,
+            -0.02326599,
+            0.0077079,
+            0.19230206,
+            0.08525489,
+            -0.12724928,
+        ],
+        [
+            0.05741159,
+            1.0,
+            0.00979333,
+            -0.00597878,
+            -0.01864312,
+            -0.12725387,
+            -0.20681375,
+            0.16167847,
+        ],
+        [
+            0.01948892,
+            0.00979333,
+            1.0,
+            0.06583417,
+            0.00240035,
+            0.04198489,
+            0.02614081,
+            -0.11107066,
+        ],
+        [
+            -0.02326599,
+            -0.00597878,
+            0.06583417,
+            1.0,
+            -0.00156359,
+            -0.03826249,
+            -0.0178134,
+            -0.06751349,
+        ],
+        [
+            0.0077079,
+            -0.01864312,
+            0.00240035,
+            -0.00156359,
+            1.0,
+            0.08306285,
+            -0.14175595,
+            -0.17519639,
+        ],
+        [
+            0.19230206,
+            -0.12725387,
+            0.04198489,
+            -0.03826249,
+            0.08306285,
+            1.0,
+            0.92056977,
+            -0.92448677,
+        ],
+        [
+            0.08525489,
+            -0.20681375,
+            0.02614081,
+            -0.0178134,
+            -0.14175595,
+            0.92056977,
+            1.0,
+            -0.88499252,
+        ],
+        [
+            -0.12724928,
+            0.16167847,
+            -0.11107066,
+            -0.06751349,
+            -0.17519639,
+            -0.92448677,
+            -0.88499252,
+            1.0,
+        ],
+    ]
     assert np.allclose(bestfit, bestfit_expected)
     assert np.allclose(uncertainty, uncertainty_expected)
     assert np.allclose(best_twice_nll, best_twice_nll_expected)
+    assert np.allclose(corr_mat, corr_mat_expected)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -135,4 +135,4 @@ def test_integration(tmp_path, ntuple_creator):
     assert np.allclose(bestfit, bestfit_expected)
     assert np.allclose(uncertainty, uncertainty_expected)
     assert np.allclose(best_twice_nll, best_twice_nll_expected)
-    assert np.allclose(corr_mat, corr_mat_expected)
+    assert np.allclose(corr_mat, corr_mat_expected, rtol=5e-5)

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -104,23 +104,41 @@ def test_pulls(mock_draw):
     exclude_list = ["a"]
     folder_path = "tmp"
 
-    expected_bestfit = np.asarray([1.0, 1.1])
-    expected_uncertainty = np.asarray([1.0, 0.7])
-    expected_labels = np.asarray(["b", "c"])
+    filtered_bestfit = np.asarray([1.0, 1.1])
+    filtered_uncertainty = np.asarray([1.0, 0.7])
+    filtered_labels = np.asarray(["b", "c"])
     figure_path = Path(folder_path) / "pulls.pdf"
 
+    # with filtering
     visualize.pulls(
-        bestfit, uncertainty, labels, exclude_list, folder_path, method="matplotlib"
+        bestfit,
+        uncertainty,
+        labels,
+        folder_path,
+        exclude_list=exclude_list,
+        method="matplotlib",
     )
 
     mock_draw.assert_called_once()
-    assert np.allclose(mock_draw.call_args[0][0], expected_bestfit)
-    assert np.allclose(mock_draw.call_args[0][1], expected_uncertainty)
+    assert np.allclose(mock_draw.call_args[0][0], filtered_bestfit)
+    assert np.allclose(mock_draw.call_args[0][1], filtered_uncertainty)
     assert np.any(
         [
-            mock_draw.call_args[0][2][i] == expected_labels[i]
-            for i in range(len(expected_labels))
+            mock_draw.call_args[0][2][i] == filtered_labels[i]
+            for i in range(len(filtered_labels))
         ]
+    )
+    assert mock_draw.call_args[0][3] == figure_path
+    assert mock_draw.call_args[1] == {}
+
+    # without filtering
+    visualize.pulls(
+        bestfit, uncertainty, labels, folder_path, method="matplotlib",
+    )
+    assert np.allclose(mock_draw.call_args[0][0], bestfit)
+    assert np.allclose(mock_draw.call_args[0][1], uncertainty)
+    assert np.any(
+        [mock_draw.call_args[0][2][i] == labels[i] for i in range(len(labels))]
     )
     assert mock_draw.call_args[0][3] == figure_path
     assert mock_draw.call_args[1] == {}
@@ -128,5 +146,10 @@ def test_pulls(mock_draw):
     # unknown plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
         visualize.pulls(
-            bestfit, uncertainty, labels, exclude_list, folder_path, method="unknown"
+            bestfit,
+            uncertainty,
+            labels,
+            folder_path,
+            exclude_list=exclude_list,
+            method="unknown",
         )


### PR DESCRIPTION
Following the `pyhf` refactor https://github.com/scikit-hep/pyhf/pull/951, switch to using the new `return_result_obj=True` keyword to obtain additional information from the minimizer. Also raise the minimum `pyhf` version to 0.5.0, which is the first version to include this API update.

In addition, adding pull plot / correlation matrix plot to the example.

Temporarily fixing the `boost-histogram` version until https://github.com/scikit-hep/boost-histogram/issues/437 is resolved.