### PR TITLE
style: update to black 20.8 formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     -   id: black
         language_version: python3
@@ -15,7 +15,7 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
     -   id: check-added-large-files
         args: ["--maxkb=100"]

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extras_require["test"] = sorted(
             "flake8-print",
             "mypy",
             "typeguard",
-            "black;python_version>='3.6'",  # Black is Python3 only
+            "black==20.8b1;python_version>='3.6'",  # Black is Python3 only
         ]
     )
 )

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -12,16 +12,14 @@ from .. import workspace as cabinetry_workspace
 
 
 class OrderedGroup(click.Group):
-    """a group that shows commands in the order they were added
-    """
+    """a group that shows commands in the order they were added"""
 
     def list_commands(self, _: Any) -> KeysView[str]:
         return self.commands.keys()
 
 
 def _set_logging() -> None:
-    """set log levels and format for CLI
-    """
+    """set log levels and format for CLI"""
     logging.basicConfig(
         level=logging.INFO, format="%(levelname)s - %(name)s - %(message)s"
     )
@@ -30,8 +28,7 @@ def _set_logging() -> None:
 
 @click.group(cls=OrderedGroup)
 def cabinetry() -> None:
-    """Entrypoint to the cabinetry CLI.
-    """
+    """Entrypoint to the cabinetry CLI."""
 
 
 @click.command()

--- a/src/cabinetry/contrib/matplotlib_visualize.py
+++ b/src/cabinetry/contrib/matplotlib_visualize.py
@@ -142,7 +142,7 @@ def data_MC(
     data_model_ratio = data_histogram_yields / total_yield
     data_model_ratio_unc = data_histogram_stdev / total_yield
     ax2.errorbar(
-        bin_centers, data_model_ratio, yerr=data_model_ratio_unc, fmt="o", color="k",
+        bin_centers, data_model_ratio, yerr=data_model_ratio_unc, fmt="o", color="k"
     )
 
     ax1.legend(frameon=False, fontsize="large")
@@ -305,17 +305,20 @@ def ranking(
 
     y_pos = np.arange(num_pars)[::-1]
 
+    # pre-fit up
     pre_up = ax_impact.barh(
-        y_pos, impact_prefit_up, fill=False, linewidth=1, edgecolor="C0",
-    )  # pre-fit up
+        y_pos, impact_prefit_up, fill=False, linewidth=1, edgecolor="C0"
+    )
+    # pre-fit down
     pre_down = ax_impact.barh(
-        y_pos, impact_prefit_down, fill=False, linewidth=1, edgecolor="C5",
-    )  # pre-fit down
-    post_up = ax_impact.barh(y_pos, impact_postfit_up, color="C0")  # post-fit up
-    post_down = ax_impact.barh(y_pos, impact_postfit_down, color="C5")  # post-fit down
-    pulls = ax_pulls.errorbar(
-        bestfit, y_pos, xerr=uncertainty, fmt="o", color="k"
-    )  # nuisance parameter pulls
+        y_pos, impact_prefit_down, fill=False, linewidth=1, edgecolor="C5"
+    )
+    # post-fit up
+    post_up = ax_impact.barh(y_pos, impact_postfit_up, color="C0")
+    # post-fit down
+    post_down = ax_impact.barh(y_pos, impact_postfit_down, color="C5")
+    # nuisance parameter pulls
+    pulls = ax_pulls.errorbar(bestfit, y_pos, xerr=uncertainty, fmt="o", color="k")
 
     ax_pulls.set_xlabel(r"$\left(\hat{\theta} - \theta_0\right) / \Delta \theta$")
     ax_impact.set_xlabel(r"$\Delta \mu$")

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -38,8 +38,7 @@ class Router:
     """
 
     def __init__(self) -> None:
-        """Initialize a Router instance, with no processors or wrappers defined.
-        """
+        """Initialize a Router instance, with no processors or wrappers defined."""
         # initialize all lists of processor types the user can specify
         self.template_builders: List[Dict[str, Any]] = []
 

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -210,8 +210,7 @@ def _get_binning(region: Dict[str, Any]) -> np.ndarray:
 
 
 class _Builder:
-    """Handles the instructions for backends to create histograms.
-    """
+    """Handles the instructions for backends to create histograms."""
 
     def __init__(
         self, histogram_folder: pathlib.Path, general_path: str, method: str
@@ -303,7 +302,7 @@ class _Builder:
         histogram.save(histo_path)
 
     def _wrap_custom_template_builder(
-        self, func: route.UserTemplateFunc,
+        self, func: route.UserTemplateFunc
     ) -> route.ProcessorFunc:
         """Wrapper for custom template builder functions that return a ``boost_histogram.Histogram``.
         Returns a function that executes the custom template builder and saves the resulting

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -14,8 +14,7 @@ log = logging.getLogger(__name__)
 
 
 class WorkspaceBuilder:
-    """Collects functionality to build a ``pyhf`` workspace.
-    """
+    """Collects functionality to build a ``pyhf`` workspace."""
 
     def __init__(self, config: Dict[str, Any]) -> None:
         """Creates a workspace corresponding to a cabinetry configuration.
@@ -251,7 +250,7 @@ class WorkspaceBuilder:
         return modifiers
 
     def get_sys_modifiers(
-        self, region: Dict[str, Any], sample: Dict[str, Any],
+        self, region: Dict[str, Any], sample: Dict[str, Any]
     ) -> List[Dict[str, Any]]:
         """Returns the list of all systematic modifiers acting on a sample.
 

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -7,8 +7,7 @@ from cabinetry import histo
 
 
 class ExampleHistograms:
-    """a collection of different kinds of histograms
-    """
+    """a collection of different kinds of histograms"""
 
     @staticmethod
     def normal():

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -82,7 +82,7 @@ def test_Router_register_template_builder(processor_examples):
     example_template_builder = processor_examples.get_example_template_builder()
 
     example_router.register_template_builder(
-        region_name="reg", sample_name="signal", systematic_name="sys", template="Up",
+        region_name="reg", sample_name="signal", systematic_name="sys", template="Up"
     )(example_template_builder)
 
     assert example_router.template_builders == [

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -41,22 +41,28 @@ def test__get_ntuple_path(caplog):
     ) == pathlib.Path("path.root")
 
     # general path with region and sample templates
-    assert template_builder._get_ntuple_path(
-        "{RegionPath}/{SamplePath}",
-        {"RegionPath": "region"},
-        {"SamplePath": "sample.root"},
-        {},
-        "",
-    ) == pathlib.Path("region/sample.root")
+    assert (
+        template_builder._get_ntuple_path(
+            "{RegionPath}/{SamplePath}",
+            {"RegionPath": "region"},
+            {"SamplePath": "sample.root"},
+            {},
+            "",
+        )
+        == pathlib.Path("region/sample.root")
+    )
 
     # systematic with override
-    assert template_builder._get_ntuple_path(
-        "{SamplePath}",
-        {},
-        {"SamplePath": "path.root"},
-        {"Name": "variation", "Up": {"SamplePath": "variation.root"}},
-        "Up",
-    ) == pathlib.Path("variation.root")
+    assert (
+        template_builder._get_ntuple_path(
+            "{SamplePath}",
+            {},
+            {"SamplePath": "path.root"},
+            {"Name": "variation", "Up": {"SamplePath": "variation.root"}},
+            "Up",
+        )
+        == pathlib.Path("variation.root")
+    )
 
     # systematic without override
     assert template_builder._get_ntuple_path(
@@ -125,7 +131,7 @@ def test__get_filter():
     # systematic without override
     assert (
         template_builder._get_filter(
-            {"Filter": "jet_pt > 0"}, {}, {"Name": "variation"}, "Up",
+            {"Filter": "jet_pt > 0"}, {}, {"Name": "variation"}, "Up"
         )
         == "jet_pt > 0"
     )
@@ -154,7 +160,7 @@ def test__get_weight():
     # systematic without override
     assert (
         template_builder._get_weight(
-            {}, {"Weight": "weight_mc"}, {"Name": "variation"}, "Up",
+            {}, {"Weight": "weight_mc"}, {"Name": "variation"}, "Up"
         )
         == "weight_mc"
     )
@@ -172,7 +178,7 @@ def test__get_position_in_file():
     # systematic with override
     assert (
         template_builder._get_position_in_file(
-            {"Tree": "nominal"}, {"Name": "variation", "Up": {"Tree": "up_tree"}}, "Up",
+            {"Tree": "nominal"}, {"Name": "variation", "Up": {"Tree": "up_tree"}}, "Up"
         )
         == "up_tree"
     )
@@ -180,7 +186,7 @@ def test__get_position_in_file():
     # systematic without override
     assert (
         template_builder._get_position_in_file(
-            {"Tree": "nominal"}, {"Name": "variation"}, "Up",
+            {"Tree": "nominal"}, {"Name": "variation"}, "Up"
         )
         == "nominal"
     )

--- a/tests/test_template_postprocessor.py
+++ b/tests/test_template_postprocessor.py
@@ -15,7 +15,7 @@ from cabinetry import template_postprocessor
             histo.Histogram.from_arrays([1, 2, 3], [1, 2], [float("nan"), 0.2]),
             [0.0, 0.2],
         ),
-        (histo.Histogram.from_arrays([1, 2, 3], [1, 2], [0.1, 0.2]), [0.1, 0.2],),
+        (histo.Histogram.from_arrays([1, 2, 3], [1, 2], [0.1, 0.2]), [0.1, 0.2]),
     ],
 )
 def test__fix_stat_unc(test_histo, fixed_stdev):

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -26,7 +26,7 @@ def test__build_figure_name(test_input, expected):
 
 @mock.patch("cabinetry.contrib.matplotlib_visualize.data_MC")
 @mock.patch(
-    "cabinetry.histo.Histogram.from_config", return_value=MockHistogram([], [], []),
+    "cabinetry.histo.Histogram.from_config", return_value=MockHistogram([], [], [])
 )
 def test_data_MC(mock_load, mock_draw, tmp_path):
     """contrib.matplotlib_visualize is only imported depending on the keyword argument,
@@ -146,9 +146,7 @@ def test_pulls(mock_draw):
     bestfit_expected = np.asarray([0.8, 1.0, 1.1])
     uncertainty_expected = np.asarray([0.9, 1.0, 0.7])
     labels_expected = ["a", "b", "c"]
-    visualize.pulls(
-        bestfit, uncertainty, labels, folder_path, method="matplotlib",
-    )
+    visualize.pulls(bestfit, uncertainty, labels, folder_path, method="matplotlib")
     assert np.allclose(mock_draw.call_args[0][0], bestfit_expected)
     assert np.allclose(mock_draw.call_args[0][1], uncertainty_expected)
     assert np.any(


### PR DESCRIPTION
Updating the formatting to the latest [black](https://github.com/psf/black) tag `20.8b1`. Some trailing commas needed to be removed by hand to not force function arguments to be spread out across different lines. Pinning the `black` version in `pre-commit` and in the setup extras to `20.8b1`.