### PR TITLE
feat: visualization of ntuple creation utility can be disabled

### DIFF
--- a/util/create_ntuples.py
+++ b/util/create_ntuples.py
@@ -1,5 +1,4 @@
-"""Creates ntuples used as input for a minimal example of cabinetry.
-"""
+"""Creates ntuples used as input for a minimal example of cabinetry."""
 import os
 
 import matplotlib.pyplot as plt

--- a/util/create_ntuples.py
+++ b/util/create_ntuples.py
@@ -1,3 +1,5 @@
+"""Creates ntuples used as input for a minimal example of cabinetry.
+"""
 import os
 
 import matplotlib.pyplot as plt

--- a/util/create_ntuples.py
+++ b/util/create_ntuples.py
@@ -169,7 +169,7 @@ def plot_distributions(data, weights, labels, pseudodata, bins):
     plt.savefig("stacked.png", dpi=200)
 
 
-def run(output_directory):
+def run(output_directory, visualize=False):
     # configuration
     num_events = 5000
     yield_s = 125
@@ -213,9 +213,10 @@ def run(output_directory):
     np.testing.assert_allclose(w_read, weights)
     np.testing.assert_allclose(pd_read, pseudodata)
 
-    # visualize results
-    bins = np.linspace(0, 1200, 24 + 1)
-    plot_distributions(d_read, w_read, l_read, pseudodata, bins)
+    if visualize:
+        # visualize results
+        bins = np.linspace(0, 1200, 24 + 1)
+        plot_distributions(d_read, w_read, l_read, pseudodata, bins)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The ntuple creation script in `util` includes visualizes of the distributions it produces. This is now disabled by default, and can be re-enabled with the keyword argument `visualize`.