### PR TITLE
feat: Asimov fits

### DIFF
--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -53,7 +53,7 @@ def fit(
     the results of the fit
 
     Args:
-        spec (Dict[str, Any]): a pyhf workspace specificaton
+        spec (Dict[str, Any]): a pyhf workspace specification
 
     Returns:
         Tuple[np.ndarray, np.ndarray, List[str], float, np.ndarray]:
@@ -91,14 +91,16 @@ def fit(
 
 
 def custom_fit(
-    spec: Dict[str, Any]
+    spec: Dict[str, Any], asimov: bool = False
 ) -> Tuple[np.ndarray, np.ndarray, List[str], float, np.ndarray]:
     """Perform an unconstrained maximum likelihood fit with iminuit and report
     the result. Compared to fit(), this does not use the pyhf.infer API for more
     control over the minimization.
 
     Args:
-        spec (Dict[str, Any]): a pyhf workspace specificaton
+        spec (Dict[str, Any]): a pyhf workspace specification
+        asimov (bool, optional): whether to fit the Asimov dataset, defaults
+            to False
 
     Returns:
         Tuple[np.ndarray, np.ndarray, List[str], float, np.ndarray]:
@@ -117,11 +119,15 @@ def custom_fit(
             "histosys": {"interpcode": "code4p"},
         }
     )  # use HistFactory InterpCode=4
-    data = workspace.data(model)
 
     init_pars = model.config.suggested_init()
     par_bounds = model.config.suggested_bounds()
     fix_pars = model.config.suggested_fixed()
+
+    if not asimov:
+        data = workspace.data(model)
+    else:
+        data = model.expected_data(init_pars)
 
     step_size = [0.1 for _ in init_pars]
 

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -14,7 +14,7 @@ def get_parameter_names(model: pyhf.pdf.Model) -> List[str]:
     one bin per vector entry (gammas)
 
     Args:
-        model (pyhf.pdf.Model): a HistFactory-style model in pyhf format
+        model (pyhf.pdf.Model): a HistFactory-style model in ``pyhf`` format
 
     Returns:
         List[str]: names of fit parameters
@@ -47,13 +47,17 @@ def print_results(
 
 
 def fit(
-    spec: Dict[str, Any]
+    spec: Dict[str, Any], asimov: bool = False
 ) -> Tuple[np.ndarray, np.ndarray, List[str], float, np.ndarray]:
-    """perform an unconstrained maximum likelihood fit with pyhf and report
-    the results of the fit
+    """Performs an unconstrained maximum likelihood fit with ``pyhf``.
+
+    Reports and returns the results of the fit. The ``asimov`` flag
+    allows to fit the Asimov dataset instead of observed data.
 
     Args:
-        spec (Dict[str, Any]): a pyhf workspace specification
+        spec (Dict[str, Any]): a ``pyhf`` workspace specification
+        asimov (bool, optional): whether to fit the Asimov dataset, defaults
+            to False
 
     Returns:
         Tuple[np.ndarray, np.ndarray, List[str], float, np.ndarray]:
@@ -72,7 +76,11 @@ def fit(
             "histosys": {"interpcode": "code4p"},
         }
     )  # use HistFactory InterpCode=4
-    data = workspace.data(model)
+
+    if not asimov:
+        data = workspace.data(model)
+    else:
+        data = model.expected_data(model.config.suggested_init())
 
     pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=True))
     result, result_obj = pyhf.infer.mle.fit(
@@ -93,12 +101,15 @@ def fit(
 def custom_fit(
     spec: Dict[str, Any], asimov: bool = False
 ) -> Tuple[np.ndarray, np.ndarray, List[str], float, np.ndarray]:
-    """Perform an unconstrained maximum likelihood fit with iminuit and report
-    the result. Compared to fit(), this does not use the pyhf.infer API for more
-    control over the minimization.
+    """Performs an unconstrained maximum likelihood fit with ``iminuit``.
+
+    Reports and returns the results of the fit. The ``asimov`` flag
+    allows to fit the Asimov dataset instead of observed data. Compared to
+    ``fit()``, this does not use the ``pyhf.infer`` API for more control
+    over the minimization.
 
     Args:
-        spec (Dict[str, Any]): a pyhf workspace specification
+        spec (Dict[str, Any]): a ``pyhf`` workspace specification
         asimov (bool, optional): whether to fit the Asimov dataset, defaults
             to False
 

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -46,6 +46,21 @@ def print_results(
         log.info(f"{l_with_spacer}: {bestfit[i]: .6f} +/- {uncertainty[i]:.6f}")
 
 
+def build_Asimov_data(model: pyhf.Model) -> np.ndarray:
+    """Returns the Asimov dataset (with auxdata) for a model.
+
+    Args:
+        model (pyhf.Model): the model from which to construct the
+            dataset
+
+    Returns:
+        np.ndarray: the Asimov dataset
+    """
+    asimov_data = np.sum(model.nominal_rates, axis=1)[0][0]
+    asimov_aux = model.config.auxdata
+    return np.hstack((asimov_data, asimov_aux))
+
+
 def fit(
     spec: Dict[str, Any], asimov: bool = False
 ) -> Tuple[np.ndarray, np.ndarray, List[str], float, np.ndarray]:
@@ -80,7 +95,7 @@ def fit(
     if not asimov:
         data = workspace.data(model)
     else:
-        data = model.expected_data(model.config.suggested_init())
+        data = build_Asimov_data(model)
 
     pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=True))
     result, result_obj = pyhf.infer.mle.fit(
@@ -138,7 +153,7 @@ def custom_fit(
     if not asimov:
         data = workspace.data(model)
     else:
-        data = model.expected_data(init_pars)
+        data = build_Asimov_data(model)
 
     step_size = [0.1 for _ in init_pars]
 

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -77,6 +77,16 @@ def test_fit(example_spec):
     assert np.allclose(best_twice_nll, 3.83054341)
     assert np.allclose(corr_mat, [[1.0, -0.73366055], [-0.73366055, 1.0]])
 
+    # Asimov fit
+    bestfit, uncertainty, labels, best_twice_nll, corr_mat = fit.fit(
+        example_spec, asimov=True
+    )
+    assert np.allclose(bestfit, [1.0, 1.0])
+    assert np.allclose(uncertainty, [0.04956451, 0.14741004])
+    assert labels == ["staterror_Signal-Region", "Signal strength"]
+    assert np.allclose(best_twice_nll, 1.61824907)
+    assert np.allclose(corr_mat, [[1.0, -0.33612583], [-0.33612583, 1.0]])
+
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_custom_fit(example_spec):
@@ -88,4 +98,14 @@ def test_custom_fit(example_spec):
     assert np.allclose(uncertainty, [0.1, 0.41879343])
     assert labels == ["staterror_Signal-Region", "Signal strength"]
     assert np.allclose(best_twice_nll, 3.83054248)
+    assert np.allclose(corr_mat, [[1.0]])
+
+    # Asimov fit
+    bestfit, uncertainty, labels, best_twice_nll, corr_mat = fit.custom_fit(
+        example_spec, asimov=True
+    )
+    assert np.allclose(bestfit, [1.0, 1.0])
+    assert np.allclose(uncertainty, [0.1, 0.13883476])
+    assert labels == ["staterror_Signal-Region", "Signal strength"]
+    assert np.allclose(best_twice_nll, 1.61824907)
     assert np.allclose(corr_mat, [[1.0]])

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -36,7 +36,13 @@ def example_spec():
         "measurements": [
             {
                 "config": {
-                    "parameters": [{"name": "staterror_Signal-Region", "fixed": True}],
+                    "parameters": [
+                        {
+                            "name": "staterror_Signal-Region",
+                            "fixed": True,
+                            "inits": [1.1],
+                        }
+                    ],
                     "poi": "Signal strength",
                 },
                 "name": "My fit",
@@ -71,21 +77,21 @@ def test_print_results(caplog):
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_fit(example_spec):
     bestfit, uncertainty, labels, best_twice_nll, corr_mat = fit.fit(example_spec)
-    assert np.allclose(bestfit, [0.99998772, 9.16255687])
-    assert np.allclose(uncertainty, [0.04954955, 0.61348804])
+    assert np.allclose(bestfit, [1.00016745, 9.16046294])
+    assert np.allclose(uncertainty, [0.04953864, 0.6131055])
     assert labels == ["staterror_Signal-Region", "Signal strength"]
-    assert np.allclose(best_twice_nll, 3.83054341)
-    assert np.allclose(corr_mat, [[1.0, -0.73366055], [-0.73366055, 1.0]])
+    assert np.allclose(best_twice_nll, 3.83055796)
+    assert np.allclose(corr_mat, [[1.0, -0.73346895], [-0.73346895, 1.0]])
 
     # Asimov fit
     bestfit, uncertainty, labels, best_twice_nll, corr_mat = fit.fit(
         example_spec, asimov=True
     )
-    assert np.allclose(bestfit, [1.0, 1.0])
-    assert np.allclose(uncertainty, [0.04956451, 0.14741004])
+    assert np.allclose(bestfit, [1.1, 1.0])
+    assert np.allclose(uncertainty, [0.04956467, 0.13983193])
     assert labels == ["staterror_Signal-Region", "Signal strength"]
-    assert np.allclose(best_twice_nll, 1.61824907)
-    assert np.allclose(corr_mat, [[1.0, -0.33612583], [-0.33612583, 1.0]])
+    assert np.allclose(best_twice_nll, 1.71326699)
+    assert np.allclose(corr_mat, [[1.0, -0.3221417], [-0.3221417, 1.0]])
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
@@ -94,18 +100,18 @@ def test_custom_fit(example_spec):
         example_spec
     )
     # compared to fit(), the gamma is fixed
-    assert np.allclose(bestfit, [1.0, 9.16273912])
-    assert np.allclose(uncertainty, [0.1, 0.41879343])
+    assert np.allclose(bestfit, [1.1, 8.32985794])
+    assert np.allclose(uncertainty, [0.1, 0.38153392])
     assert labels == ["staterror_Signal-Region", "Signal strength"]
-    assert np.allclose(best_twice_nll, 3.83054248)
+    assert np.allclose(best_twice_nll, 7.90080378)
     assert np.allclose(corr_mat, [[1.0]])
 
     # Asimov fit
     bestfit, uncertainty, labels, best_twice_nll, corr_mat = fit.custom_fit(
         example_spec, asimov=True
     )
-    assert np.allclose(bestfit, [1.0, 1.0])
-    assert np.allclose(uncertainty, [0.1, 0.13883476])
+    assert np.allclose(bestfit, [1.1, 1.0])
+    assert np.allclose(uncertainty, [0.1, 0.13238269])
     assert labels == ["staterror_Signal-Region", "Signal strength"]
-    assert np.allclose(best_twice_nll, 1.61824907)
+    assert np.allclose(best_twice_nll, 1.71326699)
     assert np.allclose(corr_mat, [[1.0]])

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -72,6 +72,12 @@ def test_print_results(caplog):
     caplog.clear()
 
 
+def test_build_Asimov_data(example_spec):
+    ws = pyhf.Workspace(example_spec)
+    model = ws.model()
+    assert np.allclose(fit.build_Asimov_data(model), [51.839756, 1])
+
+
 # skip a "RuntimeWarning: numpy.ufunc size changed" warning
 # due to different numpy versions used in dependencies
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -87,11 +87,11 @@ def test_fit(example_spec):
     bestfit, uncertainty, labels, best_twice_nll, corr_mat = fit.fit(
         example_spec, asimov=True
     )
-    assert np.allclose(bestfit, [1.1, 1.0])
-    assert np.allclose(uncertainty, [0.04956467, 0.13983193])
+    assert np.allclose(bestfit, [1.0, 1.0], rtol=1e-4)
+    assert np.allclose(uncertainty, [0.04956413, 0.1474005])
     assert labels == ["staterror_Signal-Region", "Signal strength"]
-    assert np.allclose(best_twice_nll, 1.71326699)
-    assert np.allclose(corr_mat, [[1.0, -0.3221417], [-0.3221417, 1.0]])
+    assert np.allclose(best_twice_nll, 1.61824936)
+    assert np.allclose(corr_mat, [[1.0, -0.33610697], [-0.33610697, 1.0]])
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
@@ -106,12 +106,14 @@ def test_custom_fit(example_spec):
     assert np.allclose(best_twice_nll, 7.90080378)
     assert np.allclose(corr_mat, [[1.0]])
 
-    # Asimov fit
+    # Asimov fit, with fixed gamma (fixed not to Asimov MLE)
     bestfit, uncertainty, labels, best_twice_nll, corr_mat = fit.custom_fit(
         example_spec, asimov=True
     )
-    assert np.allclose(bestfit, [1.1, 1.0])
-    assert np.allclose(uncertainty, [0.1, 0.13238269])
+    # the gamma factor is multiplicative and fixed to 1.1, so the
+    # signal strength needs to be 1/1.1 to compensate
+    assert np.allclose(bestfit, [1.1, 0.90917877])
+    assert np.allclose(uncertainty, [0.1, 0.12623172])
     assert labels == ["staterror_Signal-Region", "Signal strength"]
-    assert np.allclose(best_twice_nll, 1.71326699)
+    assert np.allclose(best_twice_nll, 5.68851093)
     assert np.allclose(corr_mat, [[1.0]])


### PR DESCRIPTION
Adding an `asimov` keyword arguments to fit functions, which enables fits to the Asimov dataset instead of observed data.

The approach may be refactored in the future depending on the `pyhf` API (see https://github.com/scikit-hep/pyhf/issues/1029).