### PR TITLE
feat: adding histogram folder to config

### DIFF
--- a/config_example.yml
+++ b/config_example.yml
@@ -1,6 +1,7 @@
 General:
   Measurement: "minimal_example"
   POI: "Signal_norm"
+  HistogramFolder: "histograms/"
 
 Regions:
   - Name: "Signal_region"

--- a/example.py
+++ b/example.py
@@ -22,17 +22,14 @@ if __name__ == "__main__":
     cabinetry.configuration.print_overview(cabinetry_config)
 
     # create template histograms
-    histo_folder = "histograms/"
-    cabinetry.template_builder.create_histograms(
-        cabinetry_config, histo_folder, method="uproot"
-    )
+    cabinetry.template_builder.create_histograms(cabinetry_config, method="uproot")
 
     # perform histogram post-processing
-    cabinetry.template_postprocessor.run(cabinetry_config, histo_folder)
+    cabinetry.template_postprocessor.run(cabinetry_config)
 
     # build a workspace and save to file
     workspace_path = "workspaces/example_workspace.json"
-    ws = cabinetry.workspace.build(cabinetry_config, histo_folder)
+    ws = cabinetry.workspace.build(cabinetry_config)
     cabinetry.workspace.save(ws, workspace_path)
 
     # run a fit
@@ -45,6 +42,4 @@ if __name__ == "__main__":
     cabinetry.visualize.correlation_matrix(corr_mat, labels, "figures/")
 
     # visualize templates and data
-    cabinetry.visualize.data_MC(
-        cabinetry_config, histo_folder, figure_folder, prefit=True
-    )
+    cabinetry.visualize.data_MC(cabinetry_config, figure_folder, prefit=True)

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -36,44 +36,33 @@ def cabinetry() -> None:
 
 @click.command()
 @click.argument("config_path", type=click.Path(exists=True))
-@click.option(
-    "--histofolder", default="histograms/", help="folder to save histograms to"
-)
 @click.option("--method", default="uproot", help="backend for histogram production")
-def templates(config_path: str, histofolder: str, method: str) -> None:
+def templates(config_path: str, method: str) -> None:
     """Produce template histograms.
 
     CONFIG_PATH: path to cabinetry configuration file
     """
     _set_logging()
     cabinetry_config = cabinetry_configuration.read(config_path)
-    cabinetry_template_builder.create_histograms(
-        cabinetry_config, histofolder, method=method
-    )
+    cabinetry_template_builder.create_histograms(cabinetry_config, method=method)
 
 
 @click.command()
 @click.argument("config_path", type=click.Path(exists=True))
-@click.option(
-    "--histofolder", default="histograms/", help="folder to save histograms to"
-)
-def postprocess(config_path: str, histofolder: str) -> None:
+def postprocess(config_path: str) -> None:
     """Post-process template histograms.
 
     CONFIG_PATH: path to cabinetry configuration file
     """
     _set_logging()
     cabinetry_config = cabinetry_configuration.read(config_path)
-    cabinetry_template_postprocessor.run(cabinetry_config, histofolder)
+    cabinetry_template_postprocessor.run(cabinetry_config)
 
 
 @click.command()
 @click.argument("config_path", type=click.Path(exists=True))
 @click.argument("ws_path", type=click.Path(exists=False))
-@click.option(
-    "--histofolder", default="histograms/", help="folder containing histograms"
-)
-def workspace(config_path: str, ws_path: str, histofolder: str) -> None:
+def workspace(config_path: str, ws_path: str) -> None:
     """Produce a ``pyhf`` workspace.
 
     CONFIG_PATH: path to cabinetry configuration file
@@ -82,7 +71,7 @@ def workspace(config_path: str, ws_path: str, histofolder: str) -> None:
     """
     _set_logging()
     cabinetry_config = cabinetry_configuration.read(config_path)
-    ws = cabinetry_workspace.build(cabinetry_config, histofolder)
+    ws = cabinetry_workspace.build(cabinetry_config)
     cabinetry_workspace.save(ws, ws_path)
 
 

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -52,7 +52,7 @@
             "$$target": "#/definitions/general",
             "description": "general settings",
             "type": "object",
-            "required": ["Measurement", "POI"],
+            "required": ["Measurement", "POI", "HistogramFolder"],
             "properties": {
                 "Measurement": {
                     "description": "name of measurement",
@@ -60,6 +60,10 @@
                 },
                 "POI": {
                     "description": "name of parameter of interest",
+                    "type": "string"
+                },
+                "HistogramFolder": {
+                    "description": "folder to save histograms to and read histograms from",
                     "type": "string"
                 },
                 "Fixed": {

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 import pathlib
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 import boost_histogram as bh
 import numpy as np
@@ -182,14 +182,14 @@ class _Builder:
     """class to handle the instructions for backends to create histograms
     """
 
-    def __init__(self, folder_path_str: Union[str, pathlib.Path], method: str) -> None:
+    def __init__(self, histogram_folder: pathlib.Path, method: str) -> None:
         """create an instance, set folder and method
 
         Args:
-            folder_path_str (Union[str, pathlib.Path]): folder to save the histograms to
+            histogram_folder (pathlib.Path): folder to save the histograms to
             method (str): backend to use for histogram production
         """
-        self.folder_path_str = folder_path_str
+        self.histogram_folder = histogram_folder
         self.method = method
 
     def _create_histogram(
@@ -262,7 +262,7 @@ class _Builder:
         histogram.validate(histogram_name)
 
         # save it
-        histo_path = pathlib.Path(self.folder_path_str) / histogram_name
+        histo_path = self.histogram_folder / histogram_name
         histogram.save(histo_path)
 
     def _wrap_custom_template_builder(
@@ -312,7 +312,6 @@ class _Builder:
 
 def create_histograms(
     config: Dict[str, Any],
-    folder_path_str: Union[str, pathlib.Path],
     method: str = "uproot",
     router: Optional[route.Router] = None,
 ) -> None:
@@ -322,13 +321,13 @@ def create_histograms(
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        folder_path_str (Union[str, pathlib.Path]): folder to save the histograms to
         method (str, optional): backend to use for histogram production, defaults to "uproot"
         router (Optional[route.Router], optional): instance of cabinetry.route.Router
             that contains user-defined overrides, defaults to None
     """
     # create an instance of the class doing the template building
-    builder = _Builder(folder_path_str, method=method)
+    histogram_folder = pathlib.Path(config["General"]["HistogramFolder"])
+    builder = _Builder(histogram_folder, method=method)
 
     match_func: Optional[route.MatchFunc] = None
     if router is not None:

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 import pathlib
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 import numpy as np
 
@@ -44,9 +44,7 @@ def apply_postprocessing(histogram: histo.Histogram, name: str) -> histo.Histogr
     return adjusted_histogram
 
 
-def _get_postprocessor(
-    histogram_folder: Union[str, pathlib.Path]
-) -> route.ProcessorFunc:
+def _get_postprocessor(histogram_folder: pathlib.Path) -> route.ProcessorFunc:
     """return the postprocessing function to be applied to template histograms, for
     example via ``cabinetry.route.apply_to_all_templates``
     could alternatively create a ``Postprocessor`` class that contains processors
@@ -83,18 +81,18 @@ def _get_postprocessor(
         histogram_name = histo.build_name(region, sample, systematic, template)
         new_histogram = apply_postprocessing(histogram, histogram_name)
         histogram.validate(histogram_name)
-        new_histo_path = pathlib.Path(histogram_folder) / (histogram_name + "_modified")
+        new_histo_path = histogram_folder / (histogram_name + "_modified")
         new_histogram.save(new_histo_path)
 
     return process_template
 
 
-def run(config: Dict[str, Any], histogram_folder: Union[str, pathlib.Path]) -> None:
+def run(config: Dict[str, Any]) -> None:
     """apply postprocessing to all histograms
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        histogram_folder (Union[str, pathlib.Path]): folder containing histograms
     """
+    histogram_folder = pathlib.Path(config["General"]["HistogramFolder"])
     postprocessor = _get_postprocessor(histogram_folder)
     route.apply_to_all_templates(config, postprocessor)

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -31,7 +31,6 @@ def _build_figure_name(region_name: str, is_prefit: bool) -> str:
 
 def data_MC(
     config: Dict[str, Any],
-    histogram_folder: Union[str, pathlib.Path],
     figure_folder: Union[str, pathlib.Path],
     prefit: bool = True,
     method: str = "matplotlib",
@@ -40,7 +39,6 @@ def data_MC(
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        histogram_folder (Union[str, pathlib.Path]): path to the folder containing template histograms
         figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
         prefit (bool, optional): show the pre- or post-fit model, defaults to True
         method (str, optional): what backend to use for plotting, defaults to "matplotlib"
@@ -50,6 +48,7 @@ def data_MC(
         NotImplementedError: when trying to visualize post-fit distributions, not supported yet
     """
     log.info("visualizing histogram")
+    histogram_folder = pathlib.Path(config["General"]["HistogramFolder"])
     for region in config["Regions"]:
         histogram_dict_list = []
         for sample in config["Samples"]:

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -17,17 +17,14 @@ class WorkspaceBuilder:
     """Collects functionality to build a ``pyhf`` workspace.
     """
 
-    def __init__(
-        self, config: Dict[str, Any], histogram_folder: Union[str, pathlib.Path]
-    ) -> None:
+    def __init__(self, config: Dict[str, Any]) -> None:
         """Creates a workspace corresponding to a cabinetry configuration.
 
         Args:
             config (Dict[str, Any]): ``cabinetry`` configuration
-            histogram_folder (Union[str, pathlib.Path]): path to folder containing histograms
         """
         self.config = config
-        self.histogram_folder = histogram_folder
+        self.histogram_folder = pathlib.Path(config["General"]["HistogramFolder"])
 
     def _get_data_sample(self) -> Dict[str, Any]:
         """Returns the data sample dictionary.
@@ -443,16 +440,11 @@ class WorkspaceBuilder:
         return ws
 
 
-def build(
-    config: Dict[str, Any],
-    histogram_folder: Union[str, pathlib.Path],
-    with_validation: bool = True,
-) -> Dict[str, Any]:
+def build(config: Dict[str, Any], with_validation: bool = True) -> Dict[str, Any]:
     """Returns a `HistFactory` workspace in ``pyhf`` format.
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        histogram_folder (Union[str, pathlib.Path]): path to folder containing histograms
         with_validation (bool, optional): validate workspace validity with pyhf, defaults to True
 
     Returns:
@@ -460,7 +452,7 @@ def build(
     """
     log.info("building workspace")
 
-    ws_builder = WorkspaceBuilder(config, histogram_folder)
+    ws_builder = WorkspaceBuilder(config)
     ws = ws_builder.build()
 
     if with_validation:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -16,7 +16,7 @@ def test_read(mock_validation):
 
 def test_validate():
     config_valid = {
-        "General": {"Measurement": "", "POI": ""},
+        "General": {"Measurement": "", "POI": "", "HistogramFolder": ""},
         "Regions": [{"Name": "", "Filter": "", "Variable": "", "Binning": [0, 1]}],
         "Samples": [{"Name": "", "Path": "", "Tree": "", "Data": True}],
         "NormFactors": [{"Name": "", "Samples": ""}],
@@ -25,7 +25,7 @@ def test_validate():
 
     # not exactly one data sample
     config_multiple_data_samples = {
-        "General": {"Measurement": "", "POI": ""},
+        "General": {"Measurement": "", "POI": "", "HistogramFolder": ""},
         "Regions": [{"Name": "", "Filter": "", "Variable": "", "Binning": [0, 1]}],
         "Samples": [{"Name": "", "Path": "", "Tree": ""}],
         "NormFactors": [{"Name": "", "Samples": ""}],

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,13 +18,10 @@ def test_integration(tmp_path, ntuple_creator):
     ntuple_creator(str(tmp_path) + "/")
 
     cabinetry_config = cabinetry.configuration.read("config_example.yml")
-    histo_folder = str(tmp_path) + "/histograms/"
-    cabinetry.template_builder.create_histograms(
-        cabinetry_config, histo_folder, method="uproot"
-    )
-    cabinetry.template_postprocessor.run(cabinetry_config, histo_folder)
+    cabinetry.template_builder.create_histograms(cabinetry_config, method="uproot")
+    cabinetry.template_postprocessor.run(cabinetry_config)
     workspace_path = "workspaces/example_workspace.json"
-    ws = cabinetry.workspace.build(cabinetry_config, histo_folder)
+    ws = cabinetry.workspace.build(cabinetry_config)
     cabinetry.workspace.save(ws, workspace_path)
     ws = cabinetry.workspace.load(workspace_path)
     bestfit, uncertainty, _, best_twice_nll, corr_mat = cabinetry.fit.fit(ws)

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -151,8 +151,8 @@ def test__get_binning():
 
 
 def test__Builder():
-    builder = template_builder._Builder("path", "uproot")
-    assert builder.folder_path_str == "path"
+    builder = template_builder._Builder(pathlib.Path("path"), "uproot")
+    assert builder.histo_folder == pathlib.Path("path")
     assert builder.method == "uproot"
 
 
@@ -248,12 +248,11 @@ def test__Builder__wrap_custom_template_builder(mock_save):
 
 def test_create_histograms():
     config = {}
-    folder_path_str = "path"
     method = "uproot"
 
     # no router
     with mock.patch("cabinetry.route.apply_to_all_templates") as mock_apply:
-        template_builder.create_histograms(config, folder_path_str, method)
+        template_builder.create_histograms(config, method)
         assert len(mock_apply.call_args_list) == 1
         config_call, func_call = mock_apply.call_args_list[0][0]
         assert config_call == config
@@ -265,9 +264,7 @@ def test_create_histograms():
     # including a router
     mock_router = mock.MagicMock()
     with mock.patch("cabinetry.route.apply_to_all_templates") as mock_apply:
-        template_builder.create_histograms(
-            config, folder_path_str, method, router=mock_router
-        )
+        template_builder.create_histograms(config, method, router=mock_router)
 
         # verify wrapper was set
         assert (

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -152,7 +152,7 @@ def test__get_binning():
 
 def test__Builder():
     builder = template_builder._Builder(pathlib.Path("path"), "uproot")
-    assert builder.histo_folder == pathlib.Path("path")
+    assert builder.histogram_folder == pathlib.Path("path")
     assert builder.method == "uproot"
 
 
@@ -172,7 +172,7 @@ def test__Builder_create_histogram(mock_uproot_builder, mock_histo, mock_save):
     }
     systematic = {"Name": "nominal"}
 
-    builder = template_builder._Builder("path", "uproot")
+    builder = template_builder._Builder(pathlib.Path("path"), "uproot")
     builder._create_histogram(region, sample, systematic, "Nominal")
 
     # verify the backend call happened properly
@@ -192,7 +192,7 @@ def test__Builder_create_histogram(mock_uproot_builder, mock_histo, mock_save):
     ]
 
     # other backends
-    builder_unknown = template_builder._Builder("path", "unknown")
+    builder_unknown = template_builder._Builder(pathlib.Path("path"), "unknown")
     with pytest.raises(NotImplementedError, match="unknown backend unknown"):
         builder_unknown._create_histogram(region, sample, systematic, "Nominal")
 
@@ -205,7 +205,7 @@ def test__Builder__name_and_save(mock_name):
 
     histogram = mock.MagicMock()
 
-    builder = template_builder._Builder("path", "uproot")
+    builder = template_builder._Builder(pathlib.Path("path"), "uproot")
     builder._name_and_save(histogram, region, sample, systematic, "Up")
 
     # check that the naming function was called, the histogram was validated and saved
@@ -224,7 +224,7 @@ def test__Builder__wrap_custom_template_builder(mock_save):
     def test_func(reg, sam, sys, tem):
         return histogram
 
-    builder = template_builder._Builder("path", "uproot")
+    builder = template_builder._Builder(pathlib.Path("path"), "uproot")
     wrapped_func = builder._wrap_custom_template_builder(test_func)
 
     # check the behavior of the wrapped function
@@ -247,7 +247,7 @@ def test__Builder__wrap_custom_template_builder(mock_save):
 
 
 def test_create_histograms():
-    config = {}
+    config = {"General": {"HistogramFolder": "path/"}}
     method = "uproot"
 
     # no router

--- a/tests/test_template_postprocessor.py
+++ b/tests/test_template_postprocessor.py
@@ -40,7 +40,7 @@ def test_apply_postprocessing():
 )
 @mock.patch("cabinetry.histo.build_name", return_value="histo_name")
 def test__get_postprocessor(mock_name, mock_apply):
-    postprocessor = template_postprocessor._get_postprocessor("path")
+    postprocessor = template_postprocessor._get_postprocessor(pathlib.Path("path"))
 
     region = {"Name": "region"}
     sample = {"Name": "sample"}
@@ -62,7 +62,7 @@ def test__get_postprocessor(mock_name, mock_apply):
             # check that the relevant functions were called
             assert mock_from_config.call_args_list == [
                 (
-                    ("path", region, sample, systematic),
+                    (pathlib.Path("path"), region, sample, systematic),
                     {"modified": False, "template": template},
                 )
             ]  # histogram was created
@@ -79,9 +79,8 @@ def test__get_postprocessor(mock_name, mock_apply):
 @mock.patch("cabinetry.route.apply_to_all_templates")
 @mock.patch("cabinetry.template_postprocessor._get_postprocessor", return_value="func")
 def test_run(mock_postprocessor, mock_apply):
-    config = {}
-    path = "path"
-    template_postprocessor.run(config, path)
+    config = {"General": {"HistogramFolder": "path/"}}
+    template_postprocessor.run(config)
 
-    assert mock_postprocessor.call_args_list == [((path,), {})]
+    assert mock_postprocessor.call_args_list == [((pathlib.Path("path/"),), {})]
     assert mock_apply.call_args_list == [((config, "func"), {})]

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -36,11 +36,12 @@ def test_data_MC(mock_load, mock_draw, tmp_path):
     https://docs.python.org/3/library/unittest.mock.html#where-to-patch
     """
     config = {
+        "General": {"HistogramFolder": tmp_path},
         "Regions": [{"Name": "reg_1", "Variable": "x"}],
         "Samples": [{"Name": "sample_1"}],
     }
 
-    visualize.data_MC(config, tmp_path, tmp_path, prefit=True, method="matplotlib")
+    visualize.data_MC(config, tmp_path, prefit=True, method="matplotlib")
 
     # the call_args_list contains calls (outer round brackets), first filled with
     # arguments (inner round brackets) and then keyword arguments
@@ -73,11 +74,11 @@ def test_data_MC(mock_load, mock_draw, tmp_path):
 
     # other plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
-        visualize.data_MC(config, tmp_path, tmp_path, prefit=True, method="unknown")
+        visualize.data_MC(config, tmp_path, prefit=True, method="unknown")
 
     # postfit
     with pytest.raises(NotImplementedError, match="only prefit implemented so far"):
-        visualize.data_MC(config, tmp_path, tmp_path, prefit=False, method="matplotlib")
+        visualize.data_MC(config, tmp_path, prefit=False, method="matplotlib")
 
 
 @mock.patch("cabinetry.contrib.matplotlib_visualize.correlation_matrix")


### PR DESCRIPTION
Adding a new mandatory configuration file option `HistogramFolder` under `General`:

```yaml
General:
  HistogramFolder: "histograms/"
```
This contains the path to the folder where all histograms are saved to and read from.

Switch to using `autospec=True` in CLI unit tests to catch changes in public API.