### PR TITLE
feat: removing staterrors from pull plot

### DIFF
--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -43,7 +43,7 @@ def print_results(
     max_label_length = max([len(label) for label in labels])
     for i, label in enumerate(labels):
         l_with_spacer = label + " " * (max_label_length - len(label))
-        log.info(f"{l_with_spacer}: {bestfit[i]:.6f} +/- {uncertainty[i]:.6f}")
+        log.info(f"{l_with_spacer}: {bestfit[i]: .6f} +/- {uncertainty[i]:.6f}")
 
 
 def fit(

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -149,12 +149,17 @@ def pulls(
     figure_path = pathlib.Path(figure_folder) / "pulls.pdf"
     labels_np = np.asarray(labels)
 
+    if exclude_list is None:
+        exclude_list = []
+
+    # exclude staterror parameters from pull plot (they are centered at 1)
+    exclude_list += [label for label in labels_np if label[0:10] == "staterror_"]
+
     # filter out parameters
-    if exclude_list is not None:
-        mask = [True if label not in exclude_list else False for label in labels_np]
-        bestfit = bestfit[mask]
-        uncertainty = uncertainty[mask]
-        labels_np = labels_np[mask]
+    mask = [True if label not in exclude_list else False for label in labels_np]
+    bestfit = bestfit[mask]
+    uncertainty = uncertainty[mask]
+    labels_np = labels_np[mask]
 
     if method == "matplotlib":
         from cabinetry.contrib import matplotlib_visualize

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -61,8 +61,8 @@ def test_print_results(caplog):
     uncertainty = np.asarray([0.1, 0.3])
     labels = ["param_A", "param_B"]
     fit.print_results(bestfit, uncertainty, labels)
-    assert "param_A: 1.000000 +/- 0.100000" in [rec.message for rec in caplog.records]
-    assert "param_B: 2.000000 +/- 0.300000" in [rec.message for rec in caplog.records]
+    assert "param_A:  1.000000 +/- 0.100000" in [rec.message for rec in caplog.records]
+    assert "param_B:  2.000000 +/- 0.300000" in [rec.message for rec in caplog.records]
     caplog.clear()
 
 

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -109,9 +109,9 @@ def test_correlation_matrix(mock_draw):
 
 @mock.patch("cabinetry.contrib.matplotlib_visualize.pulls")
 def test_pulls(mock_draw):
-    bestfit = np.asarray([0.8, 1.0, 1.1])
-    uncertainty = np.asarray([0.9, 1.0, 0.7])
-    labels = ["a", "b", "c"]
+    bestfit = np.asarray([0.8, 1.0, 1.05, 1.1])
+    uncertainty = np.asarray([0.9, 1.0, 0.03, 0.7])
+    labels = ["a", "b", "staterror_region[bin_0]", "c"]
     exclude_list = ["a"]
     folder_path = "tmp"
 
@@ -142,14 +142,20 @@ def test_pulls(mock_draw):
     assert mock_draw.call_args[0][3] == figure_path
     assert mock_draw.call_args[1] == {}
 
-    # without filtering
+    # without filtering via list, but with staterror removal
+    bestfit_expected = np.asarray([0.8, 1.0, 1.1])
+    uncertainty_expected = np.asarray([0.9, 1.0, 0.7])
+    labels_expected = ["a", "b", "c"]
     visualize.pulls(
         bestfit, uncertainty, labels, folder_path, method="matplotlib",
     )
-    assert np.allclose(mock_draw.call_args[0][0], bestfit)
-    assert np.allclose(mock_draw.call_args[0][1], uncertainty)
+    assert np.allclose(mock_draw.call_args[0][0], bestfit_expected)
+    assert np.allclose(mock_draw.call_args[0][1], uncertainty_expected)
     assert np.any(
-        [mock_draw.call_args[0][2][i] == labels[i] for i in range(len(labels))]
+        [
+            mock_draw.call_args[0][2][i] == labels_expected[i]
+            for i in range(len(labels_expected))
+        ]
     )
     assert mock_draw.call_args[0][3] == figure_path
     assert mock_draw.call_args[1] == {}


### PR DESCRIPTION
The pull plot functionality so far allowed to manually exclude parameters. This adds automatic removal of MC statistical uncertainties (labels starting with "staterror_") from the plot. Such parameters are centered around 1 and do not have unit width, so they make less sense to put on the same plot as other parameters with associated unit Gaussian constraint term.

Also fixing fit result reporting to have an extra space that allows negative fitted values to line up with positive ones in the log.