### PR TITLE
feat: user-defined overrides for template histogram handling

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -1,0 +1,92 @@
+Advanced topics
+===============
+
+Overrides for template building
+-------------------------------
+
+Introduction
+^^^^^^^^^^^^
+
+It is possible to define functions that are called when `cabinetry` tries to construct a template histogram.
+Such functions need to accept four arguments in the following order:
+
+- a dictionary with information about the region being processed,
+- a dictionary with information about the sample being processed,
+- a dictionary with information about the systematic being processed,
+- a string with the name of the template being processed: `Nominal`, `Up` or `Down`.
+
+The function needs to return a `boost-histogram Histogram <https://boost-histogram.readthedocs.io/en/latest/usage/histogram.html>`_.
+This histogram is then further processed in `cabinetry`.
+
+Example
+^^^^^^^
+
+The example below defines a function `build_data_hist`.
+The decorator specifies that this function should be applied to all histograms for samples with name `Data`.
+It is also possible to specify `region_name`, `systematic_name` and `template` for the names of the region, systematic and template.
+When no user-defined function matches a given histogram that has to be produced, `cabinetry` falls back to use the default histogram creation methods.
+
+.. code-block:: python
+
+    import boost_histogram as bh
+    import cabinetry
+
+    my_router = cabinetry.route.Router()
+
+    # define a custom template builder function that is executed for data samples
+    @my_router.register_template_builder(sample_name="Data")
+    def build_data_hist(
+        region: dict, sample: dict, systematic: dict, template: str
+    ) -> bh.Histogram:
+        hist = bh.Histogram(
+            bh.axis.Variable(reg["Binning"], underflow=False, overflow=False),
+            storage=bh.storage.Weight(),
+        )
+        yields = np.asarray([17, 12, 25, 20])
+        variance = np.asarray([1.5, 1.2, 1.8, 1.6])
+        hist[...] = np.stack([yields, variance], axis=-1)
+        return hist
+
+
+    cabinetry.template_builder.create_histograms(
+        cabinetry_config, histo_folder, method="uproot", router=my_router
+    )
+
+The instance of `cabinetry.route.Router` is handed to `cabinetry.template_builder.create_histograms` to enable the use of `build_data_hist`.
+
+The function `build_data_hist` in this example always returns the same histogram.
+Given that the dictionaries in the function signature provide additional information, it is for example possible to return different yields per region:
+
+.. code-block:: python
+
+    if region["Name"] == "Signal_region":
+        yields = np.asarray([17, 12, 25, 20])
+    elif region["Name"] == "Background_region":
+        yields = np.asarray([102, 121, 138, 154])
+
+
+Wildcards and multiple requirements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It is also possible to use wildcards to specify which templates a function should be applied to.
+The implementation currently makes use of `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_.
+The following decorator
+
+.. code-block:: python
+
+    @my_router.register_template_builder(sample_name="ttbar_*")
+
+means that the function will for example be applied if the sample name is `ttbar_ljets` or `ttbar_dil`, but not if it is `single_top`.
+All conditions need to be fulfilled to apply a user-defined function, so
+
+.. code-block:: python
+
+    @my_router.register_template_builder(
+        region_name="signal_region",
+        sample_name="signal",
+        systematic="alpha_S",
+        template="*",
+    )
+
+means that for the decorated function to be executed, the region name needs to be `signal_region`, the sample needs to be called `signal`, the systematic needs to be `alpha_S`, but there is no restriction to the template name.
+Omitting `template` from the arguments, or using the default `template=None` has the same result.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14,7 +14,7 @@ cabinetry.configuration
 
 
 cabinetry.route
--------------------
+---------------
 
 .. automodule:: cabinetry.route
    :members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,10 +13,10 @@ cabinetry.configuration
    :members:
 
 
-cabinetry.fit
--------------
+cabinetry.route
+-------------------
 
-.. automodule:: cabinetry.fit
+.. automodule:: cabinetry.route
    :members:
 
 
@@ -41,17 +41,24 @@ cabinetry.template_postprocessor
    :members:
 
 
-cabinetry.visualize
--------------------
-
-.. automodule:: cabinetry.visualize
-   :members:
-
-
 cabinetry.workspace
 -------------------
 
 .. automodule:: cabinetry.workspace
+   :members:
+
+
+cabinetry.fit
+-------------
+
+.. automodule:: cabinetry.fit
+   :members:
+
+
+cabinetry.visualize
+-------------------
+
+.. automodule:: cabinetry.visualize
    :members:
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@
    :maxdepth: 1
 
    config
+   advanced
    api
    license
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,7 @@
 [tool:pytest]
 addopts = --cov=cabinetry --cov-report html --cov-report term-missing --cov-branch --typeguard-packages=cabinetry
+filterwarnings =
+    ignore::DeprecationWarning:uproot:
 
 [flake8]
 max-complexity = 10

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -1,5 +1,6 @@
 from . import configuration  # NOQA
 from . import fit  # NOQA
+from . import route  # NOQA
 from . import template_builder  # NOQA
 from . import template_postprocessor  # NOQA
 from . import visualize  # NOQA

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -220,7 +220,7 @@ def apply_to_all_templates(
 
                     log.debug(
                         f"      variation {systematic['Name']}"
-                        f" {template if template != 'Nominal' else ''}"
+                        f"{' ' + template if template != 'Nominal' else ''}"
                     )
 
                     func_override = None

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -120,7 +120,7 @@ class Router:
 
         Returns:
             Optional[ProcessorFunc]: processor function matching the description,
-                or None if no matches are found
+            or None if no matches are found
         """
         matches = []
         for processor in processor_list:
@@ -161,7 +161,7 @@ class Router:
 
         Returns:
             Optional[ProcessorFunc]: template builder function matching the description,
-                or None if no matches are found
+            or None if no matches are found
         """
         return self._find_match(
             self.template_builders, region_name, sample_name, systematic_name, template

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -1,0 +1,242 @@
+import fnmatch
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+from . import configuration
+
+log = logging.getLogger(__name__)
+
+# type of a function processing templates
+ProcessorFunc = Callable[[Dict[str, Any], Dict[str, Any], Dict[str, Any], str], None]
+
+# type of a function called with names of region-sample-systematic-template,
+# which returns either a ProcessorFunc or None
+MatchFunc = Callable[[str, str, str, str], Optional[ProcessorFunc]]
+
+
+class Router:
+    """holds user-defined processing functions, and provides functions matching
+    a pattern to apply the right function to each template
+    """
+
+    def __init__(self) -> None:
+        # initialize all lists of processor types the user can specify
+        self.template_builders: List[Dict[str, Any]] = []
+
+    def _register_processor(
+        self,
+        processor_list: List[Dict[str, Any]],
+        region_name: Optional[str],
+        sample_name: Optional[str],
+        systematic_name: Optional[str],
+        template: Optional[str],
+    ) -> Callable[[ProcessorFunc], None]:
+        """decorator for registering a custom processor function
+
+        Args:
+            region_name  (Optional[str]): name of the region to apply the function to,
+                or None to apply to all regions
+            sample_name  (Optional[str]): name of the sample to apply the function to,
+                or None to apply to all samples
+            systematic_name  (Optional[str]): name of the systematic to apply the function to,
+                or None to apply to all systematics
+            template (Optional[str]): name of the template to apply the function to,
+                or None to apply to all templates
+
+        Returns:
+            Callable[[ProcessorFunc], None]: the function to register a processor
+        """
+        if region_name is None:
+            region_name = "*"
+        if sample_name is None:
+            sample_name = "*"
+        if systematic_name is None:
+            systematic_name = "*"
+        if template is None:
+            template = "*"
+
+        def _register(func: ProcessorFunc) -> None:
+            """register a processor function to be applied when matching the patterns of a
+            given region-sample-systematic-template
+
+            Args:
+                func (ProcessorFunc): the function to register
+            """
+            processor_list.append(
+                {
+                    "region": region_name,
+                    "sample": sample_name,
+                    "systematic": systematic_name,
+                    "template": template,
+                    "name": func.__name__,
+                    "func": func,
+                }
+            )
+
+        return _register
+
+    def register_template_builder(
+        self,
+        region_name: Optional[str] = None,
+        sample_name: Optional[str] = None,
+        systematic_name: Optional[str] = None,
+        template: Optional[str] = None,
+    ) -> Callable[[ProcessorFunc], None]:
+        """decorator for registering a template builder function
+
+        Args:
+            region_name (Optional[str], optional): name of the region to apply the function to,
+                defaults to None (apply to all regions)
+            sample_name (Optional[str], optional): name of the sample to apply the function to,
+                defaults to None (apply to all samples)
+            systematic_name (Optional[str], optional): name of the systematic to apply the function to,
+                defaults to None (apply to all systematics)
+            template (Optional[str], optional): name of the template to apply the function to,
+                defaults to None (apply to all templates)
+
+        Returns:
+            Callable[[ProcessorFunc], None]: the generic function to register a processor
+        """
+        return self._register_processor(
+            self.template_builders, region_name, sample_name, systematic_name, template
+        )
+
+    def _find_match(
+        self,
+        processor_list: List[Dict[str, Any]],
+        region_name: str,
+        sample_name: str,
+        systematic_name: str,
+        template: str,
+    ) -> Optional[ProcessorFunc]:
+        """return a function matching the provided specification
+
+        Args:
+            processor_list (List[Dict[str, Any]]): list of processors to search in
+            region_name (str): region name
+            sample_name (str): sample name
+            systematic_name (str): systematic name
+            template (str): template name
+
+        Returns:
+            Optional[ProcessorFunc]: processor function matching the description,
+                or None if no matches are found
+        """
+        matches = []
+        for processor in processor_list:
+            region_matches = fnmatch.fnmatch(region_name, processor["region"])
+            sample_matches = fnmatch.fnmatch(sample_name, processor["sample"])
+            systematic_matches = fnmatch.fnmatch(
+                systematic_name, processor["systematic"]
+            )
+            template_matches = fnmatch.fnmatch(template, processor["template"])
+            if (
+                region_matches
+                and sample_matches
+                and systematic_matches
+                and template_matches
+            ):
+                matches.append(processor["func"])
+
+        if len(matches) > 1:
+            log.warning(
+                f"found {len(matches)} matches, continuing with the first one "
+                f"({matches[0].__name__})"
+            )
+        elif len(matches) == 0:
+            return None
+        return matches[0]
+
+    def _find_template_builder_match(
+        self, region_name: str, sample_name: str, systematic_name: str, template: str
+    ) -> Optional[ProcessorFunc]:
+        """return a template builder function matching the provided specification, or
+        None if no matches are found
+
+        Args:
+            region_name (str): region name
+            sample_name (str): sample name
+            systematic_name (str): systematic name
+            template (str): template name
+
+        Returns:
+            Optional[ProcessorFunc]: template builder function matching the description,
+                or None if no matches are found
+        """
+        return self._find_match(
+            self.template_builders, region_name, sample_name, systematic_name, template
+        )
+
+
+def apply_to_all_templates(
+    config: Dict[str, Any],
+    default_func: ProcessorFunc,
+    match_func: Optional[MatchFunc] = None,
+) -> None:
+    """Apply the supplied function `func` to all templates specified by the
+    configuration file. This function takes four arguments in this order:
+
+    - the dict specifying region information
+    - the dict specifying sample information
+    - the dict specifying systematic information
+    - name of the template being considered: "Nominal", "Up", "Down"
+
+    Args:
+        config (Dict[str, Any]): cabinetry configuration
+        default_func (ProcessorFunc):
+            function to be called for every template by default
+        match_func: (MatchFunc, optional):
+            function that provides user-defined functions to override the call to `default_func`,
+            defaults to None (then it is not used)
+    """
+    for region in config["Regions"]:
+        log.debug(f"  in region {region['Name']}")
+
+        for sample in config["Samples"]:
+            log.debug(f"    reading sample {sample['Name']}")
+
+            for systematic in [{"Name": "nominal"}] + config["Systematics"]:
+
+                # determine how many templates need to be considered
+                if systematic["Name"] == "nominal":
+                    # only nominal template is needed
+                    templates = ["Nominal"]
+                else:
+                    # systematics can have up and down template
+                    templates = ["Up", "Down"]
+
+                for template in templates:
+
+                    # determine whether a histogram is needed for this
+                    # specific combination of sample-region-systematic-template
+                    histo_needed = configuration.histogram_is_needed(
+                        region, sample, systematic, template
+                    )
+
+                    if not histo_needed:
+                        # no further action is needed, continue with the next
+                        # region-sample-systematic combination
+                        continue
+
+                    log.debug(
+                        f"      variation {systematic['Name']}"
+                        f" {template if template != 'Nominal' else ''}"
+                    )
+
+                    func_override = None
+                    if match_func is not None:
+                        # check whether a user-defined function was registered that
+                        # matches this region-sample-systematic-template
+                        func_override = match_func(
+                            region["Name"], sample["Name"], systematic["Name"], template
+                        )
+                    if func_override is not None:
+                        # call the user-defined function
+                        log.debug(
+                            f"executing user-defined override "
+                            f"{func_override.__name__}"
+                        )
+                        func_override(region, sample, systematic, template)
+                    else:
+                        # call the provided default function
+                        default_func(region, sample, systematic, template)

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -6,7 +6,8 @@ from . import configuration
 
 log = logging.getLogger(__name__)
 
-# type of a function processing templates
+# type of a function processing templates, takes sample-region-systematic-template,
+# returns None
 ProcessorFunc = Callable[[Dict[str, Any], Dict[str, Any], Dict[str, Any], str], None]
 
 # type of a function called with names of region-sample-systematic-template,
@@ -173,7 +174,7 @@ def apply_to_all_templates(
     default_func: ProcessorFunc,
     match_func: Optional[MatchFunc] = None,
 ) -> None:
-    """Apply the supplied function `func` to all templates specified by the
+    """Apply the supplied function `default_func` to all templates specified by the
     configuration file. This function takes four arguments in this order:
 
     - the dict specifying region information
@@ -183,11 +184,9 @@ def apply_to_all_templates(
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        default_func (ProcessorFunc):
-            function to be called for every template by default
-        match_func: (MatchFunc, optional):
-            function that provides user-defined functions to override the call to `default_func`,
-            defaults to None (then it is not used)
+        default_func (ProcessorFunc): function to be called for every template by default
+        match_func: (MatchFunc, optional): function that returns user-defined functions
+            to override the call to `default_func`, defaults to None (then it is not used)
     """
     for region in config["Regions"]:
         log.debug(f"  in region {region['Name']}")

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -28,11 +28,18 @@ MatchFunc = Callable[[str, str, str, str], Optional[ProcessorFunc]]
 
 
 class Router:
-    """holds user-defined processing functions, and provides functions matching
-    a pattern to apply the right function to each template
+    """Holds user-defined processing functions, and provides functions for matching
+    a pattern to apply the right function to each template.
+
+    Attributes:
+        template_builders (List[Dict[str, Any]]): user-defined processors for template building
+        template_builder_wrapper (Optional[Callable[[UserTemplateFunc], ProcessorFunc]]):
+            wrapper to apply on user-defined template builders
     """
 
     def __init__(self) -> None:
+        """Initialize a Router instance, with no processors or wrappers defined.
+        """
         # initialize all lists of processor types the user can specify
         self.template_builders: List[Dict[str, Any]] = []
 

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -44,8 +44,8 @@ class Router:
             Callable[[UserTemplateFunc], ProcessorFunc]
         ] = None
 
+    @staticmethod
     def _register_processor(
-        self,
         processor_list: List[Dict[str, Any]],
         region_name: Optional[str],
         sample_name: Optional[str],
@@ -123,8 +123,8 @@ class Router:
             self.template_builders, region_name, sample_name, systematic_name, template
         )
 
+    @staticmethod
     def _find_match(
-        self,
         processor_list: List[Dict[str, Any]],
         region_name: str,
         sample_name: str,

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -190,7 +190,7 @@ class Router:
             or None if no matches are found
         """
         if self.template_builder_wrapper is None:
-            # a wrapper needs to be defined to convert the user-defined UserTemplateFunc
+            # a wrapper needs to be defined already to convert the user-defined UserTemplateFunc
             # into a ProcessorFunc
             raise ValueError("no template builder wrapper defined")
 
@@ -216,6 +216,9 @@ def apply_to_all_templates(
     - the dict specifying sample information
     - the dict specifying systematic information
     - name of the template being considered: "Nominal", "Up", "Down"
+
+    In addition it is possible to specify a function that returns custom overrides. If one
+    is found for a given template, it is used instead of the default.
 
     Args:
         config (Dict[str, Any]): cabinetry configuration

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -181,11 +181,11 @@ class _Builder:
     """class to handle the instructions for backends to create histograms
     """
 
-    def __init__(self, folder_path_str: str, method: str) -> None:
+    def __init__(self, folder_path_str: Union[str, pathlib.Path], method: str) -> None:
         """create an instance, set folder and method
 
         Args:
-            folder_path_str (str): folder to save the histograms to
+            folder_path_str (Union[str, pathlib.Path]): folder to save the histograms to
             method (str): backend to use for histogram production
         """
         self.folder_path_str = folder_path_str
@@ -261,7 +261,7 @@ class _Builder:
         histogram.validate(histogram_name)
 
         # save it
-        histo_path = Path(self.folder_path_str) / histogram_name
+        histo_path = pathlib.Path(self.folder_path_str) / histogram_name
         histogram.save(histo_path)
 
     def _wrap_custom_template_builder(

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -290,7 +290,7 @@ class _Builder:
         ) -> None:
             """Takes a user-defined function that returns a histogram, executes that function and
             saves the histogram. Returns None, to turn the user-defined function into a
-            ProcessorFunc when wrapped by this.
+            ProcessorFunc when wrapped with this.
 
             Args:
                 region (Dict[str, Any]): dict with region information

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -301,7 +301,7 @@ class _Builder:
             histogram = func(region, sample, systematic, template)
             if not isinstance(histogram, bh.Histogram):
                 raise TypeError(
-                    f"histogram produced by {func.__name__} must be a boost_histogram.Histogram"
+                    f"{func.__name__} must return a boost_histogram.Histogram"
                 )
             self._name_and_save(
                 histo.Histogram(histogram), region, sample, systematic, template

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -3,6 +3,7 @@ import logging
 import pathlib
 from typing import Any, Dict, Optional, Union
 
+import boost_histogram as bh
 import numpy as np
 
 from . import histo
@@ -295,8 +296,14 @@ class _Builder:
                 systematic (Dict[str, Any]): dict with systematic information
                 template (str): name of the template: "Nominal", "Up", "Down"
             """
-            histogram = histo.Histogram(func(region, sample, systematic, template))
-            self._name_and_save(histogram, region, sample, systematic, template)
+            histogram = func(region, sample, systematic, template)
+            if not isinstance(histogram, bh.Histogram):
+                raise TypeError(
+                    f"histogram produced by {func.__name__} must be a boost_histogram.Histogram"
+                )
+            self._name_and_save(
+                histo.Histogram(histogram), region, sample, systematic, template
+            )
 
         return wrapper
 

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -278,7 +278,9 @@ class _Builder:
         Returns:
             cabinetry.route.ProcessorFunc: wrapped template builder
         """
-        # decorating this with functools.wraps will keep the name of the wrapped function the same
+        # decorating this with functools.wraps will keep the name of the wrapped function the same,
+        # however the signature of the wrapped function is slightly different (the return value
+        # becomes None)
         @functools.wraps(func)
         def wrapper(
             region: Dict[str, Any],

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -288,7 +288,7 @@ class _Builder:
             systematic: Dict[str, Any],
             template: str,
         ) -> None:
-            """Takes a user-defined function that returns a histogram, runs that function and
+            """Takes a user-defined function that returns a histogram, executes that function and
             saves the histogram. Returns None, to turn the user-defined function into a
             ProcessorFunc when wrapped by this.
 

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -1,4 +1,4 @@
-from functools import wraps
+import functools
 import logging
 import pathlib
 from typing import Any, Dict, Optional, Union
@@ -279,7 +279,7 @@ class _Builder:
             cabinetry.route.ProcessorFunc: wrapped template builder
         """
         # decorating this with functools.wraps will keep the name of the wrapped function the same
-        @wraps(func)
+        @functools.wraps(func)
         def wrapper(
             region: Dict[str, Any],
             sample: Dict[str, Any],

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -44,7 +44,9 @@ def apply_postprocessing(histogram: histo.Histogram, name: str) -> histo.Histogr
     return adjusted_histogram
 
 
-def get_postprocessor(histogram_folder: Union[str, pathlib.Path]) -> route.ProcessorFunc:
+def _get_postprocessor(
+    histogram_folder: Union[str, pathlib.Path]
+) -> route.ProcessorFunc:
     """return the postprocessing function to be applied to template histograms, for
     example via `cabinetry.route.apply_to_all_templates`
     could alternatively create a `Postprocessor` class that contains processors
@@ -81,7 +83,7 @@ def get_postprocessor(histogram_folder: Union[str, pathlib.Path]) -> route.Proce
         histogram_name = histo.build_name(region, sample, systematic, template)
         new_histogram = apply_postprocessing(histogram, histogram_name)
         histogram.validate(histogram_name)
-        new_histo_path = Path(histogram_folder) / (histogram_name + "_modified")
+        new_histo_path = pathlib.Path(histogram_folder) / (histogram_name + "_modified")
         new_histogram.save(new_histo_path)
 
     return process_template

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -48,7 +48,6 @@ def get_postprocessor(histogram_folder: Union[str, pathlib.Path]) -> route.Proce
     """return the postprocessing function to be applied to template histograms, for
     example via `cabinetry.route.apply_to_all_templates`
     could alternatively create a `Postprocessor` class that contains processors
-    TODO: allow users to only override `apply_postprocessing()` without having to build names for histograms and save
 
     Args:
         histogram_folder (Union[str, pathlib.Path]): folder containing histograms

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -5,14 +5,14 @@ from typing import Any, Dict, Union
 
 import numpy as np
 
-from . import configuration
 from . import histo
+from . import route
 
 
 log = logging.getLogger(__name__)
 
 
-def _fix_stat_unc(histogram: histo.H, name: str) -> None:
+def _fix_stat_unc(histogram: histo.Histogram, name: str) -> None:
     """replace nan stat. unc. by zero for a histogram, modifies the
     histogram handed over in the argument
 
@@ -26,7 +26,7 @@ def _fix_stat_unc(histogram: histo.H, name: str) -> None:
         histogram.stdev = np.nan_to_num(histogram.stdev, nan=0.0)
 
 
-def apply_postprocessing(histogram: histo.H, name: str) -> histo.H:
+def apply_postprocessing(histogram: histo.Histogram, name: str) -> histo.Histogram:
     """Create a new modified histogram, currently only calling the
     stat. uncertainty fix. The histogram in the function argument
     stays unchanged.
@@ -44,51 +44,56 @@ def apply_postprocessing(histogram: histo.H, name: str) -> histo.H:
     return adjusted_histogram
 
 
+def get_postprocessor(histogram_folder: Union[str, pathlib.Path]) -> route.ProcessorFunc:
+    """return the postprocessing function to be applied to template histograms, for
+    example via `cabinetry.route.apply_to_all_templates`
+    could alternatively create a `Postprocessor` class that contains processors
+    TODO: allow users to only override `apply_postprocessing()` without having to build names for histograms and save
+
+    Args:
+        histogram_folder (Union[str, pathlib.Path]): folder containing histograms
+
+    Returns:
+        route.ProcessorFunc: function to apply to a template histogram
+    """
+
+    def process_template(
+        region: Dict[str, Any],
+        sample: Dict[str, Any],
+        systematic: Dict[str, Any],
+        template: str,
+    ) -> None:
+        """apply post-processing to a single histogram
+
+        Args:
+            region (Dict[str, Any]): specifying region information
+            sample (Dict[str, Any]): specifying sample information
+            systematic (Dict[str, Any]): specifying systematic information
+            template (str): name of the template: "Nominal", "Up", "Down"
+        """
+        histogram = histo.Histogram.from_config(
+            histogram_folder,
+            region,
+            sample,
+            systematic,
+            modified=False,
+            template=template,
+        )
+        histogram_name = histo.build_name(region, sample, systematic, template)
+        new_histogram = apply_postprocessing(histogram, histogram_name)
+        histogram.validate(histogram_name)
+        new_histo_path = Path(histogram_folder) / (histogram_name + "_modified")
+        new_histogram.save(new_histo_path)
+
+    return process_template
+
+
 def run(config: Dict[str, Any], histogram_folder: Union[str, pathlib.Path]) -> None:
-    """apply post-processing as needed for all histograms
-    this is very similar to template_builder.create_histograms() and should be refactored
+    """apply postprocessing to all histograms
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        histogram_folder (Union[str, pathlib.Path]): folder containing the histograms
+        histogram_folder (Union[str, pathlib.Path]): folder containing histograms
     """
-    log.info("applying post-processing to histograms")
-    # loop over all histograms
-    for region in config["Regions"]:
-        for sample in config["Samples"]:
-            for systematic in [{"Name": "nominal"}] + config["Systematics"]:
-                # determine how many templates need to be considered
-                if systematic["Name"] == "nominal":
-                    # only nominal template is needed
-                    templates = ["Nominal"]
-                else:
-                    # systematics can have up and down template
-                    templates = ["Up", "Down"]
-                for template in templates:
-                    # determine whether a histogram is needed for this
-                    # specific combination of sample-region-systematic-template
-                    histo_needed = configuration.histogram_is_needed(
-                        region, sample, systematic, template
-                    )
-
-                    if not histo_needed:
-                        # no further action is needed, continue with the next region-sample-systematic combination
-                        continue
-
-                    histogram = histo.Histogram.from_config(
-                        histogram_folder,
-                        region,
-                        sample,
-                        systematic,
-                        modified=False,
-                        template=template,
-                    )
-                    histogram_name = histo.build_name(
-                        region, sample, systematic, template
-                    )
-                    new_histogram = apply_postprocessing(histogram, histogram_name)
-                    histogram.validate(histogram_name)
-                    new_histo_path = pathlib.Path(histogram_folder) / (
-                        histogram_name + "_modified"
-                    )
-                    new_histogram.save(new_histo_path)
+    postprocessor = get_postprocessor(histogram_folder)
+    route.apply_to_all_templates(config, postprocessor)

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -95,5 +95,5 @@ def run(config: Dict[str, Any], histogram_folder: Union[str, pathlib.Path]) -> N
         config (Dict[str, Any]): cabinetry configuration
         histogram_folder (Union[str, pathlib.Path]): folder containing histograms
     """
-    postprocessor = get_postprocessor(histogram_folder)
+    postprocessor = _get_postprocessor(histogram_folder)
     route.apply_to_all_templates(config, postprocessor)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -24,7 +24,7 @@ def test_validate():
     assert configuration.validate(config_valid)
 
     # not exactly one data sample
-    config_multiple_data_samples = config_valid = {
+    config_multiple_data_samples = {
         "General": {"Measurement": "", "POI": ""},
         "Regions": [{"Name": "", "Filter": "", "Variable": "", "Binning": [0, 1]}],
         "Samples": [{"Name": "", "Path": "", "Tree": ""}],

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -201,7 +201,11 @@ def test_build_name():
     region = {"Name": "Region"}
     sample = {"Name": "Sample"}
     systematic = {"Name": "Systematic"}
-    assert histo.build_name(region, sample, systematic) == "Region_Sample_Systematic"
+    template = "Up"
+    assert (
+        histo.build_name(region, sample, systematic, template)
+        == "Region_Sample_Systematic_Up"
+    )
 
     region = {"Name": "Region 1"}
     sample = {"Name": "Sample 1"}

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -1,0 +1,160 @@
+import logging
+
+import boost_histogram as bh
+import numpy as np
+import pytest
+
+from cabinetry import route
+
+
+class ProcessorExamples:
+    @staticmethod
+    def get_example_template_builder():
+        def example_template_builder(
+            reg: dict, sam: dict, sys: dict, tem: str
+        ) -> bh.Histogram:
+            hist = bh.Histogram(bh.axis.Variable([0, 1]), storage=bh.storage.Weight())
+            yields = np.asarray([2])
+            stdev = np.asarray([0.1])
+            hist[...] = np.stack([yields, stdev ** 2], axis=-1)
+            return hist
+
+        return example_template_builder
+
+
+@pytest.fixture
+def example_callables():
+    return ProcessorExamples
+
+
+def test_Router():
+    router = route.Router()
+    assert router.template_builders == []
+    assert router.template_builder_wrapper is None
+
+
+def test_Router__register_processor(example_callables):
+    example_router = route.Router()
+    example_template_builder = example_callables.get_example_template_builder()
+
+    example_router._register_processor(
+        example_router.template_builders,
+        region_name="reg",
+        sample_name="signal",
+        systematic_name="sys",
+        template="Up",
+    )(example_template_builder)
+
+    assert example_router.template_builders == [
+        {
+            "region": "reg",
+            "sample": "signal",
+            "systematic": "sys",
+            "template": "Up",
+            "name": "example_template_builder",
+            "func": example_template_builder,
+        }
+    ]
+
+    # test registration with no details specified
+    example_router._register_processor(
+        example_router.template_builders,
+        region_name=None,
+        sample_name=None,
+        systematic_name=None,
+        template=None,
+    )(example_template_builder)
+
+    assert example_router.template_builders[-1] == {
+        "region": "*",
+        "sample": "*",
+        "systematic": "*",
+        "template": "*",
+        "name": "example_template_builder",
+        "func": example_template_builder,
+    }
+
+
+def test_Router_register_template_builder(example_callables):
+    example_router = route.Router()
+    example_template_builder = example_callables.get_example_template_builder()
+
+    example_router.register_template_builder(
+        region_name="reg", sample_name="signal", systematic_name="sys", template="Up",
+    )(example_template_builder)
+
+    assert example_router.template_builders == [
+        {
+            "region": "reg",
+            "sample": "signal",
+            "systematic": "sys",
+            "template": "Up",
+            "name": "example_template_builder",
+            "func": example_template_builder,
+        }
+    ]
+
+
+def test_Router__find_match(example_callables, caplog):
+    caplog.set_level(logging.DEBUG)
+    example_router = route.Router()
+    example_template_builder = example_callables.get_example_template_builder()
+
+    def other_processor():
+        pass
+
+    example_processor_specification = {
+        "region": "r?g",
+        "sample": "sig*",
+        "systematic": "*",
+        "template": "Up",
+        "name": "example_template_builder",
+        "func": example_template_builder,
+    }
+    other_processor_specification = {
+        "region": "abc",
+        "sample": "*",
+        "systematic": "*",
+        "template": "*",
+        "name": "other_processor",
+        "func": other_processor,
+    }
+    example_router.template_builders = [
+        other_processor_specification,
+        example_processor_specification,
+    ]
+
+    # get a single match
+    assert (
+        example_router._find_match(
+            example_router.template_builders, "reg", "signal", "sys", "Up"
+        )
+        is example_template_builder
+    )
+
+    # no matches available
+    assert (
+        example_router._find_match(
+            example_router.template_builders, "reg", "background", "sys", "Up"
+        )
+        is None
+    )
+
+    # multiple matches
+    caplog.clear()
+    example_router.template_builders = [
+        example_processor_specification,
+        example_processor_specification,
+    ]
+    assert (
+        example_router._find_match(
+            example_router.template_builders, "reg", "signal", "sys", "Up"
+        )
+        is example_template_builder
+    )
+
+    assert (
+        "found 2 matches, continuing with the first one (example_template_builder)"
+        in [rec.message for rec in caplog.records]
+    )
+    caplog.clear()

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -1,10 +1,10 @@
-import logging
 import pathlib
+from unittest import mock
 
+import boost_histogram as bh
 import numpy as np
 import pytest
 
-from cabinetry import histo
 from cabinetry import template_builder
 
 
@@ -150,71 +150,135 @@ def test__get_binning():
         assert template_builder._get_binning({})
 
 
-def test_create_histograms(tmp_path, caplog, utils):
-    caplog.set_level(logging.DEBUG)
-    fname = tmp_path / "test.root"
-    treename = "tree"
-    varname = "var"
-    var_array = [1.1, 2.3, 3.0, 3.2]
-    weightname = "weight"
-    weight_array = [1.0, 1.0, 2.0, 1.0]
-    bins = [1, 2, 3, 4]
-    # create something to read
-    utils.create_ntuple(fname, treename, varname, var_array, weightname, weight_array)
+def test__Builder():
+    builder = template_builder._Builder("path", "uproot")
+    assert builder.folder_path_str == "path"
+    assert builder.method == "uproot"
 
-    # create a systematic uncertainty to read
-    var_array_sys = [1.1, 1.1, 1.1, 1.1]
-    fname_sys = tmp_path / "test_sys.root"
-    utils.create_ntuple(
-        fname_sys, treename, varname, var_array_sys, weightname, weight_array
-    )
 
-    config = {
-        "Regions": [{"Name": "test_region", "Variable": varname, "Binning": bins}],
-        "Samples": [{"Name": "sample", "Tree": treename, "Path": fname}],
-        "Systematics": [
-            {"Name": "norm", "Type": "Normalization"},
-            {
-                "Name": "var",
-                "Type": "NormPlusShape",
-                "Samples": "sample",
-                "Up": {"Path": str(fname_sys)},
-            },
-        ],
+@mock.patch("cabinetry.template_builder._Builder._name_and_save")
+@mock.patch("cabinetry.histo.Histogram.from_arrays", return_value="histogram")
+@mock.patch(
+    "cabinetry.contrib.histogram_creation.from_uproot", return_value=([1], [0.1])
+)
+def test__Builder_create_histogram(mock_uproot_builder, mock_histo, mock_save):
+    # the binning [0] is not a proper binning, but simplifies the comparison
+    region = {"Name": "test_region", "Variable": "x", "Binning": [0], "Filter": "x>3"}
+    sample = {
+        "Name": "sample",
+        "Tree": "tree",
+        "Path": "path_to_sample",
+        "Weight": "weight_mc",
     }
-    template_builder.create_histograms(config, tmp_path, method="uproot")
+    systematic = {"Name": "nominal"}
+
+    builder = template_builder._Builder("path", "uproot")
+    builder._create_histogram(region, sample, systematic, "Nominal")
+
+    # verify the backend call happened properly
+    assert mock_uproot_builder.call_args_list == [
+        (
+            (pathlib.Path("path_to_sample"), "tree", "x", [0]),
+            {"weight": "weight_mc", "selection_filter": "x>3"},
+        )
+    ]
+
+    # verify the histogram conversion call
+    assert mock_histo.call_args_list == [(([0], [1], [0.1]), {})]
+
+    # verify the call for saving
+    assert mock_save.call_args_list == [
+        (("histogram", region, sample, systematic, "Nominal"), {})
+    ]
 
     # other backends
+    builder_unknown = template_builder._Builder("path", "unknown")
     with pytest.raises(NotImplementedError, match="unknown backend"):
-        assert template_builder.create_histograms(config, tmp_path, method="unknown")
+        builder_unknown._create_histogram(region, sample, systematic, "Nominal")
 
-    saved_histo = histo.Histogram.from_config(
-        tmp_path,
-        config["Regions"][0],
-        config["Samples"][0],
-        {"Name": "nominal"},
-        modified=False,
+
+@mock.patch("cabinetry.histo.build_name", return_value="name")
+def test__Builder__name_and_save(mock_name):
+    region = {"Name": "test_region"}
+    sample = {"Name": "sample"}
+    systematic = {"Name": "nominal"}
+
+    histogram = mock.MagicMock()
+
+    builder = template_builder._Builder("path", "uproot")
+    builder._name_and_save(histogram, region, sample, systematic, "Up")
+
+    # check that the naming function was called, the histogram was validated and saved
+    assert mock_name.call_args_list == [((region, sample, systematic, "Up"), {})]
+    assert histogram.validate.call_args_list == [mock.call("name")]
+    assert histogram.save.call_args_list == [mock.call(pathlib.Path("path/name"))]
+
+
+@mock.patch("cabinetry.template_builder._Builder._name_and_save")
+def test__Builder__wrap_custom_template_builder(mock_save):
+    histogram = bh.Histogram(bh.axis.Variable([0, 1]))
+    region = {"Name": "test_region"}
+    sample = {"Name": "sample"}
+    systematic = {"Name": "nominal"}
+
+    def test_func(reg, sam, sys, tem):
+        return histogram
+
+    builder = template_builder._Builder("path", "uproot")
+    wrapped_func = builder._wrap_custom_template_builder(test_func)
+
+    # check the behavior of the wrapped function
+    # when called, it should save the returned histogram
+    wrapped_func(region, sample, systematic, "Up")
+
+    assert mock_save.call_args_list == [
+        ((histogram, region, sample, systematic, "Up"), {})
+    ]
+
+    # wrapped function returns wrong type
+    def test_func_wrong_return(reg, sam, sys, tem):
+        return None
+
+    wrapped_func_wrong_return = builder._wrap_custom_template_builder(
+        test_func_wrong_return
     )
+    with pytest.raises(TypeError, match="must be a boost_histogram.Histogram"):
+        wrapped_func_wrong_return(region, sample, systematic, "Up")
 
-    assert np.allclose(saved_histo.yields, [1, 1, 2])
-    assert np.allclose(saved_histo.stdev, [1, 1, 1.41421356])
-    assert np.allclose(saved_histo.bins, bins)
 
-    saved_histo_sys = histo.Histogram.from_config(
-        tmp_path,
-        config["Regions"][0],
-        config["Samples"][0],
-        {"Name": "var"},
-        modified=False,
-        template="Up",
-    )
+def test_create_histograms():
+    config = {}
+    folder_path_str = "path"
+    method = "uproot"
 
-    assert np.allclose(saved_histo_sys.yields, [4, 0, 0])
-    assert np.allclose(saved_histo_sys.stdev, [2, 0, 0])
-    assert np.allclose(saved_histo_sys.bins, bins)
+    # no router
+    with mock.patch("cabinetry.route.apply_to_all_templates") as mock_apply:
+        template_builder.create_histograms(config, folder_path_str, method)
+        assert len(mock_apply.call_args_list) == 1
+        config_call, func_call = mock_apply.call_args_list[0][0]
+        assert config_call == config
+        assert (
+            func_call.__name__ == "_create_histogram"
+        )  # could also compare to function
+        assert mock_apply.call_args_list[0][1] == {"match_func": None}
 
-    assert "  in region test_region" in [rec.message for rec in caplog.records]
-    assert "    reading sample sample" in [rec.message for rec in caplog.records]
-    assert "      variation nominal" in [rec.message for rec in caplog.records]
-    assert "      variation var Up" in [rec.message for rec in caplog.records]
-    caplog.clear()
+    # including a router
+    mock_router = mock.MagicMock()
+    with mock.patch("cabinetry.route.apply_to_all_templates") as mock_apply:
+        template_builder.create_histograms(
+            config, folder_path_str, method, router=mock_router
+        )
+
+        # verify wrapper was set
+        assert (
+            mock_router.template_builder_wrapper.__name__
+            == "_wrap_custom_template_builder"
+        )
+
+        assert len(mock_apply.call_args_list) == 1
+        config_call, func_call = mock_apply.call_args_list[0][0]
+        assert config_call == config
+        assert func_call.__name__ == "_create_histogram"
+        assert mock_apply.call_args_list[0][1] == {
+            "match_func": mock_router._find_template_builder_match
+        }

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -242,7 +242,7 @@ def test__Builder__wrap_custom_template_builder(mock_save):
     wrapped_func_wrong_return = builder._wrap_custom_template_builder(
         test_func_wrong_return
     )
-    with pytest.raises(TypeError, match="must be a boost_histogram.Histogram"):
+    with pytest.raises(TypeError, match="must return a boost_histogram.Histogram"):
         wrapped_func_wrong_return(region, sample, systematic, "Up")
 
 

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -184,10 +184,6 @@ def test_create_histograms(tmp_path, caplog, utils):
     }
     template_builder.create_histograms(config, tmp_path, method="uproot")
 
-    # ServiceX is not yet implemented
-    with pytest.raises(NotImplementedError, match="ServiceX not yet implemented"):
-        assert template_builder.create_histograms(config, tmp_path, method="ServiceX")
-
     # other backends
     with pytest.raises(NotImplementedError, match="unknown backend"):
         assert template_builder.create_histograms(config, tmp_path, method="unknown")
@@ -217,8 +213,8 @@ def test_create_histograms(tmp_path, caplog, utils):
     assert np.allclose(saved_histo_sys.stdev, [2, 0, 0])
     assert np.allclose(saved_histo_sys.bins, bins)
 
-    assert "  reading sample sample" in [rec.message for rec in caplog.records]
     assert "  in region test_region" in [rec.message for rec in caplog.records]
-    assert "  variation nominal" in [rec.message for rec in caplog.records]
-    assert "  variation var" in [rec.message for rec in caplog.records]
+    assert "    reading sample sample" in [rec.message for rec in caplog.records]
+    assert "      variation nominal" in [rec.message for rec in caplog.records]
+    assert "      variation var Up" in [rec.message for rec in caplog.records]
     caplog.clear()

--- a/tests/test_template_postprocessor.py
+++ b/tests/test_template_postprocessor.py
@@ -1,3 +1,6 @@
+import pathlib
+from unittest import mock
+
 import numpy as np
 import pytest
 
@@ -31,24 +34,54 @@ def test_apply_postprocessing():
     np.testing.assert_equal(histogram.stdev, [float("nan"), 0.2])
 
 
-def test_run(tmp_path):
-    # should test systematics here as well, but the logic is the same as in
-    # template_builder.create_histograms(), where it gets tested
-    config = {
-        "Regions": [{"Name": "region_1"}],
-        "Samples": [{"Name": "signal"}],
-        "Systematics": [
-            {"Name": "var", "Samples": "background", "Type": "Normalization"}
-        ],
-    }
+@mock.patch(
+    "cabinetry.template_postprocessor.apply_postprocessing",
+    return_value="new_histogram",
+)
+@mock.patch("cabinetry.histo.build_name", return_value="histo_name")
+def test__get_postprocessor(mock_name, mock_apply):
+    postprocessor = template_postprocessor._get_postprocessor("path")
 
-    # create an input histogram
-    histo_path = tmp_path / "region_1_signal_nominal.npz"
-    histogram = histo.Histogram.from_arrays([0.0, 1.0, 2.0], [1.0, 2.0], [1.0, 1.0])
-    histogram.save(histo_path)
+    region = {"Name": "region"}
+    sample = {"Name": "sample"}
+    systematic = {"Name": "systematic"}
+    template = "Up"
 
-    template_postprocessor.run(config, tmp_path)
-    modified_histo = histo.Histogram.from_path(histo_path, modified=True)
-    assert np.allclose(modified_histo.yields, histogram.yields)
-    assert np.allclose(modified_histo.stdev, histogram.stdev)
-    assert np.allclose(modified_histo.bins, histogram.bins)
+    mock_original_histogram = mock.MagicMock()
+    mock_new_histogram = mock.MagicMock()
+    with mock.patch(
+        "cabinetry.histo.Histogram.from_config", return_value=mock_original_histogram
+    ) as mock_from_config:
+        with mock.patch(
+            "cabinetry.template_postprocessor.apply_postprocessing",
+            return_value=mock_new_histogram,
+        ) as mock_postprocessing:
+            # execute the provided function
+            postprocessor(region, sample, systematic, template)
+
+            # check that the relevant functions were called
+            assert mock_from_config.call_args_list == [
+                (
+                    ("path", region, sample, systematic),
+                    {"modified": False, "template": template},
+                )
+            ]  # histogram was created
+
+            assert mock_postprocessing.call_args_list == [
+                ((mock_original_histogram, "histo_name"), {})
+            ]  # postprocessing was executed
+
+            assert mock_new_histogram.save.call_args_list == [
+                ((pathlib.Path("path/histo_name_modified"),), {})
+            ]  # new histogram was saved (meaning right name was obtained)
+
+
+@mock.patch("cabinetry.route.apply_to_all_templates")
+@mock.patch("cabinetry.template_postprocessor._get_postprocessor", return_value="func")
+def test_run(mock_postprocessor, mock_apply):
+    config = {}
+    path = "path"
+    template_postprocessor.run(config, path)
+
+    assert mock_postprocessor.call_args_list == [((path,), {})]
+    assert mock_apply.call_args_list == [((config, "func"), {})]


### PR DESCRIPTION
With this update, template histograms are controlled from a new `route` module. This enables user-defined overrides for template histogram building.

The `route` module takes care of looping over templates and determining which function to apply to which template. A new decorator `@register_template_builder` allows users to define their own function that builds histograms, and this function is applied when matching the specified patterns.

Example:
```python
my_router = cabinetry.route.Router()

# define a custom template builder function that is executed for data samples
@my_router.register_template_builder(sample_name="Data")
def build_data_hist(reg: dict, sam: dict, sys: dict, tem: str) -> bh.Histogram:
    hist = bh.Histogram(
        bh.axis.Variable(reg["Binning"], underflow=False, overflow=False),
        storage=bh.storage.Weight(),
    )
    yields = np.asarray([100, 102, 103, 104])
    stdev = np.asarray([0.1, 0.1, 0.1, 0.1])
    hist[...] = np.stack([yields, stdev ** 2], axis=-1)
    return hist

...

cabinetry.template_builder.create_histograms(
        cabinetry_config, histo_folder, method="uproot", router=my_router
)
```

Documentation is added to sphinx under a new "advanced topics" section.