### PR TITLE
feat: always calculate Hessian

### DIFF
--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -134,6 +134,7 @@ def custom_fit(
     # decrease tolerance (goal: EDM < 0.002*tol*errordef), default tolerance is 0.1
     m.tol /= 10
     m.migrad()
+    m.hesse()
 
     corr_mat = m.np_matrix(correlation=True)
     bestfit = m.np_values()

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -85,7 +85,7 @@ def test_custom_fit(example_spec):
     )
     # compared to fit(), the gamma is fixed
     assert np.allclose(bestfit, [1.0, 9.16273912])
-    assert np.allclose(uncertainty, [0.1, 0.41879022])
+    assert np.allclose(uncertainty, [0.1, 0.41879343])
     assert labels == ["staterror_Signal-Region", "Signal strength"]
     assert np.allclose(best_twice_nll, 3.83054248)
     assert np.allclose(corr_mat, [[1.0]])


### PR DESCRIPTION
Always run the Minuit HESSE algorithm after MIGRAD in `cabinetry.fit.custom_fit`. Section 7.2 in https://root.cern.ch/download/minuit.pdf describes the differences.