### PR TITLE
test: integration test isolation

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,9 +15,14 @@ def test_integration(tmp_path, ntuple_creator):
     """The purpose of this integration test is to check whether the
     steps run without error and whether the fit result is as expected.
     """
-    ntuple_creator(str(tmp_path) + "/")
+    ntuple_creator(str(tmp_path))
 
     cabinetry_config = cabinetry.configuration.read("config_example.yml")
+
+    # override config options to point to tmp_path
+    cabinetry_config["General"]["HistogramFolder"] = str(tmp_path / "histograms")
+    cabinetry_config["General"]["InputPath"] = str(tmp_path / "{SamplePath}")
+
     cabinetry.template_builder.create_histograms(cabinetry_config, method="uproot")
     cabinetry.template_postprocessor.run(cabinetry_config)
     workspace_path = tmp_path / "example_workspace.json"

--- a/util/create_ntuples.py
+++ b/util/create_ntuples.py
@@ -177,8 +177,8 @@ def run(output_directory, visualize=False):
     yield_b = 1000
     yield_b_var = 1000
     labels = ["signal", "background", "background_varied"]  # names of prcesses
-    file_name = output_directory + "prediction.root"
-    file_name_pseudodata = output_directory + "data.root"
+    file_name = output_directory + "/prediction.root"
+    file_name_pseudodata = output_directory + "/data.root"
 
     np.random.seed(0)
 


### PR DESCRIPTION
Updating the integration test to use the histograms saved under `tmp_path`, rather than the histograms created by running `example.py` in an earlier CI step.