### PR TITLE
fix: observed data in multiple regions

### DIFF
--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -406,8 +406,8 @@ class WorkspaceBuilder:
         """
         data_sample = self._get_data_sample()
         observations = []
-        observation = {}
         for region in self.config["Regions"]:
+            observation = {}
             histo_yield = self.get_yield_for_sample(region, data_sample)
             observation.update({"name": region["Name"]})
             observation.update({"data": histo_yield})


### PR DESCRIPTION
The observation dicts written to the `pyhf` workspace did not update properly when using more than one channel. This is fixed, and a test is added that can catch such an issue in the future.