### PR TITLE
feat: support reading vector branches

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -1,6 +1,14 @@
 Advanced topics
 ===============
 
+Accessing vector branches
+-------------------------
+
+The transverse momentum of the first jet in a vector branch ``jet_pT`` is obtained via ``jet_pT[0]`` in ``ROOT``.
+The ``uproot4`` backend for ntuple reading treats expressions (such as what is written in ``Filter`` and ``Weight`` configuration file options) as Python code.
+The correct way to access the same information through ``cabinetry`` is ``jet_pT[:,0]``, where the first index runs over events.
+
+
 Overrides for template building
 -------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,9 @@ ignore_missing_imports = True
 [mypy-uproot4]
 ignore_missing_imports = True
 
+[mypy-awkward1]
+ignore_missing_imports = True
+
 [mypy-pyhf]
 ignore_missing_imports = True
 

--- a/src/cabinetry/contrib/histogram_creation.py
+++ b/src/cabinetry/contrib/histogram_creation.py
@@ -1,6 +1,7 @@
 import pathlib
 from typing import Optional, Tuple
 
+import awkward1 as ak
 import boost_histogram as bh
 import numpy as np
 import uproot4 as uproot
@@ -35,7 +36,7 @@ def from_uproot(
     # extract observable and weights
     # need the last [variable] to select the right entry out of the dict
     # this only reads the observable branch and branches needed for the cut into memory
-    observables = np.asarray(tree.arrays(variable, cut=selection_filter)[variable])
+    observables = ak.to_numpy(tree.arrays(variable, cut=selection_filter)[variable])
 
     if weight is not None:
         try:
@@ -43,7 +44,7 @@ def from_uproot(
             weights = np.ones_like(observables) * float(weight)
         except ValueError:
             # evaluate the expression with uproot4
-            weights = np.asarray(tree.arrays(weight, cut=selection_filter)[weight])
+            weights = ak.to_numpy(tree.arrays(weight, cut=selection_filter)[weight])
 
     else:
         weights = np.ones_like(observables)

--- a/src/cabinetry/contrib/histogram_creation.py
+++ b/src/cabinetry/contrib/histogram_creation.py
@@ -35,7 +35,7 @@ def from_uproot(
     # extract observable and weights
     # need the last [variable] to select the right entry out of the dict
     # this only reads the observable branch and branches needed for the cut into memory
-    observables = tree.arrays(variable, cut=selection_filter, library="np")[variable]
+    observables = np.asarray(tree.arrays(variable, cut=selection_filter)[variable])
 
     if weight is not None:
         try:
@@ -43,7 +43,7 @@ def from_uproot(
             weights = np.ones_like(observables) * float(weight)
         except ValueError:
             # evaluate the expression with uproot4
-            weights = tree.arrays(weight, cut=selection_filter, library="np")[weight]
+            weights = np.asarray(tree.arrays(weight, cut=selection_filter)[weight])
 
     else:
         weights = np.ones_like(observables)


### PR DESCRIPTION
This update enables reading observables / weights from vectors. In ROOT syntax, this would look like
```yaml
Weight: weight[0]*other_weight
```
In `cabinetry` it has to be written like
```yaml
Weight: weight[:,0]*other_weight
```

This is due to `uproot4` interpreting the string as Python code. More details are provided in this `uproot4` issue: https://github.com/scikit-hep/uproot4/issues/72.

Adding a section in the sphinx docs that describes this difference.