### PR TITLE
feat: skip fixed parameters in pull plot and correlation matrix

### DIFF
--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -105,7 +105,7 @@ def fit(
     bestfit = result[:, 0]
     uncertainty = result[:, 1]
     best_twice_nll = float(result_obj.fun)  # convert 0-dim np.ndarray to float
-    corr_mat = result_obj.minuit.np_matrix(correlation=True)
+    corr_mat = result_obj.minuit.np_matrix(correlation=True, skip_fixed=False)
     labels = get_parameter_names(model)
 
     print_results(bestfit, uncertainty, labels)

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -155,7 +155,9 @@ def custom_fit(
     else:
         data = build_Asimov_data(model)
 
-    step_size = [0.1 for _ in init_pars]
+    # set initial step size to 0 for fixed parameters
+    # this will cause the associated parameter uncertainties to be 0 post-fit
+    step_size = [0.1 if not fix_pars[i_par] else 0.0 for i_par in range(len(init_pars))]
 
     labels = get_parameter_names(model)
 
@@ -178,9 +180,9 @@ def custom_fit(
     m.migrad()
     m.hesse()
 
-    corr_mat = m.np_matrix(correlation=True)
     bestfit = m.np_values()
     uncertainty = m.np_errors()
+    corr_mat = m.np_matrix(correlation=True, skip_fixed=False)
     best_twice_nll = m.fval
 
     print_results(bestfit, uncertainty, labels)

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -106,7 +106,7 @@ def correlation_matrix(
         NotImplementedError: when trying to plot with a method that is not supported
     """
     # create a matrix that's True if a correlation is below threshold, and True on the diagonal
-    below_threshold = np.where(np.abs(corr_mat) < pruning_threshold, True, False)
+    below_threshold = np.where(np.abs(corr_mat) <= pruning_threshold, True, False)
     np.fill_diagonal(below_threshold, True)
     # get indices of rows/columns where everything is below threshold
     delete_indices = np.where(np.all(below_threshold, axis=0))
@@ -152,6 +152,11 @@ def pulls(
 
     if exclude_list is None:
         exclude_list = []
+
+    # exclude fixed parameters from pull plot
+    exclude_list += [
+        label for i_np, label in enumerate(labels_np) if uncertainty[i_np] == 0.0
+    ]
 
     # exclude staterror parameters from pull plot (they are centered at 1)
     exclude_list += [label for label in labels_np if label[0:10] == "staterror_"]

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -107,10 +107,10 @@ def test_custom_fit(example_spec):
     )
     # compared to fit(), the gamma is fixed
     assert np.allclose(bestfit, [1.1, 8.32985794])
-    assert np.allclose(uncertainty, [0.1, 0.38153392])
+    assert np.allclose(uncertainty, [0.0, 0.38153392])
     assert labels == ["staterror_Signal-Region", "Signal strength"]
     assert np.allclose(best_twice_nll, 7.90080378)
-    assert np.allclose(corr_mat, [[1.0]])
+    assert np.allclose(corr_mat, [[0.0, 0.0], [0.0, 1.0]])
 
     # Asimov fit, with fixed gamma (fixed not to Asimov MLE)
     bestfit, uncertainty, labels, best_twice_nll, corr_mat = fit.custom_fit(
@@ -119,7 +119,7 @@ def test_custom_fit(example_spec):
     # the gamma factor is multiplicative and fixed to 1.1, so the
     # signal strength needs to be 1/1.1 to compensate
     assert np.allclose(bestfit, [1.1, 0.90917877])
-    assert np.allclose(uncertainty, [0.1, 0.12623172])
+    assert np.allclose(uncertainty, [0.0, 0.12623172])
     assert labels == ["staterror_Signal-Region", "Signal strength"]
     assert np.allclose(best_twice_nll, 5.68851093)
-    assert np.allclose(corr_mat, [[1.0]])
+    assert np.allclose(corr_mat, [[0.0, 0.0], [0.0, 1.0]])


### PR DESCRIPTION
Set the initial step size for fixed parameters in `custom_fit` to 0.0, which causes the post-fit parameter uncertainty to be 0.0. Affected parameters will automatically be pruned from the pull plot. Switch to using `skip_fixed=False` for the correlation matrix, to include rows/columns for fixed parameters (with all values set to 0.0). These parameters are automatically pruned from the correlation matrix visualization.

this implements the plot improvements mentioned in #82