### PR TITLE
fix: close matplotlib figures after saving

### DIFF
--- a/src/cabinetry/contrib/matplotlib_visualize.py
+++ b/src/cabinetry/contrib/matplotlib_visualize.py
@@ -164,6 +164,7 @@ def data_MC(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
+    plt.close(fig)
 
 
 def correlation_matrix(
@@ -206,6 +207,7 @@ def correlation_matrix(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
+    plt.close(fig)
 
 
 def pulls(
@@ -241,6 +243,7 @@ def pulls(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
+    plt.close(fig)
 
 
 def ranking(
@@ -354,6 +357,7 @@ def ranking(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
+    plt.close(fig)
 
 
 def templates(
@@ -511,3 +515,4 @@ def templates(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
+    plt.close(fig)

--- a/util/create_ntuples.py
+++ b/util/create_ntuples.py
@@ -142,6 +142,7 @@ def plot_distributions(data, weights, labels, pseudodata, bins):
     plt.xlabel(r"jet $p_T$ [GeV]")
     plt.ylabel("normalized")
     plt.savefig("normalized.png", dpi=200)
+    plt.close()
 
     # plot stack
     plt.clf()
@@ -168,6 +169,7 @@ def plot_distributions(data, weights, labels, pseudodata, bins):
     plt.xlabel(r"jet $p_T$ [GeV]")
     plt.ylabel("events / " + bin_width_str + " GeV")
     plt.savefig("stacked.png", dpi=200)
+    plt.close()
 
 
 def run(output_directory, visualize=False):


### PR DESCRIPTION
When visualizing a lot of templates, `matplotlib` printed a warning about many figures being open at once. This closes all figures after saving, since they are not needed anymore after that point.