### PR TITLE
chore: updating version to 0.1.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cabinetry
-version = 0.1.1
+version = 0.1.2
 author = Alexander Held
 description = design and steer profile likelihood fits
 long_description = file: README.md

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -8,4 +8,4 @@ from . import visualize  # NOQA
 from . import workspace  # NOQA
 
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"


### PR DESCRIPTION
Updating version to allow for a new `cabinetry` release that includes pre- and post-fit plots introduced in #96.