### PR TITLE
docs: NSF badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,4 +146,6 @@ The basic implementations that exist there help with API design.
 
 ## Acknowledgements
 
-This work was supported by the U.S. National Science Foundation (NSF) cooperative agreement OAC-1836650 (IRIS-HEP).
+[![NSF-1836650](https://img.shields.io/badge/NSF-1836650-blue.svg)](https://nsf.gov/awardsearch/showAward?AWD_ID=1836650)
+
+This work was supported by the U.S. National Science Foundation (NSF) cooperative agreement [OAC-1836650 (IRIS-HEP)](https://nsf.gov/awardsearch/showAward?AWD_ID=1836650).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,4 +27,4 @@ See the `README on github <https://github.com/alexander-held/cabinetry/blob/mast
 
 Acknowledgements
 ----------------
-This work was supported by the U.S. National Science Foundation (NSF) cooperative agreement OAC-1836650 (IRIS-HEP).
+This work was supported by the U.S. National Science Foundation (NSF) cooperative agreement `OAC-1836650 (IRIS-HEP) <https://nsf.gov/awardsearch/showAward?AWD_ID=1836650>`_.


### PR DESCRIPTION
Adding a new badge to the readme:

[![NSF-1836650](https://img.shields.io/badge/NSF-1836650-blue.svg)](https://nsf.gov/awardsearch/showAward?AWD_ID=1836650)

to help with tracking of NSF funded projects via http://throughputdb.com/.