### PR TITLE
test: fix issues raised by typeguard

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = --cov=cabinetry --cov-report html --cov-report term-missing --cov-branch
+addopts = --cov=cabinetry --cov-report html --cov-report term-missing --cov-branch --typeguard-packages=cabinetry
 
 [flake8]
 max-complexity = 10

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ extras_require["test"] = sorted(
             "flake8-import-order",
             "flake8-print",
             "mypy",
+            "typeguard",
             "black;python_version>='3.6'",  # Black is Python3 only
         ]
     )

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from pathlib import Path
+import pathlib
 import pkgutil
 from typing import Any, Dict, List, Union
 
@@ -10,16 +10,16 @@ import yaml
 log = logging.getLogger(__name__)
 
 
-def read(file_path_string: str) -> Dict[str, Any]:
+def read(file_path_string: Union[str, pathlib.Path]) -> Dict[str, Any]:
     """read a config file from a provided path and return it
 
     Args:
-        file_path_string (str): path to config file
+        file_path_string (Union[str, pathlib.Path]): path to config file
 
     Returns:
         Dict[str, Any]: cabinetry configuration
     """
-    file_path = Path(file_path_string)
+    file_path = pathlib.Path(file_path_string)
     log.info(f"opening config file {file_path}")
     config = yaml.safe_load(file_path.read_text())
     validate(config)

--- a/src/cabinetry/contrib/histogram_creation.py
+++ b/src/cabinetry/contrib/histogram_creation.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+import pathlib
 from typing import Optional, Tuple
 
 import boost_histogram as bh
@@ -7,7 +7,7 @@ import uproot4 as uproot
 
 
 def from_uproot(
-    ntuple_path: Path,
+    ntuple_path: pathlib.Path,
     pos_in_file: str,
     variable: str,
     bins: np.ndarray,

--- a/src/cabinetry/contrib/matplotlib_visualize.py
+++ b/src/cabinetry/contrib/matplotlib_visualize.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from pathlib import Path
+import pathlib
 from typing import Any, Dict, List, Union
 
 import matplotlib as mpl
@@ -25,7 +25,9 @@ def _total_yield_uncertainty(stdev_list: List[np.ndarray]) -> np.ndarray:
     return tot_unc
 
 
-def data_MC(histogram_dict_list: List[Dict[str, Any]], figure_path: Path) -> None:
+def data_MC(
+    histogram_dict_list: List[Dict[str, Any]], figure_path: pathlib.Path
+) -> None:
     """draw a data/MC histogram
 
     Args:
@@ -115,7 +117,9 @@ def data_MC(histogram_dict_list: List[Dict[str, Any]], figure_path: Path) -> Non
 
 
 def correlation_matrix(
-    corr_mat: np.ndarray, labels: Union[List[str], np.ndarray], figure_path: Path
+    corr_mat: np.ndarray,
+    labels: Union[List[str], np.ndarray],
+    figure_path: pathlib.Path,
 ) -> None:
     """draw a correlation matrix
 
@@ -159,7 +163,7 @@ def pulls(
     bestfit: np.ndarray,
     uncertainty: np.ndarray,
     labels: Union[List[str], np.ndarray],
-    figure_path: Path,
+    figure_path: pathlib.Path,
 ) -> None:
     """draw a pull plot
 

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from pathlib import Path
+import pathlib
 from typing import Any, Dict, List, Type, TypeVar, Union
 
 import boost_histogram as bh
@@ -54,7 +54,7 @@ class Histogram(bh.Histogram):
         return out
 
     @classmethod
-    def from_path(cls: Type[H], histo_path: Path, modified: bool = True) -> H:
+    def from_path(cls: Type[H], histo_path: pathlib.Path, modified: bool = True) -> H:
         """build a histogram from disk
         try to load the "modified" version of the histogram by default
         (which received post-processing)
@@ -84,7 +84,7 @@ class Histogram(bh.Histogram):
     @classmethod
     def from_config(
         cls: Type[H],
-        histo_folder: str,
+        histo_folder: Union[str, pathlib.Path],
         region: Dict[str, Any],
         sample: Dict[str, Any],
         systematic: Dict[str, Any],
@@ -95,7 +95,7 @@ class Histogram(bh.Histogram):
         relevant information from the config: region, sample, systematic
 
         Args:
-            histo_folder (str): folder containing all histograms
+            histo_folder (Union[str, patlib.Path]): folder containing all histograms
             region (Dict[str, Any]): containing all region information
             sample (Dict[str, Any]): containing all sample information
             systematic (Dict[str, Any]): containing all systematic information
@@ -107,7 +107,7 @@ class Histogram(bh.Histogram):
         """
         # find the histogram name given config information, and then load the histogram
         histo_name = build_name(region, sample, systematic, template)
-        histo_path = Path(histo_folder) / histo_name
+        histo_path = pathlib.Path(histo_folder) / histo_name
         return cls.from_path(histo_path, modified)
 
     @property
@@ -146,7 +146,7 @@ class Histogram(bh.Histogram):
         """
         return self.axes[0].edges
 
-    def save(self, histo_path: Path) -> None:
+    def save(self, histo_path: pathlib.Path) -> None:
         """save a histogram to disk
 
         Args:

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -1,6 +1,6 @@
 import logging
-from pathlib import Path
-from typing import Any, Dict, Optional
+import pathlib
+from typing import Any, Dict, Optional, Union
 
 import numpy as np
 
@@ -34,7 +34,7 @@ def _get_ntuple_path(
     sample: Dict[str, Any],
     systematic: Dict[str, Any],
     template: str,
-) -> Path:
+) -> pathlib.Path:
     """determine the path to ntuples from which a histogram has to be built
     for non-nominal templates, override the nominal path if an alternative is
     specified for the template
@@ -55,7 +55,7 @@ def _get_ntuple_path(
         path_str_override = _check_for_override(systematic, template, "Path")
         if path_str_override is not None:
             path_str = path_str_override
-    path = Path(path_str)
+    path = pathlib.Path(path_str)
     return path
 
 
@@ -177,7 +177,9 @@ def _get_binning(region: Dict[str, Any]) -> np.ndarray:
 
 
 def create_histograms(
-    config: Dict[str, Any], folder_path_str: str, method: str = "uproot"
+    config: Dict[str, Any],
+    folder_path_str: Union[str, pathlib.Path],
+    method: str = "uproot",
 ) -> None:
     """generate all required histograms specified by a configuration file
     a tool providing histograms should provide bin yields and statistical
@@ -185,7 +187,7 @@ def create_histograms(
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        folder_path_str (str): folder to save the histograms to
+        folder_path_str (Union[str, pathlib.Path]): folder to save the histograms to
         method (str, optional): backend to use for histogram production, defaults to "uproot"
 
     Raises:
@@ -262,5 +264,5 @@ def create_histograms(
                     histogram.validate(histogram_name)
 
                     # save it
-                    histo_path = Path(folder_path_str) / histogram_name
+                    histo_path = pathlib.Path(folder_path_str) / histogram_name
                     histogram.save(histo_path)

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -1,7 +1,7 @@
 import copy
 import logging
-from pathlib import Path
-from typing import Any, Dict
+import pathlib
+from typing import Any, Dict, Union
 
 import numpy as np
 
@@ -44,13 +44,13 @@ def apply_postprocessing(histogram: histo.H, name: str) -> histo.H:
     return adjusted_histogram
 
 
-def run(config: Dict[str, Any], histogram_folder: str) -> None:
+def run(config: Dict[str, Any], histogram_folder: Union[str, pathlib.Path]) -> None:
     """apply post-processing as needed for all histograms
     this is very similar to template_builder.create_histograms() and should be refactored
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        histogram_folder (str): folder containing the histograms
+        histogram_folder (Union[str, pathlib.Path]): folder containing the histograms
     """
     log.info("applying post-processing to histograms")
     # loop over all histograms
@@ -88,7 +88,7 @@ def run(config: Dict[str, Any], histogram_folder: str) -> None:
                     )
                     new_histogram = apply_postprocessing(histogram, histogram_name)
                     histogram.validate(histogram_name)
-                    new_histo_path = Path(histogram_folder) / (
+                    new_histo_path = pathlib.Path(histogram_folder) / (
                         histogram_name + "_modified"
                     )
                     new_histogram.save(new_histo_path)

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -31,7 +31,7 @@ def _build_figure_name(region_name: str, is_prefit: bool) -> str:
 
 def data_MC(
     config: Dict[str, Any],
-    histogram_folder: str,
+    histogram_folder: Union[str, pathlib.Path],
     figure_folder: Union[str, pathlib.Path],
     prefit: bool = True,
     method: str = "matplotlib",
@@ -40,7 +40,7 @@ def data_MC(
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        histogram_folder (str): path to the folder containing template histograms
+        histogram_folder (Union[str, pathlib.Path]): path to the folder containing template histograms
         figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
         prefit (bool, optional): show the pre- or post-fit model, defaults to True
         method (str, optional): what backend to use for plotting, defaults to "matplotlib"

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -1,6 +1,6 @@
 import logging
-from pathlib import Path
-from typing import Any, Dict, List, Optional
+import pathlib
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 
@@ -32,7 +32,7 @@ def _build_figure_name(region_name: str, is_prefit: bool) -> str:
 def data_MC(
     config: Dict[str, Any],
     histogram_folder: str,
-    figure_folder: str,
+    figure_folder: Union[str, pathlib.Path],
     prefit: bool = True,
     method: str = "matplotlib",
 ) -> None:
@@ -41,7 +41,7 @@ def data_MC(
     Args:
         config (Dict[str, Any]): cabinetry configuration
         histogram_folder (str): path to the folder containing template histograms
-        figure_folder (str): path to the folder to save figures in
+        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
         prefit (bool, optional): show the pre- or post-fit model, defaults to True
         method (str, optional): what backend to use for plotting, defaults to "matplotlib"
 
@@ -77,7 +77,7 @@ def data_MC(
             if method == "matplotlib":
                 from cabinetry.contrib import matplotlib_visualize
 
-                figure_path = Path(figure_folder) / figure_name
+                figure_path = pathlib.Path(figure_folder) / figure_name
                 matplotlib_visualize.data_MC(histogram_dict_list, figure_path)
             else:
                 raise NotImplementedError(f"unknown backend: {method}")
@@ -88,7 +88,7 @@ def data_MC(
 def correlation_matrix(
     corr_mat: np.ndarray,
     labels: List[str],
-    figure_folder: str,
+    figure_folder: Union[str, pathlib.Path],
     pruning_threshold: float = 0.0,
     method: str = "matplotlib",
 ) -> None:
@@ -97,7 +97,7 @@ def correlation_matrix(
     Args:
         corr_mat (np.ndarray): the correlation matrix to plot
         labels (List[str]): names of parameters in the correlation matrix
-        figure_folder (str): path to the folder to save figures in
+        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
         pruning_threshold (float, optional): minimum correlation for a parameter to
             have with any other parameters to not get pruned, defaults to 0.0
         method (str, optional): what backend to use for plotting, defaults to "matplotlib"
@@ -116,7 +116,7 @@ def correlation_matrix(
     )
     labels = np.delete(labels, delete_indices)
 
-    figure_path = Path(figure_folder) / "correlation_matrix.pdf"
+    figure_path = pathlib.Path(figure_folder) / "correlation_matrix.pdf"
     if method == "matplotlib":
         from cabinetry.contrib import matplotlib_visualize
 
@@ -129,7 +129,7 @@ def pulls(
     bestfit: np.ndarray,
     uncertainty: np.ndarray,
     labels: List[str],
-    figure_folder: str,
+    figure_folder: Union[str, pathlib.Path],
     exclude_list: Optional[List[str]] = None,
     method: str = "matplotlib",
 ) -> None:
@@ -139,7 +139,7 @@ def pulls(
         bestfit (np.ndarray): best-fit results for parameters
         uncertainty (np.ndarray): parameter uncertainties
         labels (List[str]): parameter names
-        figure_folder (str): path to the folder to save figures in
+        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
         exclude_list (Optional[List[str]], optional): list of parameters to exclude from plot,
             defaults to None (nothing excluded)
         method (str, optional): what backend to use for plotting, defaults to "matplotlib"
@@ -147,7 +147,7 @@ def pulls(
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
     """
-    figure_path = Path(figure_folder) / "pulls.pdf"
+    figure_path = pathlib.Path(figure_folder) / "pulls.pdf"
     labels_np = np.asarray(labels)
 
     # filter out parameters

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -1,8 +1,8 @@
 import json
 import logging
 import os
-from pathlib import Path
-from typing import Any, Dict, List, Optional
+import pathlib
+from typing import Any, Dict, List, Optional, Union
 
 import pyhf
 
@@ -31,7 +31,7 @@ def _get_data_sample(config: Dict[str, Any]) -> Dict[str, Any]:
 def get_yield_for_sample(
     region: Dict[str, Any],
     sample: Dict[str, Any],
-    histogram_folder: str,
+    histogram_folder: Union[str, pathlib.Path],
     systematic: Optional[Dict[str, Any]] = None,
 ) -> List[float]:
     """get the yield for a specific sample, by figuring out its name and then
@@ -40,7 +40,7 @@ def get_yield_for_sample(
     Args:
         region (Dict[str, Any]): specific region to use
         sample (Dict[str, Any]): specific sample to use
-        histogram_folder (str): path to folder containing histograms
+        histogram_folder (Union[str, pathlib.Path]): path to folder containing histograms
         systematic (Optional[Dict[str, Any]], optional): specific systematic variation to use,
             defaults to None -> {"Name": "nominal"}
 
@@ -60,7 +60,7 @@ def get_yield_for_sample(
 def get_unc_for_sample(
     region: Dict[str, Any],
     sample: Dict[str, Any],
-    histogram_folder: str,
+    histogram_folder: Union[str, pathlib.Path],
     systematic: Optional[Dict[str, Any]] = None,
 ) -> List[float]:
     """get the uncertainty of a specific sample, by figuring out its name and then
@@ -69,7 +69,7 @@ def get_unc_for_sample(
     Args:
         region (Dict[str, Any]): specific region to use
         sample (Dict[str, Any]): specific sample to use
-        histogram_folder (str): path to folder containing histograms
+        histogram_folder (Union[str, pathlib.Path]): path to folder containing histograms
         systematic (Optional[Dict[str, Any]], optional): specific systematic variation to use,
             defaults to None -> {"Name": "nominal"}
 
@@ -139,7 +139,7 @@ def get_NormPlusShape_modifiers(
     region: Dict[str, Any],
     sample: Dict[str, Any],
     systematic: Dict[str, Any],
-    histogram_folder: str,
+    histogram_folder: Union[str, pathlib.Path],
 ) -> List[Dict[str, Any]]:
     """For a variation including a correlated shape + normalization effect, this
     provides the histosys and normsys modifiers for pyhf (in HistFactory language,
@@ -151,7 +151,7 @@ def get_NormPlusShape_modifiers(
         region (Dict[str, Any]): region the systematic variation acts in
         sample (Dict[str, Any]): sample the systematic variation acts on
         systematic (Dict[str, Any]): the systematic variation under consideration
-        histogram_folder (str): path to folder containing histograms
+        histogram_folder (Union[str, pathlib.Path]): path to folder containing histograms
 
     Returns:
         List[Dict[str, Any]]: a list with a pyhf normsys modifier and a histosys modifier
@@ -216,7 +216,7 @@ def get_sys_modifiers(
     config: Dict[str, Any],
     region: Dict[str, Any],
     sample: Dict[str, Any],
-    histogram_folder: str,
+    histogram_folder: Union[str, pathlib.Path],
 ) -> List[Dict[str, Any]]:
     """get the list of all systematic modifiers acting on a sample
 
@@ -224,7 +224,7 @@ def get_sys_modifiers(
         config (Dict[str, Any]): cabinetry configuration
         region (Dict[str, Any]): region considered
         sample (Dict[str, Any]): specific sample to get modifiers for
-        histogram_folder (str): path to folder containing histograms
+        histogram_folder (Union[str, pathlib.Path]): path to folder containing histograms
 
     Raises:
         NotImplementedError: when unsupported modifiers act on sample
@@ -255,12 +255,14 @@ def get_sys_modifiers(
     return modifiers
 
 
-def get_channels(config: Dict[str, Any], histogram_folder: str) -> List[Dict[str, Any]]:
+def get_channels(
+    config: Dict[str, Any], histogram_folder: Union[str, pathlib.Path]
+) -> List[Dict[str, Any]]:
     """construct the channel information: yields per sample and modifiers
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        histogram_folder (str): path to folder containing histograms
+        histogram_folder (Union[str, pathlib.Path]): path to folder containing histograms
 
     Returns:
         List[Dict[str, Any]]: channels for pyhf-style workspace
@@ -353,13 +355,13 @@ def get_measurements(config: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 
 def get_observations(
-    config: Dict[str, Any], histogram_folder: str
+    config: Dict[str, Any], histogram_folder: Union[str, pathlib.Path]
 ) -> List[Dict[str, Any]]:
     """build the observations
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        histogram_folder (str): path to folder containing histograms
+        histogram_folder (Union[str, pathlib.Path]): path to folder containing histograms
 
     Returns:
         List[Dict[str, Any]]: observations for pyhf-style workspace
@@ -376,13 +378,15 @@ def get_observations(
 
 
 def build(
-    config: Dict[str, Any], histogram_folder: str, with_validation: bool = True
+    config: Dict[str, Any],
+    histogram_folder: Union[str, pathlib.Path],
+    with_validation: bool = True,
 ) -> Dict[str, Any]:
     """build a HistFactory workspace, pyhf style
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        histogram_folder (str): path to folder containing histograms
+        histogram_folder (Union[str, pathlib.Path]): path to folder containing histograms
         with_validation (bool, optional): validate workspace validity with pyhf, defaults to True
 
     Returns:
@@ -422,14 +426,14 @@ def validate(ws: Dict[str, Any]) -> None:
     pyhf.Workspace(ws)
 
 
-def save(ws: Dict[str, Any], file_path_string: str) -> None:
+def save(ws: Dict[str, Any], file_path_string: Union[str, pathlib.Path]) -> None:
     """save the workspace to a file
 
     Args:
         ws (Dict[str, Any]): pyhf-compatible HistFactory workspace
-        file_path_string (str): path to the file to save the workspace in
+        file_path_string (Union[str, pathlib.Path]): path to the file to save the workspace in
     """
-    file_path = Path(file_path_string)
+    file_path = pathlib.Path(file_path_string)
     log.debug(f"saving workspace to {file_path}")
     # create output directory if it does not exist yet
     if not os.path.exists(file_path.parent):
@@ -438,15 +442,15 @@ def save(ws: Dict[str, Any], file_path_string: str) -> None:
     file_path.write_text(json.dumps(ws, sort_keys=True, indent=4))
 
 
-def load(file_path_string: str) -> Dict[str, Any]:
+def load(file_path_string: Union[str, pathlib.Path]) -> Dict[str, Any]:
     """load a workspace from file
 
     Args:
-        file_path_string (str): path to the file to load the workspace from
+        file_path_string (Union[str, pathlib.Path]): path to the file to load the workspace from
 
     Returns:
         Dict[str, Any]: pyhf-compatible HistFactory workspace
     """
-    file_path = Path(file_path_string)
+    file_path = pathlib.Path(file_path_string)
     ws = json.loads(file_path.read_text())
     return ws

--- a/tests/contrib/test_histogram_creation.py
+++ b/tests/contrib/test_histogram_creation.py
@@ -10,7 +10,7 @@ def test_from_uproot(tmp_path, utils):
     var_array = [1.1, 2.3, 3.0, 3.2]
     weightname_write = "weight"
     weight_array = [1.0, 1.0, 2.0, 1.0]
-    bins = [1, 2, 3, 4]
+    bins = np.asarray([1, 2, 3, 4])
     # create something to read
     utils.create_ntuple(
         fname, treename, varname, var_array, weightname_write, weight_array
@@ -47,9 +47,9 @@ def test_from_uproot(tmp_path, utils):
 
 
 def test__bin_data():
-    data = [1.1, 2.2, 2.9, 2.5, 1.4]
-    weights = [1.0, 1.1, 0.9, 0.8, 1.5]
-    bins = [1, 2, 3]
+    data = np.asarray([1.1, 2.2, 2.9, 2.5, 1.4])
+    weights = np.asarray([1.0, 1.1, 0.9, 0.8, 1.5])
+    bins = np.asarray([1, 2, 3])
     yields, stdev = histogram_creation._bin_data(data, weights, bins)
     assert np.allclose(yields, [2.5, 2.8])
     assert np.allclose(stdev, [1.80277564, 1.63095064])

--- a/tests/contrib/test_matplotlib_visualize.py
+++ b/tests/contrib/test_matplotlib_visualize.py
@@ -6,7 +6,7 @@ from cabinetry.contrib import matplotlib_visualize
 
 
 def test__total_yield_uncertainty():
-    stdev_list = np.asarray([np.asarray([0.1, 0.2, 0.1]), np.asarray([0.3, 0.2, 0.1])])
+    stdev_list = [np.asarray([0.1, 0.2, 0.1]), np.asarray([0.3, 0.2, 0.1])]
     expected_uncertainties = [0.31622777, 0.28284271, 0.14142136]
     assert np.allclose(
         matplotlib_visualize._total_yield_uncertainty(stdev_list),

--- a/tests/contrib/test_matplotlib_visualize.py
+++ b/tests/contrib/test_matplotlib_visualize.py
@@ -6,7 +6,7 @@ from cabinetry.contrib import matplotlib_visualize
 
 
 def test__total_yield_uncertainty():
-    stdev_list = [np.asarray([0.1, 0.2, 0.1]), np.asarray([0.3, 0.2, 0.1])]
+    stdev_list = np.asarray([np.asarray([0.1, 0.2, 0.1]), np.asarray([0.3, 0.2, 0.1])])
     expected_uncertainties = [0.31622777, 0.28284271, 0.14142136]
     assert np.allclose(
         matplotlib_visualize._total_yield_uncertainty(stdev_list),

--- a/tests/contrib/test_matplotlib_visualize.py
+++ b/tests/contrib/test_matplotlib_visualize.py
@@ -6,7 +6,7 @@ from cabinetry.contrib import matplotlib_visualize
 
 
 def test__total_yield_uncertainty():
-    stdev_list = [[0.1, 0.2, 0.1], [0.3, 0.2, 0.1]]
+    stdev_list = [np.asarray([0.1, 0.2, 0.1]), np.asarray([0.3, 0.2, 0.1])]
     expected_uncertainties = [0.31622777, 0.28284271, 0.14142136]
     assert np.allclose(
         matplotlib_visualize._total_yield_uncertainty(stdev_list),

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -89,7 +89,7 @@ def test__convert_samples_to_list(samples, converted):
     "sample_and_modifier, affected",
     [
         (({"Name": "Signal"}, {"Samples": ["Signal", "Background"]}), True),
-        (({"Name": "Signal"}, {"Samples": {"Background"}}), False),
+        (({"Name": "Signal"}, {"Samples": "Background"}), False),
     ],
 )
 def test_sample_affected_by_modifier(sample_and_modifier, affected):

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -51,8 +51,8 @@ def test_get_parameter_names(example_spec):
 def test_print_results(caplog):
     caplog.set_level(logging.DEBUG)
 
-    bestfit = [1.0, 2.0]
-    uncertainty = [0.1, 0.3]
+    bestfit = np.asarray([1.0, 2.0])
+    uncertainty = np.asarray([0.1, 0.3])
     labels = ["param_A", "param_B"]
     fit.print_results(bestfit, uncertainty, labels)
     assert "param_A: 1.000000 +/- 0.100000" in [rec.message for rec in caplog.records]

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -1,5 +1,5 @@
 import logging
-from pathlib import Path
+import pathlib
 
 import numpy as np
 import pytest
@@ -37,7 +37,7 @@ def test__get_ntuple_path():
     # no override
     assert template_builder._get_ntuple_path(
         {}, {"Path": "path.root"}, {"Name": "nominal"}, ""
-    ) == Path("path.root")
+    ) == pathlib.Path("path.root")
 
     # systematic with override
     assert template_builder._get_ntuple_path(
@@ -45,12 +45,12 @@ def test__get_ntuple_path():
         {"Path": "path.root"},
         {"Name": "variation", "Up": {"Path": "variation.root"}},
         "Up",
-    ) == Path("variation.root")
+    ) == pathlib.Path("variation.root")
 
     # systematic without override
     assert template_builder._get_ntuple_path(
         {}, {"Path": "path.root"}, {"Name": "variation"}, "Up"
-    ) == Path("path.root")
+    ) == pathlib.Path("path.root")
 
 
 def test__get_variable():
@@ -178,7 +178,7 @@ def test_create_histograms(tmp_path, caplog, utils):
                 "Name": "var",
                 "Type": "NormPlusShape",
                 "Samples": "sample",
-                "Up": {"Path": fname_sys},
+                "Up": {"Path": str(fname_sys)},
             },
         ],
     }

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -40,14 +40,18 @@ def test_data_MC(mock_load, mock_draw, tmp_path):
         "Samples": [{"Name": "sample_1"}],
     }
 
-    visualize.data_MC(config, tmp_path, tmp_path, prefit=True, method="matplotlib")
+    tmp_path_str = str(tmp_path)
+
+    visualize.data_MC(
+        config, tmp_path_str, tmp_path_str, prefit=True, method="matplotlib"
+    )
 
     # the call_args_list contains calls (outer round brackets), first filled with
     # arguments (inner round brackets) and then keyword arguments
     assert mock_load.call_args_list == [
         (
             (
-                tmp_path,
+                tmp_path_str,
                 {"Name": "reg_1", "Variable": "x"},
                 {"Name": "sample_1"},
                 {"Name": "nominal"},
@@ -73,11 +77,15 @@ def test_data_MC(mock_load, mock_draw, tmp_path):
 
     # other plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
-        visualize.data_MC(config, tmp_path, tmp_path, prefit=True, method="unknown")
+        visualize.data_MC(
+            config, tmp_path_str, tmp_path_str, prefit=True, method="unknown"
+        )
 
     # postfit
     with pytest.raises(NotImplementedError, match="only prefit implemented so far"):
-        visualize.data_MC(config, tmp_path, tmp_path, prefit=False, method="matplotlib")
+        visualize.data_MC(
+            config, tmp_path_str, tmp_path_str, prefit=False, method="matplotlib"
+        )
 
 
 @mock.patch("cabinetry.contrib.matplotlib_visualize.correlation_matrix")

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -40,18 +40,14 @@ def test_data_MC(mock_load, mock_draw, tmp_path):
         "Samples": [{"Name": "sample_1"}],
     }
 
-    tmp_path_str = str(tmp_path)
-
-    visualize.data_MC(
-        config, tmp_path_str, tmp_path_str, prefit=True, method="matplotlib"
-    )
+    visualize.data_MC(config, tmp_path, tmp_path, prefit=True, method="matplotlib")
 
     # the call_args_list contains calls (outer round brackets), first filled with
     # arguments (inner round brackets) and then keyword arguments
     assert mock_load.call_args_list == [
         (
             (
-                tmp_path_str,
+                tmp_path,
                 {"Name": "reg_1", "Variable": "x"},
                 {"Name": "sample_1"},
                 {"Name": "nominal"},
@@ -77,15 +73,11 @@ def test_data_MC(mock_load, mock_draw, tmp_path):
 
     # other plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
-        visualize.data_MC(
-            config, tmp_path_str, tmp_path_str, prefit=True, method="unknown"
-        )
+        visualize.data_MC(config, tmp_path, tmp_path, prefit=True, method="unknown")
 
     # postfit
     with pytest.raises(NotImplementedError, match="only prefit implemented so far"):
-        visualize.data_MC(
-            config, tmp_path_str, tmp_path_str, prefit=False, method="matplotlib"
-        )
+        visualize.data_MC(config, tmp_path, tmp_path, prefit=False, method="matplotlib")
 
 
 @mock.patch("cabinetry.contrib.matplotlib_visualize.correlation_matrix")

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from pathlib import Path
+import pathlib
 from unittest import mock
 
 import numpy as np
@@ -95,7 +95,7 @@ def test_correlation_matrix(mock_draw):
     labels = ["a", "b", "c"]
     labels_pruned = ["a", "b"]
     folder_path = "tmp"
-    figure_path = Path(folder_path) / "correlation_matrix.pdf"
+    figure_path = pathlib.Path(folder_path) / "correlation_matrix.pdf"
 
     visualize.correlation_matrix(
         corr_mat, labels, folder_path, pruning_threshold=0.15, method="matplotlib"
@@ -125,7 +125,7 @@ def test_pulls(mock_draw):
     filtered_bestfit = np.asarray([1.0, 1.1])
     filtered_uncertainty = np.asarray([1.0, 0.7])
     filtered_labels = np.asarray(["b", "c"])
-    figure_path = Path(folder_path) / "pulls.pdf"
+    figure_path = pathlib.Path(folder_path) / "pulls.pdf"
 
     # with filtering
     visualize.pulls(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -128,7 +128,7 @@ def test_get_sys_modifiers():
     sample = {"Name": "Signal"}
     region = {}
     # needs to be expanded to include histogram loading
-    modifiers = workspace.get_sys_modifiers(config_example, region, sample, None)
+    modifiers = workspace.get_sys_modifiers(config_example, region, sample, "")
     expected_modifiers = [
         {"name": "sys", "type": "normsys", "data": {"hi": 1.1, "lo": 0.95}}
     ]
@@ -143,7 +143,7 @@ def test_get_sys_modifiers():
     with pytest.raises(
         NotImplementedError, match="not supporting other systematic types yet"
     ):
-        workspace.get_sys_modifiers(config_example_unsupported, region, sample, None)
+        workspace.get_sys_modifiers(config_example_unsupported, region, sample, "")
 
 
 @mock.patch("cabinetry.workspace.get_unc_for_sample", return_value=[0.1, 0.1])


### PR DESCRIPTION
Adding [typeguard](https://typeguard.readthedocs.io/en/latest/) to setup extras and enabling running it with `pytest`. It can also be used during runtime via the import hook

```
from typeguard.importhook import install_import_hook
install_import_hook("cabinetry")
import cabinetry
```

Fixing all issues raised by `typeguard`.

Also refactoring the path handling: the user-facing API should accept paths as `Union[str, pathlib.Path]`.