### PR TITLE
chore: moving metadata to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,42 @@
+[metadata]
+name = cabinetry
+version = 0.1.1
+author = Alexander Held
+description = design and steer profile likelihood fits
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = BSD 3-Clause
+url = https://github.com/alexander-held/cabinetry
+classifiers =
+    Development Status :: 3 - Alpha
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    License :: OSI Approved :: BSD License
+    Topic :: Scientific/Engineering
+    Topic :: Scientific/Engineering :: Physics
+
+[options]
+packages = find:
+package_dir = =src
+python_requires = >=3.6
+install_requires =
+    numpy
+    pyyaml
+    pyhf>=0.5.1  # fixed parameter bookkeeping #989
+    iminuit>1.4.0
+    boost_histogram
+    jsonschema
+    click
+
+[options.packages.find]
+where = src
+
+[options.package_data]
+cabinetry =
+    py.typed
+    schemas/config.json
+
 [options.entry_points]
 console_scripts =
     cabinetry = cabinetry.cli:cabinetry

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extras_require["test"] = sorted(
             "flake8-print",
             "mypy",
             "typeguard",
-            "black==20.8b1;python_version>='3.6'",  # Black is Python3 only
+            "black==20.8b1",
         ]
     )
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import find_packages, setup
+from setuptools import setup
 
 extras_require = {"contrib": ["matplotlib", "uproot", "uproot4", "awkward1"]}
 extras_require["test"] = sorted(
@@ -36,40 +36,6 @@ extras_require["develop"] = sorted(
 )
 extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))
 
-
-with open("README.md", "r") as f:
-    long_description = f.read()
-
 setup(
-    name="cabinetry",
-    version="0.1.1",
-    author="Alexander Held",
-    description="design and steer profile likelihood fits",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    license="BSD 3-Clause",
-    url="https://github.com/alexander-held/cabinetry",
-    packages=find_packages(where="src"),
-    package_dir={"": "src"},
-    package_data={"cabinetry": ["py.typed", "schemas/config.json"]},
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "License :: OSI Approved :: BSD License",
-        "Topic :: Scientific/Engineering",
-        "Topic :: Scientific/Engineering :: Physics",
-    ],
-    python_requires=">=3.6",
-    install_requires=[
-        "numpy",
-        "pyyaml",
-        "pyhf>=0.5.1",  # fixed parameter bookkeeping #989
-        "iminuit>1.4.0",
-        "boost_histogram",
-        "jsonschema",
-        "click",
-    ],
     extras_require=extras_require,
 )


### PR DESCRIPTION
Moving metadata from `setup.py` to `setup.cfg` using [setup-py-upgrade](https://github.com/asottile/setup-py-upgrade).

Removing `python_version>='3.6'` for `black`, since `cabinetry` is Python >=3.6 only.