### PR TITLE
feat: command-line interface

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -7,24 +7,24 @@ Overrides for template building
 Introduction
 ^^^^^^^^^^^^
 
-It is possible to define functions that are called when `cabinetry` tries to construct a template histogram.
+It is possible to define functions that are called when ``cabinetry`` tries to construct a template histogram.
 Such functions need to accept four arguments in the following order:
 
 - a dictionary with information about the region being processed,
 - a dictionary with information about the sample being processed,
 - a dictionary with information about the systematic being processed,
-- a string with the name of the template being processed: `Nominal`, `Up` or `Down`.
+- a string with the name of the template being processed: ``Nominal``, ``Up`` or ``Down``.
 
 The function needs to return a `boost-histogram Histogram <https://boost-histogram.readthedocs.io/en/latest/usage/histogram.html>`_.
-This histogram is then further processed in `cabinetry`.
+This histogram is then further processed in ``cabinetry``.
 
 Example
 ^^^^^^^
 
-The example below defines a function `build_data_hist`.
-The decorator specifies that this function should be applied to all histograms for samples with name `Data`.
-It is also possible to specify `region_name`, `systematic_name` and `template` for the names of the region, systematic and template.
-When no user-defined function matches a given histogram that has to be produced, `cabinetry` falls back to use the default histogram creation methods.
+The example below defines a function ``build_data_hist``.
+The decorator specifies that this function should be applied to all histograms for samples with name ``Data``.
+It is also possible to specify ``region_name``, ``systematic_name`` and ``template`` for the names of the region, systematic and template.
+When no user-defined function matches a given histogram that has to be produced, ``cabinetry`` falls back to use the default histogram creation methods.
 
 .. code-block:: python
 
@@ -52,9 +52,9 @@ When no user-defined function matches a given histogram that has to be produced,
         cabinetry_config, histo_folder, method="uproot", router=my_router
     )
 
-The instance of `cabinetry.route.Router` is handed to `cabinetry.template_builder.create_histograms` to enable the use of `build_data_hist`.
+The instance of ``cabinetry.route.Router`` is handed to ``cabinetry.template_builder.create_histograms`` to enable the use of ``build_data_hist``.
 
-The function `build_data_hist` in this example always returns the same histogram.
+The function ``build_data_hist`` in this example always returns the same histogram.
 Given that the dictionaries in the function signature provide additional information, it is for example possible to return different yields per region:
 
 .. code-block:: python
@@ -89,4 +89,4 @@ All conditions need to be fulfilled to apply a user-defined function, so
     )
 
 means that for the decorated function to be executed, the region name needs to be `signal_region`, the sample needs to be called `signal`, the systematic needs to be `alpha_S`, but there is no restriction to the template name.
-Omitting `template` from the arguments, or using the default `template=None` has the same result.
+Omitting ``template`` from the arguments, or using the default ``template=None`` has the same result.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -2,12 +2,14 @@ CLI
 ===
 
 The installation of `cabinetry` includes a command line interface.
-Below is an example workflow that builds template histograms defined by the config file `config_example.yml`, then constructs a workspace and performs a fit.
+Below is an example workflow that builds template histograms defined by the config file `config_example.yml`, and applies post-processing to them.
+A `pyhf` workspace is then constructed and a maximum likelihood fit is performed.
 The resulting correlation matrix and pull plot are saved to the default output folder `figures/`.
 
 .. code-block:: bash
 
    cabinetry templates config_example.yml
+   cabinetry postprocess config_example.yml
    cabinetry workspace config_example.yml workspaces/example_workspace.json
    cabinetry fit --pulls --corrmat workspaces/example_workspace.json
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,10 +1,10 @@
 CLI
 ===
 
-The installation of `cabinetry` includes a command line interface.
-Below is an example workflow that builds template histograms defined by the config file `config_example.yml`, and applies post-processing to them.
-A `pyhf` workspace is then constructed and a maximum likelihood fit is performed.
-The resulting correlation matrix and pull plot are saved to the default output folder `figures/`.
+After installing ``cabinetry``, a command line interface is available.
+Below is an example workflow that builds template histograms defined by the config file ``config_example.yml``, and applies post-processing to them.
+A ``pyhf`` workspace is then constructed and a maximum likelihood fit is performed.
+The resulting correlation matrix and pull plot are saved to the default output folder ``figures/``.
 
 .. code-block:: bash
 
@@ -12,6 +12,20 @@ The resulting correlation matrix and pull plot are saved to the default output f
    cabinetry postprocess config_example.yml
    cabinetry workspace config_example.yml workspaces/example_workspace.json
    cabinetry fit --pulls --corrmat workspaces/example_workspace.json
+
+The ``--help`` flag can be used to obtain more information on the command line:
+
+.. code-block:: bash
+
+   cabinetry --help
+
+shows the available commands, while
+
+.. code-block:: bash
+
+   cabinetry fit --help
+
+shows what the ``fit`` command does, and which options it accepts.
 
 
 .. click:: cabinetry.cli:cabinetry

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,17 @@
+CLI
+===
+
+The installation of `cabinetry` includes a command line interface.
+Below is an example workflow that builds template histograms defined by the config file `config_example.yml`, then constructs a workspace and performs a fit.
+The resulting correlation matrix and pull plot are saved to the default output folder `figures/`.
+
+.. code-block:: bash
+
+   cabinetry templates config_example.yml
+   cabinetry workspace config_example.yml workspaces/example_workspace.json
+   cabinetry fit --pulls --corrmat workspaces/example_workspace.json
+
+
+.. click:: cabinetry.cli:cabinetry
+   :prog: cabinetry
+   :nested: full

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,7 @@ extensions = [
     "sphinx_rtd_theme",
     "sphinx_copybutton",
     "sphinx-jsonschema",
+    "sphinx_click",
 ]
 
 import sphinx_rtd_theme

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,11 +1,11 @@
 Configuration schema
 ====================
 
-The configuration schema for `cabinetry` is given below.
+The configuration schema for ``cabinetry`` is given below.
 It is defined via a `json schema <https://json-schema.org/>`_ that can be found at `src/cabinetry/schemas/config.json <https://github.com/alexander-held/cabinetry/blob/master/src/cabinetry/schemas/config.json>`_.
 
-The `General` block holds general settings, followed by blocks that take lists of objects: regions, samples, normalization factors, and systematics.
-The `Regions`, `Samples` and `NormFactors` blocks are required, while `Systematics` is optional.
+The ``General`` block holds general settings, followed by blocks that take lists of objects: regions, samples, normalization factors, and systematics.
+The ``Regions``, ``Samples`` and ``NormFactors`` blocks are required, while ``Systematics`` is optional.
 Settings shown in bold are required.
 
 .. jsonschema:: ../src/cabinetry/schemas/config.json#/properties/General

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-`cabinetry`
+cabinetry
 ==============================
 
 .. toctree::
@@ -11,7 +11,7 @@
    api
    license
 
-`cabinetry` is a tool to build and steer (profile likelihood) template fits with applications in high energy physics in mind.
+``cabinetry`` is a tool to build and steer (profile likelihood) template fits with applications in high energy physics in mind.
 It acts as an interface to many powerful tools to make it easier for an analyzer to run their statistical inference pipeline.
 
 This documentation can be viewed `on Read the Docs <https://cabinetry.readthedocs.io/>`_ or locally via
@@ -21,9 +21,9 @@ This documentation can be viewed `on Read the Docs <https://cabinetry.readthedoc
    sphinx-build docs docs/_build
    open docs/_build/index.html
 
-It contains a description of the `cabinetry` configuration file schema, as well as the public facing API.
+It contains a description of the ``cabinetry`` configuration file schema, as well as the public facing API.
 
-See the `README on github <https://github.com/alexander-held/cabinetry/blob/master/README.md>`_ for an example of using `cabinetry`.
+See the `README on github <https://github.com/alexander-held/cabinetry/blob/master/README.md>`_ for an example of using ``cabinetry``.
 
 Acknowledgements
 ----------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@
    :maxdepth: 1
 
    config
+   cli
    advanced
    api
    license

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[options.entry_points]
+console_scripts =
+    cabinetry = cabinetry.cli:cabinetry
+
 [tool:pytest]
 addopts = --cov=cabinetry --cov-report html --cov-report term-missing --cov-branch --typeguard-packages=cabinetry
 filterwarnings =

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ console_scripts =
 addopts = --cov=cabinetry --cov-report html --cov-report term-missing --cov-branch --typeguard-packages=cabinetry
 filterwarnings =
     ignore::DeprecationWarning:uproot:
+    ignore:no type annotations present:UserWarning:typeguard:
 
 [flake8]
 max-complexity = 10

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ console_scripts =
     cabinetry = cabinetry.cli:cabinetry
 
 [tool:pytest]
-addopts = --cov=cabinetry --cov-report html --cov-report term-missing --cov-branch --typeguard-packages=cabinetry
+addopts = --cov=cabinetry --cov-report html --cov-report term-missing --cov-branch -rsx --typeguard-packages=cabinetry -s
 filterwarnings =
     ignore::DeprecationWarning:uproot:
     ignore:no type annotations present:UserWarning:typeguard:

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ console_scripts =
     cabinetry = cabinetry.cli:cabinetry
 
 [tool:pytest]
-addopts = --cov=cabinetry --cov-report html --cov-report term-missing --cov-branch -rsx --typeguard-packages=cabinetry -s
+addopts = --cov=cabinetry --cov-report html --cov-report term-missing --cov-branch -rsx --typeguard-packages=cabinetry
 filterwarnings =
     ignore::DeprecationWarning:uproot:
     ignore:no type annotations present:UserWarning:typeguard:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,15 @@ extras_require["test"] = sorted(
     )
 )
 extras_require["docs"] = sorted(
-    set(["sphinx", "sphinx-copybutton", "sphinx-jsonschema", "sphinx-rtd-theme"])
+    set(
+        [
+            "sphinx",
+            "sphinx-click",
+            "sphinx-copybutton",
+            "sphinx-jsonschema",
+            "sphinx-rtd-theme",
+        ]
+    )
 )
 
 extras_require["develop"] = sorted(
@@ -61,6 +69,7 @@ setup(
         "iminuit>1.4.0",
         "boost_histogram",
         "jsonschema",
+        "click",
     ],
     extras_require=extras_require,
 )

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -75,7 +75,7 @@ def postprocess(config_path: str, histofolder: str) -> None:
     "--histofolder", default="histograms/", help="folder containing histograms"
 )
 def workspace(config_path: str, ws_path: str, histofolder: str) -> None:
-    """Produce a `pyhf` workspace.
+    """Produce a ``pyhf`` workspace.
 
     CONFIG_PATH: path to cabinetry configuration file
 

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -20,7 +20,7 @@ class OrderedGroup(click.Group):
 
 
 def set_logging() -> None:
-    """setup log levels and format for CLI
+    """set log levels and format for CLI
     """
     logging.basicConfig(
         level=logging.INFO, format="%(levelname)s - %(name)s - %(message)s"

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -32,7 +32,7 @@ def set_logging() -> None:
 def cabinetry() -> None:
     """Entrypoint to the cabinetry CLI.
     """
-    pass  # NOQA
+    ...
 
 
 @click.command()

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -6,6 +6,7 @@ import click
 from .. import configuration as cabinetry_configuration
 from .. import fit as cabinetry_fit
 from .. import template_builder as cabinetry_template_builder
+from .. import template_postprocessor as cabinetry_template_postprocessor
 from .. import visualize as cabinetry_visualize
 from .. import workspace as cabinetry_workspace
 
@@ -54,6 +55,21 @@ def templates(config_path: str, histofolder: str, method: str) -> None:
 
 @click.command()
 @click.argument("config_path", type=click.Path(exists=True))
+@click.option(
+    "--histofolder", default="histograms/", help="folder to save histograms to"
+)
+def postprocess(config_path: str, histofolder: str) -> None:
+    """Post-process template histograms.
+
+    CONFIG_PATH: path to cabinetry configuration file
+    """
+    set_logging()
+    cabinetry_config = cabinetry_configuration.read(config_path)
+    cabinetry_template_postprocessor.run(cabinetry_config, histofolder)
+
+
+@click.command()
+@click.argument("config_path", type=click.Path(exists=True))
 @click.argument("ws_path", type=click.Path(exists=False))
 @click.option(
     "--histofolder", default="histograms/", help="folder containing histograms"
@@ -91,5 +107,6 @@ def fit(ws_path: str, pulls: bool, corrmat: bool, figfolder: str) -> None:
 
 
 cabinetry.add_command(templates)
+cabinetry.add_command(postprocess)
 cabinetry.add_command(workspace)
 cabinetry.add_command(fit)

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -32,7 +32,6 @@ def set_logging() -> None:
 def cabinetry() -> None:
     """Entrypoint to the cabinetry CLI.
     """
-    ...
 
 
 @click.command()

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -19,7 +19,7 @@ class OrderedGroup(click.Group):
         return self.commands.keys()
 
 
-def set_logging() -> None:
+def _set_logging() -> None:
     """set log levels and format for CLI
     """
     logging.basicConfig(
@@ -45,7 +45,7 @@ def templates(config_path: str, histofolder: str, method: str) -> None:
 
     CONFIG_PATH: path to cabinetry configuration file
     """
-    set_logging()
+    _set_logging()
     cabinetry_config = cabinetry_configuration.read(config_path)
     cabinetry_template_builder.create_histograms(
         cabinetry_config, histofolder, method=method
@@ -62,7 +62,7 @@ def postprocess(config_path: str, histofolder: str) -> None:
 
     CONFIG_PATH: path to cabinetry configuration file
     """
-    set_logging()
+    _set_logging()
     cabinetry_config = cabinetry_configuration.read(config_path)
     cabinetry_template_postprocessor.run(cabinetry_config, histofolder)
 
@@ -80,7 +80,7 @@ def workspace(config_path: str, ws_path: str, histofolder: str) -> None:
 
     WS_PATH: where to save the workspace containing the fit model
     """
-    set_logging()
+    _set_logging()
     cabinetry_config = cabinetry_configuration.read(config_path)
     ws = cabinetry_workspace.build(cabinetry_config, histofolder)
     cabinetry_workspace.save(ws, ws_path)
@@ -96,7 +96,7 @@ def fit(ws_path: str, pulls: bool, corrmat: bool, figfolder: str) -> None:
 
     WS_PATH: path to workspace used in fit
     """
-    set_logging()
+    _set_logging()
     ws = cabinetry_workspace.load(ws_path)
     bestfit, uncertainty, labels, _, corr_mat = cabinetry_fit.fit(ws)
     if pulls:

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -31,7 +31,7 @@ def set_logging() -> None:
 def cabinetry() -> None:
     """Entrypoint to the cabinetry CLI.
     """
-    pass
+    pass  # NOQA
 
 
 @click.command()

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -29,47 +29,57 @@ def set_logging() -> None:
 
 @click.group(cls=OrderedGroup)
 def cabinetry() -> None:
-    """entrypoint to the cabinetry CLI
+    """Entrypoint to the cabinetry CLI.
     """
     pass
 
 
 @click.command()
-@click.argument("config_path")
+@click.argument("config_path", type=click.Path(exists=True))
 @click.option(
     "--histofolder", default="histograms/", help="folder to save histograms to"
 )
 @click.option("--method", default="uproot", help="backend for histogram production")
 def templates(config_path: str, histofolder: str, method: str) -> None:
-    """produce template histograms
+    """Produce template histograms.
+
+    CONFIG_PATH: path to cabinetry configuration file
     """
     set_logging()
-    config = cabinetry_configuration.read(config_path)
-    cabinetry_template_builder.create_histograms(config, histofolder, method=method)
+    cabinetry_config = cabinetry_configuration.read(config_path)
+    cabinetry_template_builder.create_histograms(
+        cabinetry_config, histofolder, method=method
+    )
 
 
 @click.command()
-@click.argument("config_path")
-@click.argument("ws_path")
+@click.argument("config_path", type=click.Path(exists=True))
+@click.argument("ws_path", type=click.Path(exists=False))
 @click.option(
     "--histofolder", default="histograms/", help="folder containing histograms"
 )
 def workspace(config_path: str, ws_path: str, histofolder: str) -> None:
-    """produce a `pyhf` workspace
+    """Produce a `pyhf` workspace.
+
+    CONFIG_PATH: path to cabinetry configuration file
+
+    WS_PATH: where to save the workspace containing the fit model
     """
     set_logging()
-    config = cabinetry_configuration.read(config_path)
-    ws = cabinetry_workspace.build(config, histofolder)
+    cabinetry_config = cabinetry_configuration.read(config_path)
+    ws = cabinetry_workspace.build(cabinetry_config, histofolder)
     cabinetry_workspace.save(ws, ws_path)
 
 
 @click.command()
-@click.argument("ws_path")
+@click.argument("ws_path", type=click.Path(exists=True))
 @click.option("--pulls", is_flag=True, help="produce pull plot")
 @click.option("--corrmat", is_flag=True, help="produce correlation matrix")
 @click.option("--figfolder", default="figures/", help="folder to save figures to")
 def fit(ws_path: str, pulls: bool, corrmat: bool, figfolder: str) -> None:
-    """fit a workspace and optionally visualize the results
+    """Fit a workspace and optionally visualize the results.
+
+    WS_PATH: path to workspace used in fit
     """
     set_logging()
     ws = cabinetry_workspace.load(ws_path)

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -1,0 +1,85 @@
+import logging
+from typing import Any, KeysView
+
+import click
+
+from .. import configuration as cabinetry_configuration
+from .. import fit as cabinetry_fit
+from .. import template_builder as cabinetry_template_builder
+from .. import visualize as cabinetry_visualize
+from .. import workspace as cabinetry_workspace
+
+
+class OrderedGroup(click.Group):
+    """a group that shows commands in the order they were added
+    """
+
+    def list_commands(self, _: Any) -> KeysView[str]:
+        return self.commands.keys()
+
+
+def set_logging() -> None:
+    """setup log levels and format for CLI
+    """
+    logging.basicConfig(
+        level=logging.INFO, format="%(levelname)s - %(name)s - %(message)s"
+    )
+    logging.getLogger("pyhf").setLevel(logging.WARNING)
+
+
+@click.group(cls=OrderedGroup)
+def cabinetry() -> None:
+    """entrypoint to the cabinetry CLI
+    """
+    pass
+
+
+@click.command()
+@click.argument("config_path")
+@click.option(
+    "--histofolder", default="histograms/", help="folder to save histograms to"
+)
+@click.option("--method", default="uproot", help="backend for histogram production")
+def templates(config_path: str, histofolder: str, method: str) -> None:
+    """produce template histograms
+    """
+    set_logging()
+    config = cabinetry_configuration.read(config_path)
+    cabinetry_template_builder.create_histograms(config, histofolder, method=method)
+
+
+@click.command()
+@click.argument("config_path")
+@click.argument("ws_path")
+@click.option(
+    "--histofolder", default="histograms/", help="folder containing histograms"
+)
+def workspace(config_path: str, ws_path: str, histofolder: str) -> None:
+    """produce a `pyhf` workspace
+    """
+    set_logging()
+    config = cabinetry_configuration.read(config_path)
+    ws = cabinetry_workspace.build(config, histofolder)
+    cabinetry_workspace.save(ws, ws_path)
+
+
+@click.command()
+@click.argument("ws_path")
+@click.option("--pulls", is_flag=True, help="produce pull plot")
+@click.option("--corrmat", is_flag=True, help="produce correlation matrix")
+@click.option("--figfolder", default="figures/", help="folder to save figures to")
+def fit(ws_path: str, pulls: bool, corrmat: bool, figfolder: str) -> None:
+    """fit a workspace and optionally visualize the results
+    """
+    set_logging()
+    ws = cabinetry_workspace.load(ws_path)
+    bestfit, uncertainty, labels, _, corr_mat = cabinetry_fit.fit(ws)
+    if pulls:
+        cabinetry_visualize.pulls(bestfit, uncertainty, labels, figfolder)
+    if corrmat:
+        cabinetry_visualize.correlation_matrix(corr_mat, labels, figfolder)
+
+
+cabinetry.add_command(templates)
+cabinetry.add_command(workspace)
+cabinetry.add_command(fit)

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -216,7 +216,7 @@ def apply_to_all_templates(
     default_func: ProcessorFunc,
     match_func: Optional[MatchFunc] = None,
 ) -> None:
-    """Apply the supplied function `default_func` to all templates specified by the
+    """Apply the supplied function ``default_func`` to all templates specified by the
     configuration file. This function takes four arguments in this order:
 
     - the dict specifying region information
@@ -231,7 +231,7 @@ def apply_to_all_templates(
         config (Dict[str, Any]): cabinetry configuration
         default_func (ProcessorFunc): function to be called for every template by default
         match_func: (Optional[MatchFunc], optional): function that returns user-defined functions
-            to override the call to `default_func`, defaults to None (then it is not used)
+            to override the call to ``default_func``, defaults to None (then it is not used)
     """
     for region in config["Regions"]:
         log.debug(f"  in region {region['Name']}")

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -232,7 +232,7 @@ class _Builder:
             )
 
         else:
-            raise NotImplementedError("unknown backend")
+            raise NotImplementedError(f"unknown backend {self.method}")
 
         # store information in a Histogram instance and save it
         histogram = histo.Histogram.from_arrays(bins, yields, stdev)

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -268,7 +268,7 @@ class _Builder:
     def _wrap_custom_template_builder(
         self, func: route.UserTemplateFunc,
     ) -> route.ProcessorFunc:
-        """Wrapper for custom template builder functions that return a `boost_histogram.Histogram`.
+        """Wrapper for custom template builder functions that return a ``boost_histogram.Histogram``.
         Returns a function that executes the custom template builder and saves the resulting
         histogram.
 
@@ -317,8 +317,8 @@ def create_histograms(
     router: Optional[route.Router] = None,
 ) -> None:
     """generate all required histograms specified by the configuration file,
-    calling either a default method specified via `method`, or a custom
-    user-defined override through `router`
+    calling either a default method specified via ``method``, or a custom
+    user-defined override through ``router``
 
     Args:
         config (Dict[str, Any]): cabinetry configuration

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -48,8 +48,8 @@ def _get_postprocessor(
     histogram_folder: Union[str, pathlib.Path]
 ) -> route.ProcessorFunc:
     """return the postprocessing function to be applied to template histograms, for
-    example via `cabinetry.route.apply_to_all_templates`
-    could alternatively create a `Postprocessor` class that contains processors
+    example via ``cabinetry.route.apply_to_all_templates``
+    could alternatively create a ``Postprocessor`` class that contains processors
 
     Args:
         histogram_folder (Union[str, pathlib.Path]): folder containing histograms

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -124,14 +124,18 @@ def test_workspace(mock_read, mock_build, mock_save, cli_helpers, tmp_path):
 @mock.patch("cabinetry.visualize.pulls")
 @mock.patch("cabinetry.fit.fit", return_value=([1.0], [0.1], "label", None, [[1.0]]))
 @mock.patch("cabinetry.workspace.load", return_value={"workspace": "mock"})
-def test_fit(mock_load, mock_fit, mock_pulls, mock_corrmat):
+def test_fit(mock_load, mock_fit, mock_pulls, mock_corrmat, tmp_path):
     workspace = {"workspace": "mock"}
     bestfit = [1.0]
     uncertainty = [0.1]
     labels = "label"
     corr_mat = [[1.0]]
 
-    workspace_path = "workspace.json"
+    workspace_path = str(tmp_path / "workspace.json")
+
+    # need to save workspace to file since click looks for it
+    with open(workspace_path, "w") as f:
+        f.write("{'workspace': 'mock'}")
 
     runner = CliRunner()
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,0 +1,89 @@
+from unittest import mock
+
+from click.testing import CliRunner
+import pytest
+import yaml
+
+from cabinetry import cli
+
+
+class CLIHelpers:
+    @staticmethod
+    def write_config(path, config):
+        with open(path, "w") as f:
+            yaml.dump(config, f)
+
+
+@pytest.fixture
+def cli_helpers():
+    return CLIHelpers
+
+
+def test_cabinetry():
+    runner = CliRunner()
+    result = runner.invoke(cli.cabinetry, ["--help"])
+    assert result.exit_code == 0
+    assert "Entrypoint to the cabinetry CLI." in result.output
+
+
+@mock.patch("cabinetry.template_builder.create_histograms")
+@mock.patch(
+    "cabinetry.configuration.read",
+    return_value={"General": {"Measurement": "test_config"}},
+)
+def test_templates(mock_read, mock_create_histograms, cli_helpers, tmp_path):
+    config = {"General": {"Measurement": "test_config"}}
+
+    config_path = str(tmp_path / "config.yml")
+    cli_helpers.write_config(config_path, config)
+
+    runner = CliRunner()
+
+    # default histogram folder
+    result = runner.invoke(cli.templates, [config_path])
+    assert result.exit_code == 0
+    assert mock_read.call_args_list == [((config_path,), {})]
+    assert mock_create_histograms.call_args_list == [
+        ((config, "histograms/"), {"method": "uproot"})
+    ]
+
+    # specified histogram folder
+    result = runner.invoke(cli.templates, ["--histofolder", "path/", config_path])
+    assert result.exit_code == 0
+    assert mock_create_histograms.call_args_list[-1] == (
+        (config, "path/"),
+        {"method": "uproot"},
+    )
+
+    # different method
+    result = runner.invoke(cli.templates, ["--method", "unknown", config_path])
+    assert result.exit_code == 0
+    assert mock_create_histograms.call_args_list[-1] == (
+        (config, "histograms/"),
+        {"method": "unknown"},
+    )
+
+
+@mock.patch("cabinetry.template_postprocessor.run")
+@mock.patch(
+    "cabinetry.configuration.read",
+    return_value={"General": {"Measurement": "test_config"}},
+)
+def test_postprocess(mock_read, mock_postprocess, cli_helpers, tmp_path):
+    config = {"General": {"Measurement": "test_config"}}
+
+    config_path = str(tmp_path / "config.yml")
+    cli_helpers.write_config(config_path, config)
+
+    runner = CliRunner()
+
+    # default histogram folder
+    result = runner.invoke(cli.postprocess, [config_path])
+    assert result.exit_code == 0
+    assert mock_read.call_args_list == [((config_path,), {})]
+    assert mock_postprocess.call_args_list == [((config, "histograms/"), {})]
+
+    # specified histogram folder
+    result = runner.invoke(cli.postprocess, ["--histofolder", "path/", config_path])
+    assert result.exit_code == 0
+    assert mock_postprocess.call_args_list[-1] == ((config, "path/"), {})

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -87,3 +87,79 @@ def test_postprocess(mock_read, mock_postprocess, cli_helpers, tmp_path):
     result = runner.invoke(cli.postprocess, ["--histofolder", "path/", config_path])
     assert result.exit_code == 0
     assert mock_postprocess.call_args_list[-1] == ((config, "path/"), {})
+
+
+@mock.patch("cabinetry.workspace.save")
+@mock.patch("cabinetry.workspace.build", return_value={"workspace": "mock"})
+@mock.patch(
+    "cabinetry.configuration.read",
+    return_value={"General": {"Measurement": "test_config"}},
+)
+def test_workspace(mock_read, mock_build, mock_save, cli_helpers, tmp_path):
+    config = {"General": {"Measurement": "test_config"}}
+
+    config_path = str(tmp_path / "config.yml")
+    cli_helpers.write_config(config_path, config)
+
+    workspace_path = str(tmp_path / "workspace.json")
+
+    runner = CliRunner()
+
+    # default histogram folder
+    result = runner.invoke(cli.workspace, [config_path, workspace_path])
+    assert result.exit_code == 0
+    assert mock_read.call_args_list == [((config_path,), {})]
+    assert mock_build.call_args_list == [((config, "histograms/"), {})]
+    assert mock_save.call_args_list == [(({"workspace": "mock"}, workspace_path), {})]
+
+    # specified histogram folder
+    result = runner.invoke(
+        cli.workspace, ["--histofolder", "path/", config_path, workspace_path]
+    )
+    assert result.exit_code == 0
+    assert mock_build.call_args_list[-1] == ((config, "path/"), {})
+
+
+@mock.patch("cabinetry.visualize.correlation_matrix")
+@mock.patch("cabinetry.visualize.pulls")
+@mock.patch("cabinetry.fit.fit", return_value=([1.0], [0.1], "label", None, [[1.0]]))
+@mock.patch("cabinetry.workspace.load", return_value={"workspace": "mock"})
+def test_fit(mock_load, mock_fit, mock_pulls, mock_corrmat):
+    workspace = {"workspace": "mock"}
+    bestfit = [1.0]
+    uncertainty = [0.1]
+    labels = "label"
+    corr_mat = [[1.0]]
+
+    workspace_path = "workspace.json"
+
+    runner = CliRunner()
+
+    # default
+    result = runner.invoke(cli.fit, [workspace_path])
+    assert result.exit_code == 0
+    assert mock_load.call_args_list == [((workspace_path,), {})]
+    assert mock_fit.call_args_list == [((workspace,), {})]
+
+    # pull plot
+    result = runner.invoke(cli.fit, ["--pulls", workspace_path])
+    assert result.exit_code == 0
+    assert mock_pulls.call_args_list == [
+        ((bestfit, uncertainty, labels, "figures/"), {})
+    ]
+
+    # correlation matrix plot
+    result = runner.invoke(cli.fit, ["--corrmat", workspace_path])
+    assert result.exit_code == 0
+    assert mock_corrmat.call_args_list == [((corr_mat, labels, "figures/"), {})]
+
+    # both plots, different folder
+    result = runner.invoke(
+        cli.fit, ["--figfolder", "folder/", "--pulls", "--corrmat", workspace_path]
+    )
+    assert result.exit_code == 0
+    assert mock_corrmat.call_args_list[-1] == ((corr_mat, labels, "folder/"), {})
+    assert mock_pulls.call_args_list[-1] == (
+        (bestfit, uncertainty, labels, "folder/"),
+        {},
+    )

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -193,7 +193,7 @@ def test__Builder_create_histogram(mock_uproot_builder, mock_histo, mock_save):
 
     # other backends
     builder_unknown = template_builder._Builder("path", "unknown")
-    with pytest.raises(NotImplementedError, match="unknown backend"):
+    with pytest.raises(NotImplementedError, match="unknown backend unknown"):
         builder_unknown._create_histogram(region, sample, systematic, "Nominal")
 
 

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -32,7 +32,7 @@ def test_data_MC(mock_load, mock_draw, tmp_path):
     """contrib.matplotlib_visualize is only imported depending on the keyword argument,
     so cannot patch via cabinetry.visualize.matplotlib_visualize
     Generally it seems like following the path to the module is preferred, but that
-    does not work for the `data_MC` case. For some information see also
+    does not work for the ``data_MC`` case. For some information see also
     https://docs.python.org/3/library/unittest.mock.html#where-to-patch
     """
     config = {


### PR DESCRIPTION
Adding a basic CLI built with `click`. Documentation is added via `sphinx-click`. The entrypoint to the CLI is `cabinetry`, `cabinetry --help` to see the available commands.

Fixing inline code formatting by using two backticks instead of one.