### PR TITLE
refactor: model building and model reuse

### DIFF
--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -171,7 +171,7 @@ def fit(spec: Dict[str, Any], asimov: bool = False, custom: bool = False) -> Fit
     Returns:
         FitResults: object storing relevant fit results
     """
-    log.info("performing unconstrained fit")
+    log.info("performing maximum likelihood fit")
 
     model, data = model_and_data(spec, asimov)
 

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -45,7 +45,7 @@ def print_results(
 
 
 def model_and_data(
-    spec: Dict[str, Any], asimov: bool = False
+    spec: Dict[str, Any], asimov: bool = False, with_aux: bool = True
 ) -> Tuple[pyhf.pdf.Model, List[float]]:
     """Returns model and data for a ``pyhf`` workspace specification.
 
@@ -53,11 +53,13 @@ def model_and_data(
         spec (Dict[str, Any]): a ``pyhf`` workspace specification
         asimov (bool, optional): whether to return the Asimov dataset, defaults
             to False
+        with_aux (bool, optional): whether to also return auxdata, defaults
+            to True
 
     Returns:
         Tuple[pyhf.pdf.Model, List[float]]:
             - a HistFactory-style model in ``pyhf`` format
-            - the data (plus auxdata) for the model
+            - the data (plus auxdata if requested) for the model
     """
     workspace = pyhf.Workspace(spec)
     model = workspace.model(
@@ -67,9 +69,9 @@ def model_and_data(
         }
     )  # use HistFactory InterpCode=4
     if not asimov:
-        data = workspace.data(model)
+        data = workspace.data(model, with_aux=with_aux)
     else:
-        data = model_utils.build_Asimov_data(model)
+        data = model_utils.build_Asimov_data(model, with_aux=with_aux)
     return model, data
 
 

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, NamedTuple, Tuple
+from typing import Any, Dict, List, NamedTuple
 
 import iminuit
 import numpy as np
@@ -42,37 +42,6 @@ def print_results(
         log.info(
             f"{label.ljust(max_label_length)}: {fit_result.bestfit[i]: .6f} +/- {fit_result.uncertainty[i]:.6f}"
         )
-
-
-def model_and_data(
-    spec: Dict[str, Any], asimov: bool = False, with_aux: bool = True
-) -> Tuple[pyhf.pdf.Model, List[float]]:
-    """Returns model and data for a ``pyhf`` workspace specification.
-
-    Args:
-        spec (Dict[str, Any]): a ``pyhf`` workspace specification
-        asimov (bool, optional): whether to return the Asimov dataset, defaults
-            to False
-        with_aux (bool, optional): whether to also return auxdata, defaults
-            to True
-
-    Returns:
-        Tuple[pyhf.pdf.Model, List[float]]:
-            - a HistFactory-style model in ``pyhf`` format
-            - the data (plus auxdata if requested) for the model
-    """
-    workspace = pyhf.Workspace(spec)
-    model = workspace.model(
-        modifier_settings={
-            "normsys": {"interpcode": "code4"},
-            "histosys": {"interpcode": "code4p"},
-        }
-    )  # use HistFactory InterpCode=4
-    if not asimov:
-        data = workspace.data(model, with_aux=with_aux)
-    else:
-        data = model_utils.build_Asimov_data(model, with_aux=with_aux)
-    return model, data
 
 
 def _fit_model_pyhf(model: pyhf.pdf.Model, data: List[float]) -> FitResults:
@@ -175,7 +144,7 @@ def fit(spec: Dict[str, Any], asimov: bool = False, custom: bool = False) -> Fit
     """
     log.info("performing maximum likelihood fit")
 
-    model, data = model_and_data(spec, asimov)
+    model, data = model_utils.model_and_data(spec, asimov)
 
     if not custom:
         fit_result = _fit_model_pyhf(model, data)

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -30,19 +30,18 @@ class FitResults(NamedTuple):
 
 
 def print_results(
-    bestfit: np.ndarray, uncertainty: np.ndarray, labels: List[str]
+    fit_result: FitResults,
 ) -> None:
-    """print the best-fit parameter results and associated uncertainties
+    """Prints the best-fit parameter results and associated uncertainties.
 
     Args:
-        bestfit (numpy.ndarray): best-fit results of parameters
-        uncertainty (numpy.ndarray): uncertainties of best-fit parameter results
-        labels (List[str]): parameter labels
+        fit_result (FitResults): results of fit to be printed
     """
-    max_label_length = max([len(label) for label in labels])
-    for i, label in enumerate(labels):
-        l_with_spacer = label + " " * (max_label_length - len(label))
-        log.info(f"{l_with_spacer}: {bestfit[i]: .6f} +/- {uncertainty[i]:.6f}")
+    max_label_length = max([len(label) for label in fit_result.labels])
+    for i, label in enumerate(fit_result.labels):
+        log.info(
+            f"{label.ljust(max_label_length)}: {fit_result.bestfit[i]: .6f} +/- {fit_result.uncertainty[i]:.6f}"
+        )
 
 
 def model_and_data(
@@ -74,24 +73,19 @@ def model_and_data(
     return model, data
 
 
-def fit(spec: Dict[str, Any], asimov: bool = False) -> FitResults:
-    """Performs an unconstrained maximum likelihood fit with ``pyhf``.
+def _fit_model_pyhf(model: pyhf.pdf.Model, data: List[float]) -> FitResults:
+    """Uses the ``pyhf.infer`` API to perform a maximum likelihood fit.
 
-    Reports and returns the results of the fit. The ``asimov`` flag
-    allows to fit the Asimov dataset instead of observed data.
+    Parameters set to be fixed in the model are held constant.
 
     Args:
-        spec (Dict[str, Any]): a ``pyhf`` workspace specification
-        asimov (bool, optional): whether to fit the Asimov dataset, defaults
-            to False
+        model (pyhf.pdf.Model): the model to use in the fit
+        data (List[float]): the data to fit the model to
 
     Returns:
-        FitResults: fit information stored in one object
+        FitResults: object storing relevant fit results
     """
-    log.info("performing unconstrained fit")
     pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=True))
-
-    model, data = model_and_data(spec, asimov)
 
     result, result_obj = pyhf.infer.mle.fit(
         data, model, return_uncertainties=True, return_result_obj=True
@@ -103,33 +97,23 @@ def fit(spec: Dict[str, Any], asimov: bool = False) -> FitResults:
     corr_mat = result_obj.minuit.np_matrix(correlation=True, skip_fixed=False)
     best_twice_nll = float(result_obj.fun)  # convert 0-dim np.ndarray to float
 
-    print_results(bestfit, uncertainty, labels)
-    log.debug(f"-2 log(L) = {best_twice_nll:.6f} at the best-fit point")
-
     fit_result = FitResults(bestfit, uncertainty, labels, corr_mat, best_twice_nll)
     return fit_result
 
 
-def custom_fit(spec: Dict[str, Any], asimov: bool = False) -> FitResults:
-    """Performs an unconstrained maximum likelihood fit with ``iminuit``.
+def _fit_model_custom(model: pyhf.pdf.Model, data: List[float]) -> FitResults:
+    """Uses ``iminuit`` directly to perform a maximum likelihood fit.
 
-    Reports and returns the results of the fit. The ``asimov`` flag
-    allows to fit the Asimov dataset instead of observed data. Compared to
-    ``fit()``, this does not use the ``pyhf.infer`` API for more control
-    over the minimization.
+    Parameters set to be fixed in the model are held constant.
 
     Args:
-        spec (Dict[str, Any]): a ``pyhf`` workspace specification
-        asimov (bool, optional): whether to fit the Asimov dataset, defaults
-            to False
+        model (pyhf.pdf.Model): the model to use in the fit
+        data (List[float]): the data to fit the model to
 
     Returns:
-        FitResults: fit information stored in one object
+        FitResults: object storing relevant fit results
     """
-    log.info("performing unconstrained fit")
     pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=True))
-
-    model, data = model_and_data(spec, asimov)
 
     init_pars = model.config.suggested_init()
     par_bounds = model.config.suggested_bounds()
@@ -165,8 +149,38 @@ def custom_fit(spec: Dict[str, Any], asimov: bool = False) -> FitResults:
     corr_mat = m.np_matrix(correlation=True, skip_fixed=False)
     best_twice_nll = m.fval
 
-    print_results(bestfit, uncertainty, labels)
-    log.debug(f"-2 log(L) = {best_twice_nll:.6f} at the best-fit point")
-
     fit_result = FitResults(bestfit, uncertainty, labels, corr_mat, best_twice_nll)
+    return fit_result
+
+
+def fit(spec: Dict[str, Any], asimov: bool = False, custom: bool = False) -> FitResults:
+    """Performs a  maximum likelihood fit, reports and returns the results.
+
+    The ``asimov`` flag allows to fit the Asimov dataset instead of observed
+    data. Depending on the ``custom`` keyword argument, this uses either the
+    ``pyhf.infer`` API or ``iminuit`` directly for more control over the
+    minimization.
+
+    Args:
+        spec (Dict[str, Any]): a ``pyhf`` workspace specification
+        asimov (bool, optional): whether to fit the Asimov dataset, defaults
+            to False
+        custom (bool, optional): whether to use the ``pyhf.infer`` API or
+            ``iminuit``, defaults to False (using ``pyhf.infer``)
+
+    Returns:
+        FitResults: object storing relevant fit results
+    """
+    log.info("performing unconstrained fit")
+
+    model, data = model_and_data(spec, asimov)
+
+    if not custom:
+        fit_result = _fit_model_pyhf(model, data)
+    else:
+        fit_result = _fit_model_custom(model, data)
+
+    print_results(fit_result)
+    log.debug(f"-2 log(L) = {fit_result.best_twice_nll:.6f} at the best-fit point")
+
     return fit_result

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import awkward1 as ak
 import numpy as np
@@ -7,6 +7,37 @@ import pyhf
 
 
 log = logging.getLogger(__name__)
+
+
+def model_and_data(
+    spec: Dict[str, Any], asimov: bool = False, with_aux: bool = True
+) -> Tuple[pyhf.pdf.Model, List[float]]:
+    """Returns model and data for a ``pyhf`` workspace specification.
+
+    Args:
+        spec (Dict[str, Any]): a ``pyhf`` workspace specification
+        asimov (bool, optional): whether to return the Asimov dataset, defaults
+            to False
+        with_aux (bool, optional): whether to also return auxdata, defaults
+            to True
+
+    Returns:
+        Tuple[pyhf.pdf.Model, List[float]]:
+            - a HistFactory-style model in ``pyhf`` format
+            - the data (plus auxdata if requested) for the model
+    """
+    workspace = pyhf.Workspace(spec)
+    model = workspace.model(
+        modifier_settings={
+            "normsys": {"interpcode": "code4"},
+            "histosys": {"interpcode": "code4p"},
+        }
+    )  # use HistFactory InterpCode=4
+    if not asimov:
+        data = workspace.data(model, with_aux=with_aux)
+    else:
+        data = build_Asimov_data(model, with_aux=with_aux)
+    return model, data
 
 
 def get_parameter_names(model: pyhf.pdf.Model) -> List[str]:

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -30,6 +30,21 @@ def get_parameter_names(model: pyhf.pdf.Model) -> List[str]:
     return labels
 
 
+def build_Asimov_data(model: pyhf.Model) -> np.ndarray:
+    """Returns the Asimov dataset (with auxdata) for a model.
+
+    Args:
+        model (pyhf.Model): the model from which to construct the
+            dataset
+
+    Returns:
+        np.ndarray: the Asimov dataset
+    """
+    asimov_data = np.sum(model.nominal_rates, axis=1)[0][0]
+    asimov_aux = model.config.auxdata
+    return np.hstack((asimov_data, asimov_aux))
+
+
 def get_asimov_parameters(model: pyhf.pdf.Model) -> Tuple[np.ndarray, np.ndarray]:
     """Returns a list of Asimov parameter values and pre-fit uncertainties for a model.
 

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -30,19 +30,22 @@ def get_parameter_names(model: pyhf.pdf.Model) -> List[str]:
     return labels
 
 
-def build_Asimov_data(model: pyhf.Model) -> List[float]:
-    """Returns the Asimov dataset (with auxdata) for a model.
+def build_Asimov_data(model: pyhf.Model, with_aux: bool = True) -> List[float]:
+    """Returns the Asimov dataset (optionally with auxdata) for a model.
 
     Args:
         model (pyhf.Model): the model from which to construct the
             dataset
+        with_aux (bool, optional): whether to also return auxdata, defaults
+            to True
 
     Returns:
         List[float]: the Asimov dataset
     """
     asimov_data = np.sum(model.nominal_rates, axis=1)[0][0].tolist()
-    asimov_aux = model.config.auxdata
-    return asimov_data + asimov_aux
+    if with_aux:
+        return asimov_data + model.config.auxdata
+    return asimov_data
 
 
 def get_asimov_parameters(model: pyhf.pdf.Model) -> Tuple[np.ndarray, np.ndarray]:

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -30,7 +30,7 @@ def get_parameter_names(model: pyhf.pdf.Model) -> List[str]:
     return labels
 
 
-def build_Asimov_data(model: pyhf.Model) -> np.ndarray:
+def build_Asimov_data(model: pyhf.Model) -> List[float]:
     """Returns the Asimov dataset (with auxdata) for a model.
 
     Args:
@@ -38,11 +38,11 @@ def build_Asimov_data(model: pyhf.Model) -> np.ndarray:
             dataset
 
     Returns:
-        np.ndarray: the Asimov dataset
+        List[float]: the Asimov dataset
     """
-    asimov_data = np.sum(model.nominal_rates, axis=1)[0][0]
+    asimov_data = np.sum(model.nominal_rates, axis=1)[0][0].tolist()
     asimov_aux = model.config.auxdata
-    return np.hstack((asimov_data, asimov_aux))
+    return asimov_data + asimov_aux
 
 
 def get_asimov_parameters(model: pyhf.pdf.Model) -> Tuple[np.ndarray, np.ndarray]:

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -4,7 +4,6 @@ import pathlib
 from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
-import pyhf
 
 from . import configuration
 from . import fit
@@ -122,13 +121,7 @@ def data_MC(
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
     """
-    workspace = pyhf.Workspace(spec)
-    model = workspace.model(
-        modifier_settings={
-            "normsys": {"interpcode": "code4"},
-            "histosys": {"interpcode": "code4p"},
-        }
-    )
+    model, data_combined = fit.model_and_data(spec, with_aux=False)
 
     if fit_results:
         # fit results specified, draw a post-fit plot with them applied
@@ -148,7 +141,6 @@ def data_MC(
     yields_combined = model.main_model.expected_data(
         param_values, return_by_sample=True
     )  # all channels concatenated
-    data_combined = workspace.data(model, with_aux=False)
 
     # slice the yields into an array where the first index is the channel,
     # and the second index is the sample

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -121,7 +121,7 @@ def data_MC(
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
     """
-    model, data_combined = fit.model_and_data(spec, with_aux=False)
+    model, data_combined = model_utils.model_and_data(spec, with_aux=False)
 
     if fit_results:
         # fit results specified, draw a post-fit plot with them applied

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -454,7 +454,7 @@ def build(config: Dict[str, Any], with_validation: bool = True) -> Dict[str, Any
 
 
 def validate(ws: Dict[str, Any]) -> None:
-    """Validate a workspace with ``pyhf``.
+    """Validates a workspace with ``pyhf``.
 
     Args:
         ws (Dict[str, Any]): the workspace to validate
@@ -463,7 +463,7 @@ def validate(ws: Dict[str, Any]) -> None:
 
 
 def save(ws: Dict[str, Any], file_path_string: Union[str, pathlib.Path]) -> None:
-    """Serialize a workspace to a file.
+    """Serializes a workspace to a file.
 
     Args:
         ws (Dict[str, Any]): ``pyhf``-compatible `HistFactory` workspace
@@ -479,7 +479,7 @@ def save(ws: Dict[str, Any], file_path_string: Union[str, pathlib.Path]) -> None
 
 
 def load(file_path_string: Union[str, pathlib.Path]) -> Dict[str, Any]:
-    """Load a workspace from a file.
+    """Loads a workspace from a file.
 
     Args:
         file_path_string (Union[str, pathlib.Path]): path to the file to load the workspace from

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -32,6 +32,20 @@ def test_print_results(caplog):
     caplog.clear()
 
 
+def test_model_and_data(example_spec):
+    model, data = fit.model_and_data(example_spec)
+    assert model.spec["channels"] == example_spec["channels"]
+    assert model.config.modifier_settings == {
+        "normsys": {"interpcode": "code4"},
+        "histosys": {"interpcode": "code4p"},
+    }
+    assert np.allclose(data, [475, 1.0])
+
+    # requesting Asimov dataset
+    model, data = fit.model_and_data(example_spec, asimov=True)
+    assert np.allclose(data, [51.839756, 1.0])
+
+
 # skip a "RuntimeWarning: numpy.ufunc size changed" warning
 # due to different numpy versions used in dependencies
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -42,11 +42,15 @@ def test_model_and_data(example_spec):
         "normsys": {"interpcode": "code4"},
         "histosys": {"interpcode": "code4p"},
     }
-    assert np.allclose(data, [475, 1.0])
+    assert data == [475, 1.0]
 
     # requesting Asimov dataset
     model, data = fit.model_and_data(example_spec, asimov=True)
-    assert np.allclose(data, [51.839756, 1.0])
+    assert data == [51.839756, 1.0]
+
+    # without auxdata
+    model, data = fit.model_and_data(example_spec, with_aux=False)
+    assert data == [475]
 
 
 # skip a "RuntimeWarning: numpy.ufunc size changed" warning

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -124,3 +124,5 @@ def test_fit(mock_load, mock_pyhf, mock_custom, mock_print, example_spec):
     fit.fit(example_spec, custom=True)
     mock_custom.assert_called_once()
     assert mock_custom.call_args == [("model", "data"), {}]
+    assert mock_print.call_args[0][0].bestfit == [3.0]
+    assert mock_print.call_args[0][0].uncertainty == [0.3]

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -1,4 +1,5 @@
 import logging
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -26,7 +27,9 @@ def test_print_results(caplog):
     bestfit = np.asarray([1.0, 2.0])
     uncertainty = np.asarray([0.1, 0.3])
     labels = ["param_A", "param_B"]
-    fit.print_results(bestfit, uncertainty, labels)
+    fit_results = fit.FitResults(bestfit, uncertainty, labels, np.empty(0), 0.0)
+
+    fit.print_results(fit_results)
     assert "param_A:  1.000000 +/- 0.100000" in [rec.message for rec in caplog.records]
     assert "param_B:  2.000000 +/- 0.300000" in [rec.message for rec in caplog.records]
     caplog.clear()
@@ -49,8 +52,9 @@ def test_model_and_data(example_spec):
 # skip a "RuntimeWarning: numpy.ufunc size changed" warning
 # due to different numpy versions used in dependencies
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-def test_fit(example_spec):
-    fit_results = fit.fit(example_spec)
+def test__fit_model_pyhf(example_spec):
+    model, data = fit.model_and_data(example_spec)
+    fit_results = fit._fit_model_pyhf(model, data)
     assert np.allclose(fit_results.bestfit, [1.1, 8.32984849])
     assert np.allclose(fit_results.uncertainty, [0.0, 0.38099445])
     assert fit_results.labels == ["staterror_Signal-Region", "Signal strength"]
@@ -58,7 +62,8 @@ def test_fit(example_spec):
     assert np.allclose(fit_results.corr_mat, [[0.0, 0.0], [0.0, 1.0]])
 
     # Asimov fit
-    fit_results = fit.fit(example_spec, asimov=True)
+    model, data = fit.model_and_data(example_spec, asimov=True)
+    fit_results = fit._fit_model_pyhf(model, data)
     assert np.allclose(fit_results.bestfit, [1.1, 0.90917877], rtol=1e-4)
     assert np.allclose(fit_results.uncertainty, [0.0, 0.12623179])
     assert fit_results.labels == ["staterror_Signal-Region", "Signal strength"]
@@ -67,9 +72,9 @@ def test_fit(example_spec):
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-def test_custom_fit(example_spec):
-    fit_results = fit.custom_fit(example_spec)
-    # compared to fit(), the gamma is fixed
+def test__fit_model_custom(example_spec):
+    model, data = fit.model_and_data(example_spec)
+    fit_results = fit._fit_model_custom(model, data)
     assert np.allclose(fit_results.bestfit, [1.1, 8.32985794])
     assert np.allclose(fit_results.uncertainty, [0.0, 0.38153392])
     assert fit_results.labels == ["staterror_Signal-Region", "Signal strength"]
@@ -77,7 +82,8 @@ def test_custom_fit(example_spec):
     assert np.allclose(fit_results.corr_mat, [[0.0, 0.0], [0.0, 1.0]])
 
     # Asimov fit, with fixed gamma (fixed not to Asimov MLE)
-    fit_results = fit.custom_fit(example_spec, asimov=True)
+    model, data = fit.model_and_data(example_spec, asimov=True)
+    fit_results = fit._fit_model_custom(model, data)
     # the gamma factor is multiplicative and fixed to 1.1, so the
     # signal strength needs to be 1/1.1 to compensate
     assert np.allclose(fit_results.bestfit, [1.1, 0.90917877])
@@ -85,3 +91,36 @@ def test_custom_fit(example_spec):
     assert fit_results.labels == ["staterror_Signal-Region", "Signal strength"]
     assert np.allclose(fit_results.best_twice_nll, 5.68851093)
     assert np.allclose(fit_results.corr_mat, [[0.0, 0.0], [0.0, 1.0]])
+
+
+@mock.patch("cabinetry.fit.print_results")
+@mock.patch(
+    "cabinetry.fit._fit_model_custom",
+    return_value=fit.FitResults(
+        np.asarray([3.0]), np.asarray([0.3]), ["par"], np.empty(0), 5.0
+    ),
+)
+@mock.patch(
+    "cabinetry.fit._fit_model_pyhf",
+    return_value=fit.FitResults(
+        np.asarray([1.0]), np.asarray([0.1]), ["par"], np.empty(0), 2.0
+    ),
+)
+@mock.patch("cabinetry.fit.model_and_data", return_value=("model", "data"))
+def test_fit(mock_load, mock_pyhf, mock_custom, mock_print, example_spec):
+    fit.fit(example_spec)
+    assert mock_load.call_args_list == [[(example_spec, False), {}]]
+    assert mock_pyhf.call_args_list == [[("model", "data"), {}]]
+    mock_print.assert_called_once()
+    assert mock_print.call_args[0][0].bestfit == [1.0]
+    assert mock_print.call_args[0][0].uncertainty == [0.1]
+    assert mock_print.call_args[0][0].labels == ["par"]
+
+    # Asimov fit
+    fit.fit(example_spec, asimov=True)
+    assert mock_load.call_args == [(example_spec, True), {}]
+
+    # custom fit
+    fit.fit(example_spec, custom=True)
+    mock_custom.assert_called_once()
+    assert mock_custom.call_args == [("model", "data"), {}]

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -1,7 +1,6 @@
 import logging
 
 import numpy as np
-import pyhf
 import pytest
 
 from cabinetry import fit
@@ -31,12 +30,6 @@ def test_print_results(caplog):
     assert "param_A:  1.000000 +/- 0.100000" in [rec.message for rec in caplog.records]
     assert "param_B:  2.000000 +/- 0.300000" in [rec.message for rec in caplog.records]
     caplog.clear()
-
-
-def test_build_Asimov_data(example_spec):
-    ws = pyhf.Workspace(example_spec)
-    model = ws.model()
-    assert np.allclose(fit.build_Asimov_data(model), [51.839756, 1])
 
 
 # skip a "RuntimeWarning: numpy.ufunc size changed" warning

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -5,6 +5,24 @@ import pyhf
 from cabinetry import model_utils
 
 
+def test_model_and_data(example_spec):
+    model, data = model_utils.model_and_data(example_spec)
+    assert model.spec["channels"] == example_spec["channels"]
+    assert model.config.modifier_settings == {
+        "normsys": {"interpcode": "code4"},
+        "histosys": {"interpcode": "code4p"},
+    }
+    assert data == [475, 1.0]
+
+    # requesting Asimov dataset
+    model, data = model_utils.model_and_data(example_spec, asimov=True)
+    assert data == [51.839756, 1.0]
+
+    # without auxdata
+    model, data = model_utils.model_and_data(example_spec, with_aux=False)
+    assert data == [475]
+
+
 def test_get_parameter_names(example_spec):
     model = pyhf.Workspace(example_spec).model()
     labels = model_utils.get_parameter_names(model)

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -14,7 +14,7 @@ def test_get_parameter_names(example_spec):
 def test_build_Asimov_data(example_spec):
     ws = pyhf.Workspace(example_spec)
     model = ws.model()
-    assert np.allclose(model_utils.build_Asimov_data(model), [51.839756, 1])
+    assert model_utils.build_Asimov_data(model) == [51.839756, 1]
 
 
 def test_get_asimov_parameters(example_spec):

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -11,6 +11,12 @@ def test_get_parameter_names(example_spec):
     assert labels == ["staterror_Signal-Region", "Signal strength"]
 
 
+def test_build_Asimov_data(example_spec):
+    ws = pyhf.Workspace(example_spec)
+    model = ws.model()
+    assert np.allclose(model_utils.build_Asimov_data(model), [51.839756, 1])
+
+
 def test_get_asimov_parameters(example_spec):
     model = pyhf.Workspace(example_spec).model()
     pars, unc = model_utils.get_asimov_parameters(model)

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -16,6 +16,9 @@ def test_build_Asimov_data(example_spec):
     model = ws.model()
     assert model_utils.build_Asimov_data(model) == [51.839756, 1]
 
+    # without auxdata
+    assert model_utils.build_Asimov_data(model, with_aux=False) == [51.839756]
+
 
 def test_get_asimov_parameters(example_spec):
     model = pyhf.Workspace(example_spec).model()


### PR DESCRIPTION
Moving model construction from workspace into a function. Allowing for model-reuse, and moving Asimov data generation to the `model_utils` module.

`fit.custom_fit` is removed, and the functionality is instead accessed via `fit.fit(..., custom=True)`.

The new `model_utils.model_and_data` has a `with_aux` keyword argument that defaults to `True`, which is also added to `model_utils.build_Asimov_data`.