### PR TITLE
feat: more flexible input file path handling

### DIFF
--- a/config_example.yml
+++ b/config_example.yml
@@ -2,6 +2,7 @@ General:
   Measurement: "minimal_example"
   POI: "Signal_norm"
   HistogramFolder: "histograms/"
+  Path: "ntuples/{SamplePath}"
 
 Regions:
   - Name: "Signal_region"
@@ -12,17 +13,17 @@ Regions:
 Samples:
   - Name: "Data"
     Tree: "pseudodata"
-    Path: "ntuples/data.root"
+    SamplePath: "data.root"
     Data: True
 
   - Name: "Background"
     Tree: "background"
-    Path: "ntuples/prediction.root"
+    SamplePath: "prediction.root"
     Weight: "weight"
 
   - Name: "Signal"
     Tree: "signal"
-    Path: "ntuples/prediction.root"
+    SamplePath: "prediction.root"
     Weight: "weight"
 
 Systematics:
@@ -36,7 +37,7 @@ Systematics:
 
   - Name: "Modeling"
     Up:
-      Path: "ntuples/prediction.root"
+      SamplePath: "prediction.root"
       Tree: "background_varied"
     Down:
       Symmetrize: True

--- a/config_example.yml
+++ b/config_example.yml
@@ -2,7 +2,7 @@ General:
   Measurement: "minimal_example"
   POI: "Signal_norm"
   HistogramFolder: "histograms/"
-  Path: "ntuples/{SamplePath}"
+  InputPath: "ntuples/{SamplePath}"
 
 Regions:
   - Name: "Signal_region"

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -52,7 +52,7 @@
             "$$target": "#/definitions/general",
             "description": "general settings",
             "type": "object",
-            "required": ["Measurement", "POI", "HistogramFolder"],
+            "required": ["Measurement", "POI", "HistogramFolder", "Path"],
             "properties": {
                 "Measurement": {
                     "description": "name of measurement",
@@ -64,6 +64,10 @@
                 },
                 "HistogramFolder": {
                     "description": "folder to save histograms to and read histograms from",
+                    "type": "string"
+                },
+                "Path": {
+                    "description": "path to input ntuples",
                     "type": "string"
                 },
                 "Fixed": {
@@ -119,6 +123,10 @@
                         "type": "number"
                     },
                     "uniqueItems": true
+                },
+                "RegionPath": {
+                    "description": "(part of) path to file containing region",
+                    "type": "string"
                 }
             },
             "additionalProperties": false
@@ -128,14 +136,10 @@
             "description": "a sample of a specific process or data",
             "$$target": "#/definitions/sample",
             "type": "object",
-            "required": ["Name", "Path", "Tree"],
+            "required": ["Name", "Tree"],
             "properties": {
                 "Name": {
                     "description": "name of the sample",
-                    "type": "string"
-                },
-                "Path": {
-                    "description": "path to file containing sample",
                     "type": "string"
                 },
                 "Tree": {
@@ -144,6 +148,10 @@
                 },
                 "Weight": {
                     "description": "weight to apply to events",
+                    "type": "string"
+                },
+                "SamplePath": {
+                    "description": "(part of) path to file containing sample",
                     "type": "string"
                 },
                 "Data": {
@@ -219,8 +227,8 @@
             "description": "a systematics template (up/down)",
             "type": "object",
             "properties": {
-                "Path": {
-                    "description": "path to file",
+                "SamplePath": {
+                    "description": "(part of) path to file containing template, override for sample path",
                     "type": "string"
                 },
                 "Tree": {

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -52,7 +52,7 @@
             "$$target": "#/definitions/general",
             "description": "general settings",
             "type": "object",
-            "required": ["Measurement", "POI", "HistogramFolder", "Path"],
+            "required": ["Measurement", "POI", "InputPath", "HistogramFolder"],
             "properties": {
                 "Measurement": {
                     "description": "name of measurement",
@@ -62,12 +62,12 @@
                     "description": "name of parameter of interest",
                     "type": "string"
                 },
-                "HistogramFolder": {
-                    "description": "folder to save histograms to and read histograms from",
+                "InputPath": {
+                    "description": "path to input ntuples",
                     "type": "string"
                 },
-                "Path": {
-                    "description": "path to input ntuples",
+                "HistogramFolder": {
+                    "description": "folder to save histograms to and read histograms from",
                     "type": "string"
                 },
                 "Fixed": {

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -364,7 +364,7 @@ def create_histograms(
     """
     # create an instance of the class doing the template building
     histogram_folder = pathlib.Path(config["General"]["HistogramFolder"])
-    general_path = config["General"]["Path"]
+    general_path = config["General"]["InputPath"]
     builder = _Builder(histogram_folder, general_path, method)
 
     match_func: Optional[route.MatchFunc] = None

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -227,7 +227,7 @@ def ranking(
     impact_postfit_up = impact_postfit_up[sorted_indices]
     impact_postfit_down = impact_postfit_down[sorted_indices]
 
-    if max_pars:
+    if max_pars is not None:
         # only keep leading parameters in ranking
         bestfit = bestfit[:max_pars]
         uncertainty = uncertainty[:max_pars]

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -16,7 +16,12 @@ def test_read(mock_validation):
 
 def test_validate():
     config_valid = {
-        "General": {"Measurement": "", "POI": "", "HistogramFolder": "", "Path": ""},
+        "General": {
+            "Measurement": "",
+            "POI": "",
+            "HistogramFolder": "",
+            "InputPath": "",
+        },
         "Regions": [{"Name": "", "Filter": "", "Variable": "", "Binning": [0, 1]}],
         "Samples": [{"Name": "", "Tree": "", "Data": True}],
         "NormFactors": [{"Name": "", "Samples": ""}],
@@ -25,7 +30,12 @@ def test_validate():
 
     # not exactly one data sample
     config_multiple_data_samples = {
-        "General": {"Measurement": "", "POI": "", "HistogramFolder": "", "Path": ""},
+        "General": {
+            "Measurement": "",
+            "POI": "",
+            "HistogramFolder": "",
+            "InputPath": "",
+        },
         "Regions": [{"Name": "", "Filter": "", "Variable": "", "Binning": [0, 1]}],
         "Samples": [{"Name": "", "Tree": ""}],
         "NormFactors": [{"Name": "", "Samples": ""}],

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -16,18 +16,18 @@ def test_read(mock_validation):
 
 def test_validate():
     config_valid = {
-        "General": {"Measurement": "", "POI": "", "HistogramFolder": ""},
+        "General": {"Measurement": "", "POI": "", "HistogramFolder": "", "Path": ""},
         "Regions": [{"Name": "", "Filter": "", "Variable": "", "Binning": [0, 1]}],
-        "Samples": [{"Name": "", "Path": "", "Tree": "", "Data": True}],
+        "Samples": [{"Name": "", "Tree": "", "Data": True}],
         "NormFactors": [{"Name": "", "Samples": ""}],
     }
     assert configuration.validate(config_valid)
 
     # not exactly one data sample
     config_multiple_data_samples = {
-        "General": {"Measurement": "", "POI": "", "HistogramFolder": ""},
+        "General": {"Measurement": "", "POI": "", "HistogramFolder": "", "Path": ""},
         "Regions": [{"Name": "", "Filter": "", "Variable": "", "Binning": [0, 1]}],
-        "Samples": [{"Name": "", "Path": "", "Tree": ""}],
+        "Samples": [{"Name": "", "Tree": ""}],
         "NormFactors": [{"Name": "", "Samples": ""}],
     }
     with pytest.raises(

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -294,7 +294,7 @@ def test__Builder__wrap_custom_template_builder(mock_save):
 
 
 def test_create_histograms():
-    config = {"General": {"HistogramFolder": "path/", "Path": "file.root"}}
+    config = {"General": {"HistogramFolder": "path/", "InputPath": "file.root"}}
     method = "uproot"
 
     # no router

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 from unittest import mock
 
@@ -33,24 +34,67 @@ def test__check_for_override():
     )
 
 
-def test__get_ntuple_path():
-    # no override
+def test__get_ntuple_path(caplog):
+    # only general path, no override
     assert template_builder._get_ntuple_path(
-        {}, {"Path": "path.root"}, {"Name": "nominal"}, ""
+        "path.root", {}, {}, {}, ""
     ) == pathlib.Path("path.root")
+
+    # general path with region and sample templates
+    assert template_builder._get_ntuple_path(
+        "{RegionPath}/{SamplePath}",
+        {"RegionPath": "region"},
+        {"SamplePath": "sample.root"},
+        {},
+        "",
+    ) == pathlib.Path("region/sample.root")
 
     # systematic with override
     assert template_builder._get_ntuple_path(
+        "{SamplePath}",
         {},
-        {"Path": "path.root"},
-        {"Name": "variation", "Up": {"Path": "variation.root"}},
+        {"SamplePath": "path.root"},
+        {"Name": "variation", "Up": {"SamplePath": "variation.root"}},
         "Up",
     ) == pathlib.Path("variation.root")
 
     # systematic without override
     assert template_builder._get_ntuple_path(
-        {}, {"Path": "path.root"}, {"Name": "variation"}, "Up"
+        "{SamplePath}", {}, {"SamplePath": "path.root"}, {"Name": "variation"}, "Up"
     ) == pathlib.Path("path.root")
+
+    caplog.set_level(logging.DEBUG)
+    caplog.clear()
+
+    # warning: no region path in template
+    assert template_builder._get_ntuple_path(
+        "path.root", {"RegionPath": "region.root"}, {}, {}, ""
+    ) == pathlib.Path("path.root")
+    assert "region override specified, but {RegionPath} not found in default path" in [
+        rec.message for rec in caplog.records
+    ]
+    caplog.clear()
+
+    # warning: no region path in template
+    assert template_builder._get_ntuple_path(
+        "path.root", {}, {"SamplePath": "sample.root"}, {}, ""
+    ) == pathlib.Path("path.root")
+    assert "sample override specified, but {SamplePath} not found in default path" in [
+        rec.message for rec in caplog.records
+    ]
+    caplog.clear()
+
+    # error: no override for {RegionPath}
+    with pytest.raises(ValueError, match="no path setting found for region region"):
+        template_builder._get_ntuple_path(
+            "{RegionPath}", {"Name": "region"}, {}, {}, ""
+        )
+
+    # error: no override for {SamplePath}
+    with pytest.raises(ValueError, match="no path setting found for sample sample"):
+        template_builder._get_ntuple_path(
+            "{SamplePath}", {}, {"Name": "sample"}, {}, ""
+        )
 
 
 def test__get_variable():
@@ -147,12 +191,13 @@ def test__get_binning():
         template_builder._get_binning({"Binning": [1, 2, 3]}), [1, 2, 3]
     )
     with pytest.raises(NotImplementedError, match="cannot determine binning"):
-        assert template_builder._get_binning({})
+        template_builder._get_binning({})
 
 
 def test__Builder():
-    builder = template_builder._Builder(pathlib.Path("path"), "uproot")
+    builder = template_builder._Builder(pathlib.Path("path"), "file.root", "uproot")
     assert builder.histogram_folder == pathlib.Path("path")
+    assert builder.general_path == "file.root"
     assert builder.method == "uproot"
 
 
@@ -167,12 +212,12 @@ def test__Builder_create_histogram(mock_uproot_builder, mock_histo, mock_save):
     sample = {
         "Name": "sample",
         "Tree": "tree",
-        "Path": "path_to_sample",
+        "SamplePath": "path_to_sample",
         "Weight": "weight_mc",
     }
     systematic = {"Name": "nominal"}
 
-    builder = template_builder._Builder(pathlib.Path("path"), "uproot")
+    builder = template_builder._Builder(pathlib.Path("path"), "{SamplePath}", "uproot")
     builder._create_histogram(region, sample, systematic, "Nominal")
 
     # verify the backend call happened properly
@@ -192,7 +237,9 @@ def test__Builder_create_histogram(mock_uproot_builder, mock_histo, mock_save):
     ]
 
     # other backends
-    builder_unknown = template_builder._Builder(pathlib.Path("path"), "unknown")
+    builder_unknown = template_builder._Builder(
+        pathlib.Path("path"), "{SamplePath}", "unknown"
+    )
     with pytest.raises(NotImplementedError, match="unknown backend unknown"):
         builder_unknown._create_histogram(region, sample, systematic, "Nominal")
 
@@ -205,7 +252,7 @@ def test__Builder__name_and_save(mock_name):
 
     histogram = mock.MagicMock()
 
-    builder = template_builder._Builder(pathlib.Path("path"), "uproot")
+    builder = template_builder._Builder(pathlib.Path("path"), "file.root", "uproot")
     builder._name_and_save(histogram, region, sample, systematic, "Up")
 
     # check that the naming function was called, the histogram was validated and saved
@@ -224,7 +271,7 @@ def test__Builder__wrap_custom_template_builder(mock_save):
     def test_func(reg, sam, sys, tem):
         return histogram
 
-    builder = template_builder._Builder(pathlib.Path("path"), "uproot")
+    builder = template_builder._Builder(pathlib.Path("path"), "file.root", "uproot")
     wrapped_func = builder._wrap_custom_template_builder(test_func)
 
     # check the behavior of the wrapped function
@@ -247,7 +294,7 @@ def test__Builder__wrap_custom_template_builder(mock_save):
 
 
 def test_create_histograms():
-    config = {"General": {"HistogramFolder": "path/"}}
+    config = {"General": {"HistogramFolder": "path/", "Path": "file.root"}}
     method = "uproot"
 
     # no router


### PR DESCRIPTION
Creating a new `General` config option: `InputPath`, which specifies the path to input ntuples. It can contain two placeholders: `{RegionPath}` and `{SamplePath}`, which are filled in by the respective settings `RegionPath` and `SamplePath` in the `Regions:` and `Samples:` lists in the config. The `{SamplePath}` placeholder can also be overridden for systematic uncertainties, with the `SamplePath` option.

resolves #16
This update enables most of the setups described in #16. For file structures that cannot be captured with these configuration options, #78 allows to handle the whole histogram creation process with user-defined python functions. It may turn out in the future that a central implementation of additional functionality is useful, the issue can then be revisited.