### PR TITLE
fix: make awkward1 core dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     boost_histogram
     jsonschema
     click
+    awkward1
 
 [options.packages.find]
 where = src

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-extras_require = {"contrib": ["matplotlib", "uproot", "uproot4", "awkward1"]}
+extras_require = {"contrib": ["matplotlib", "uproot", "uproot4"]}
 extras_require["test"] = sorted(
     set(
         extras_require["contrib"]


### PR DESCRIPTION
Fixes #112.

#96 introduce a dependency on `awkward1`, which was so far only installed via the `contrib` setup extra. It is now removed from that setup extra and instead added as a core dependency.