### PR TITLE
chore: flake8-print checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: 3.8.3
     hooks:
     -   id: flake8
-        additional_dependencies: [flake8-bugbear, flake8-import-order]
+        additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.1.0
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,9 @@ count = True
 statistics = True
 import-order-style = google
 application-import-names = cabinetry, util
+# ignore print statements in example
+per-file-ignores =
+    example.py: T
 
 [mypy]
 files = src/cabinetry

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ extras_require["test"] = sorted(
             "flake8",
             "flake8-bugbear",
             "flake8-import-order",
+            "flake8-print",
             "mypy",
             "black;python_version>='3.6'",  # Black is Python3 only
         ]


### PR DESCRIPTION
Adding `flake8-print` to setup extras and pre-commit to prevent accidental commits of print statements to the library.