### PR TITLE
chore: updating version to 0.0.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "pyyaml",
         "pyhf>=0.5.0",
         "iminuit>1.4.0",
-        "boost_histogram!=0.10.1",
+        "boost_histogram",
         "jsonschema",
     ],
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ with open("README.md", "r") as f:
 
 setup(
     name="cabinetry",
-    version="0.0.4",
-    author="cabinetry developers",
+    version="0.0.5",
+    author="Alexander Held",
     description="design and steer profile likelihood fits",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -6,4 +6,4 @@ from . import visualize  # NOQA
 from . import workspace  # NOQA
 
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"


### PR DESCRIPTION
Updating version for next tag / pypi release, and adding author name to setup. Also removing version restriction for `boost-histogram` implemented in #75, as the latest version is fixed.