### PR TITLE
chore: updating version to 0.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="cabinetry",
-    version="0.0.5",
+    version="0.1.0",
     author="Alexander Held",
     description="design and steer profile likelihood fits",
     long_description=long_description,
@@ -53,7 +53,7 @@ setup(
     package_dir={"": "src"},
     package_data={"cabinetry": ["py.typed", "schemas/config.json"]},
     classifiers=[
-        "Development Status :: 2 - Pre-Alpha",
+        "Development Status :: 3 - Alpha",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -7,4 +7,4 @@ from . import visualize  # NOQA
 from . import workspace  # NOQA
 
 
-__version__ = "0.0.5"
+__version__ = "0.1.0"


### PR DESCRIPTION
Moving from minor version 0 to 1, and pre-alpha to alpha. The most important change between 0.0.5 and 0.1.0 is the possibility of user-defined template histogram building overrides in #78.