### PR TITLE
feat: support fixed parameters

### DIFF
--- a/config_example.yml
+++ b/config_example.yml
@@ -55,4 +55,3 @@ NormFactors:
     Samples: "Signal"
     Nominal: 1
     Bounds: [0, 5]
-    Fixed: False

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     install_requires=[
         "numpy",
         "pyyaml",
-        "pyhf>=0.5.0",
+        "pyhf>=0.5.1",  # fixed parameter bookkeeping #989
         "iminuit>1.4.0",
         "boost_histogram",
         "jsonschema",

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -111,8 +111,9 @@ def custom_fit(
 
     init_pars = model.config.suggested_init()
     par_bounds = model.config.suggested_bounds()
+    fix_pars = model.config.suggested_fixed()
+
     step_size = [0.1 for _ in init_pars]
-    fix_pars = [False for _ in init_pars]
 
     labels = get_parameter_names(model)
 

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -61,6 +61,28 @@
                 "POI": {
                     "description": "name of parameter of interest",
                     "type": "string"
+                },
+                "Fixed": {
+                    "description": "list of parameters to treat as constant in fits",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "description": "a fixed parameter",
+                        "type": "object",
+                        "required": ["Name", "Value"],
+                        "properties": {
+                            "Name": {
+                                "description": "name of fixed parameter",
+                                "type": "string"
+                            },
+                            "Value": {
+                                "description": "value to fix parameter to",
+                                "type": "number"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "uniqueItems": true
                 }
             },
             "additionalProperties": false

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -177,10 +177,6 @@
                         "type": "number"
                     },
                     "uniqueItems": true
-                },
-                "Fixed": {
-                    "description": "if the normalization factor is a constant",
-                    "type": "boolean"
                 }
             },
             "additionalProperties": false

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -361,6 +361,10 @@ def get_measurements(config: Dict[str, Any]) -> List[Dict[str, Any]]:
         init = nf.get("Nominal", None)
         bounds = nf.get("Bounds", None)
         fixed = _find_constant_parameter_setting(config, nf_name)
+        if (init is None) and (fixed is not None):
+            # if no initial value is specified, but a constant setting
+            # is requested, set the initial value to the constant value
+            init = fixed
 
         parameter = {"name": nf_name}
         if init is not None:
@@ -371,7 +375,7 @@ def get_measurements(config: Dict[str, Any]) -> List[Dict[str, Any]]:
             log.warning(
                 "fixed parameters are currently only respected in fit.custom_fit"
             )
-            parameter.update({"fixed": fixed})
+            parameter.update({"fixed": True})
 
         parameters_list.append(parameter)
 

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -380,6 +380,9 @@ def get_measurements(config: Dict[str, Any]) -> List[Dict[str, Any]]:
         parameters_list.append(parameter)
 
     for sys in config.get("Systematics", []):
+        # when there are many more systematics than NormFactors, it would be more
+        # efficient to loop over fixed parameters and exclude all NormFactor related
+        # ones to set all the remaining ones to constant (which are systematics)
         sys_name = sys["Name"]  # every systematic has a name
         fixed = _get_constant_parameter_setting(config, sys_name)
         if fixed is not None:

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -28,7 +28,7 @@ def _get_data_sample(config: Dict[str, Any]) -> Dict[str, Any]:
     return data_samples[0]
 
 
-def _find_constant_parameter_setting(
+def _get_constant_parameter_setting(
     config: Dict[str, Any], par_name: str
 ) -> Optional[float]:
     """for a given parameter, determine if it is supposed to be set to constant, and if yes,
@@ -360,7 +360,7 @@ def get_measurements(config: Dict[str, Any]) -> List[Dict[str, Any]]:
         nf_name = nf["Name"]  # every NormFactor has a name
         init = nf.get("Nominal", None)
         bounds = nf.get("Bounds", None)
-        fixed = _find_constant_parameter_setting(config, nf_name)
+        fixed = _get_constant_parameter_setting(config, nf_name)
         if (init is None) and (fixed is not None):
             # if no initial value is specified, but a constant setting
             # is requested, set the initial value to the constant value
@@ -381,7 +381,7 @@ def get_measurements(config: Dict[str, Any]) -> List[Dict[str, Any]]:
 
     for sys in config.get("Systematics", []):
         sys_name = sys["Name"]  # every systematic has a name
-        fixed = _find_constant_parameter_setting(config, sys_name)
+        fixed = _get_constant_parameter_setting(config, sys_name)
         if fixed is not None:
             log.warning(
                 "fixed parameters are currently only respected in fit.custom_fit"

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -34,7 +34,13 @@ def example_spec():
             }
         ],
         "measurements": [
-            {"config": {"parameters": [], "poi": "Signal strength"}, "name": "My fit"}
+            {
+                "config": {
+                    "parameters": [{"name": "staterror_Signal-Region", "fixed": True}],
+                    "poi": "Signal strength",
+                },
+                "name": "My fit",
+            }
         ],
         "observations": [{"data": [475], "name": "Signal Region"}],
         "version": "1.0.0",
@@ -77,10 +83,9 @@ def test_custom_fit(example_spec):
     bestfit, uncertainty, labels, best_twice_nll, corr_mat = fit.custom_fit(
         example_spec
     )
-    # the results match those from fit.fit(),
-    # unless the tolerance is decreased significantly
-    assert np.allclose(bestfit, [0.99998772, 9.16255687])
-    assert np.allclose(uncertainty, [0.04954955, 0.61348804])
+    # compared to fit(), the gamma is fixed
+    assert np.allclose(bestfit, [1.0, 9.16273912])
+    assert np.allclose(uncertainty, [0.1, 0.41879022])
     assert labels == ["staterror_Signal-Region", "Signal strength"]
-    assert np.allclose(best_twice_nll, 3.83054341)
-    assert np.allclose(corr_mat, [[1.0, -0.73366055], [-0.73366055, 1.0]])
+    assert np.allclose(best_twice_nll, 3.83054248)
+    assert np.allclose(corr_mat, [[1.0]])

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -197,14 +197,7 @@ def test_get_measurement():
             "name": "fit",
             "config": {
                 "poi": "mu",
-                "parameters": [
-                    {
-                        "name": "NF",
-                        "inits": [1.0],
-                        "bounds": [[0.0, 5.0]],
-                        "fixed": False,
-                    }
-                ],
+                "parameters": [{"name": "NF", "inits": [1.0], "bounds": [[0.0, 5.0]]}],
             },
         }
     ]

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -17,17 +17,17 @@ def test__get_data_sample():
         workspace._get_data_sample(config_two_data_samples)
 
 
-def test__find_constant_parameter_setting():
+def test__get_constant_parameter_setting():
     config_no_fixed = {"General": {}}
-    assert workspace._find_constant_parameter_setting(config_no_fixed, "par") is None
+    assert workspace._get_constant_parameter_setting(config_no_fixed, "par") is None
 
     config_others_fixed = {"General": {"Fixed": [{"Name": "par_a", "Value": 1.2}]}}
     assert (
-        workspace._find_constant_parameter_setting(config_others_fixed, "par_b") is None
+        workspace._get_constant_parameter_setting(config_others_fixed, "par_b") is None
     )
 
     config_par_fixed = {"General": {"Fixed": [{"Name": "par_a", "Value": 1.2}]}}
-    assert workspace._find_constant_parameter_setting(config_par_fixed, "par_a") == 1.2
+    assert workspace._get_constant_parameter_setting(config_par_fixed, "par_a") == 1.2
 
 
 @mock.patch(
@@ -231,7 +231,7 @@ def test_get_measurement():
 
     # constant normfactor
     with mock.patch(
-        "cabinetry.workspace._find_constant_parameter_setting", return_value=1.2
+        "cabinetry.workspace._get_constant_parameter_setting", return_value=1.2
     ) as mock_find_const:
         expected_measurement_const_NF = [
             {
@@ -252,7 +252,7 @@ def test_get_measurement():
 
     # constant systematic
     with mock.patch(
-        "cabinetry.workspace._find_constant_parameter_setting", return_value=1.2
+        "cabinetry.workspace._get_constant_parameter_setting", return_value=1.2
     ) as mock_find_const:
         example_config_const_sys = {
             "General": {
@@ -281,7 +281,7 @@ def test_get_measurement():
 
     # no constant systematic
     with mock.patch(
-        "cabinetry.workspace._find_constant_parameter_setting", return_value=None
+        "cabinetry.workspace._get_constant_parameter_setting", return_value=None
     ) as mock_find_const:
         example_config_sys = {
             "General": {"Measurement": "fit", "POI": "mu"},


### PR DESCRIPTION
Adding a new config option to fix parameters:
```yaml
General:
  Fixed: [{Name: "Signal_norm", Value: 0.3}]
```

Workspaces built from the config contain the information about fixed parameters. Make use of https://github.com/scikit-hep/pyhf/pull/989 to read fixed parameters from the workspace and propagate that information to Minuit in `custom_fit`. Raising minimum `pyhf` version to 0.5.1 to support this. At the moment only `fit.custom_fit` respects fixed parameters, that will change eventually (https://github.com/scikit-hep/pyhf/pull/846).

This does not include improvements for plots to handle constant parameters.