### PR TITLE
feat: nuisance parameter ranking

### DIFF
--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -32,9 +32,8 @@ class FitResults(NamedTuple):
 class RankingResults(NamedTuple):
     """Collects nuisance parameter ranking results in one object.
 
-    The best-fit results per parameter / uncertainties / labels should
-    not include the parameter of interest, since no impact for it is
-    calculated.
+    The best-fit results per parameter, the uncertainties, and the labels should
+    not include the parameter of interest, since no impact for it is calculated.
 
     Args:
         bestfit (numpy.ndarray): best-fit results of parameters

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -238,14 +238,14 @@ def ranking(
 
         parameter_impacts = []
         # calculate impacts: pre-fit up, pre-fit down, post-fit up, post-fit down
-        for val in [
+        for np_val in [
             fit_results.bestfit[i_par] + prefit_unc[i_par],
             fit_results.bestfit[i_par] - prefit_unc[i_par],
             fit_results.bestfit[i_par] + fit_results.uncertainty[i_par],
             fit_results.bestfit[i_par] - fit_results.uncertainty[i_par],
         ]:
             init_pars = init_pars_default.copy()
-            init_pars[i_par] = val  # set value of current nuisance parameter
+            init_pars[i_par] = np_val  # set value of current nuisance parameter
             # could skip pre-fit calculation for unconstrained parameters
             # skip calculation for fixed parameters?
             fit_results_ranking = _fit_model_custom(

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -104,7 +104,8 @@ def _fit_model_custom(
 ) -> FitResults:
     """Uses ``iminuit`` directly to perform a maximum likelihood fit.
 
-    Parameters set to be fixed in the model are held constant.
+    Parameters set to be fixed in the model are held constant. Additional
+    parameters can be held constant via the ``fixed_pars`` keyword argument.
 
     Args:
         model (pyhf.pdf.Model): the model to use in the fit

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -247,7 +247,6 @@ def ranking(
             init_pars = init_pars_default.copy()
             init_pars[i_par] = np_val  # set value of current nuisance parameter
             # could skip pre-fit calculation for unconstrained parameters
-            # skip calculation for fixed parameters?
             fit_results_ranking = _fit_model_custom(
                 model, data, init_pars=init_pars, fix_pars=fix_pars
             )

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -29,6 +29,32 @@ class FitResults(NamedTuple):
     best_twice_nll: float
 
 
+class RankingResults(NamedTuple):
+    """Collects nuisance parameter ranking results in one object.
+
+    The best-fit results per parameter / uncertainties / labels should
+    not include the parameter of interest, since no impact for it is
+    calculated.
+
+    Args:
+        bestfit (numpy.ndarray): best-fit results of parameters
+        uncertainty (numpy.ndarray): uncertainties of best-fit parameter results
+        labels (List[str]): parameter labels
+        prefit_up (numpy.ndarray): pre-fit impact in "up" direction
+        prefit_down (numpy.ndarray): pre-fit impact in "down" direction
+        postfit_up (numpy.ndarray): post-fit impact in "up" direction
+        postfit_down (numpy.ndarray): post-fit impact in "down" direction
+    """
+
+    bestfit: np.ndarray
+    uncertainty: np.ndarray
+    labels: List[str]
+    prefit_up: np.ndarray
+    prefit_down: np.ndarray
+    postfit_up: np.ndarray
+    postfit_down: np.ndarray
+
+
 def print_results(
     fit_result: FitResults,
 ) -> None:

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -230,7 +230,7 @@ def ranking(
     for i_par, label in enumerate(labels):
         if label == model.config.poi_name:
             continue  # do not calculate impact of POI on itself
-        log.info(f"running ranking for {label}")
+        log.info(f"calculating impact of {label} on {labels[model.config.poi_index]}")
 
         # hold current parameter constant
         fix_pars = fix_pars_default.copy()
@@ -253,7 +253,7 @@ def ranking(
             )
             poi_val = fit_results_ranking.bestfit[model.config.poi_index]
             parameter_impact = poi_val - nominal_poi
-            log.info(
+            log.debug(
                 f"POI is {poi_val:.6f}, difference to nominal is {parameter_impact:.6f}"
             )
             parameter_impacts.append(parameter_impact)

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -113,9 +113,9 @@ def _fit_model_custom(
         model (pyhf.pdf.Model): the model to use in the fit
         data (List[float]): the data to fit the model to
         init_pars (Optional[List[float]], optional): list of initial parameter
-            settings, defaults to None (use pyhf suggested inits)
+            settings, defaults to None (use ``pyhf`` suggested inits)
         fix_pars (Optional[List[bool]], optional): list of booleans specifying
-            which parameters are held constant, defaults to None (use pyhf
+            which parameters are held constant, defaults to None (use ``pyhf``
             suggestion)
 
     Returns:

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -235,7 +235,6 @@ def ranking(
         # hold current parameter constant
         fix_pars = fix_pars_default.copy()
         fix_pars[i_par] = True
-        init_pars = init_pars_default.copy()
 
         parameter_impacts = []
         # calculate impacts: pre-fit up, pre-fit down, post-fit up, post-fit down
@@ -245,8 +244,10 @@ def ranking(
             fit_results.bestfit[i_par] + fit_results.uncertainty[i_par],
             fit_results.bestfit[i_par] - fit_results.uncertainty[i_par],
         ]:
+            init_pars = init_pars_default.copy()
             init_pars[i_par] = val  # set value of current nuisance parameter
             # could skip pre-fit calculation for unconstrained parameters
+            # skip calculation for fixed parameters?
             fit_results_ranking = _fit_model_custom(
                 model, data, init_pars=init_pars, fix_pars=fix_pars
             )

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -125,11 +125,13 @@ def _fit_model_custom(
     labels = model_utils.get_parameter_names(model)
 
     if fixed_pars:
-        # hold parameters parameters
+        # hold parameters constant
         for par in fixed_pars:
             par_index = par["index"]
             par_value = par["value"]
-            log.debug(f"holding parameter {labels[par_index]} fixed at {par_value:.6f}")
+            log.debug(
+                f"holding parameter {labels[par_index]} constant at {par_value:.6f}"
+            )
             fix_pars[par_index] = True
             init_pars[par_index] = par_value
 

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -80,17 +80,15 @@ def build_Asimov_data(model: pyhf.Model, with_aux: bool = True) -> List[float]:
     return asimov_data
 
 
-def get_asimov_parameters(model: pyhf.pdf.Model) -> Tuple[np.ndarray, np.ndarray]:
-    """Returns a list of Asimov parameter values and pre-fit uncertainties for a model.
+def get_asimov_parameters(model: pyhf.pdf.Model) -> np.ndarray:
+    """Returns a list of Asimov parameter values for a model.
 
     Args:
         model (pyhf.pdf.Model): model for which to extract the parameters
 
     Returns:
-        Tuple[np.ndarray, np.ndarray]:
-            - the Asimov parameters, in the same order as
-              ``model.config.suggested_init()``
-            - pre-fit uncertainties for the parameters
+        np.ndarray: the Asimov parameters, in the same order as
+            ``model.config.suggested_init()``
     """
     # create a list of parameter names, one entry per single parameter
     # (vectors like staterror expanded)
@@ -102,7 +100,6 @@ def get_asimov_parameters(model: pyhf.pdf.Model) -> Tuple[np.ndarray, np.ndarray
     # best-fit value from the aux measurement, unconstrained parameters at
     # the init specified in the workspace)
     asimov_parameters = []
-    pre_fit_unc = []  # pre-fit uncertainties for parameters
     for parameter in model.config.par_order:
         # indices in auxdata list that match the current parameter
         aux_indices = [i for i, par in enumerate(auxdata_pars_all) if par == parameter]
@@ -116,6 +113,23 @@ def get_asimov_parameters(model: pyhf.pdf.Model) -> Tuple[np.ndarray, np.ndarray
             inits = model.config.param_set(parameter).suggested_init
         asimov_parameters += inits
 
+    return np.asarray(asimov_parameters)
+
+
+def get_prefit_uncertainties(model: pyhf.pdf.Model) -> np.ndarray:
+    """Returns a list of pre-fit parameter uncertainties for a model.
+
+    For unconstrained parameters the uncertainty is set to 0.
+
+    Args:
+        model (pyhf.pdf.Model): model for which to extract the parameters
+
+    Returns:
+        np.ndarray: pre-fit uncertainties for the parameters, in the same
+            order as ``model.config.suggested_init()``
+    """
+    pre_fit_unc = []  # pre-fit uncertainties for parameters
+    for parameter in model.config.par_order:
         # for constrained parameters, obtain their pre-fit uncertainty
         if model.config.param_set(parameter).constrained:
             pre_fit_unc += model.config.param_set(parameter).width()
@@ -126,8 +140,7 @@ def get_asimov_parameters(model: pyhf.pdf.Model) -> Tuple[np.ndarray, np.ndarray
             else:
                 # shapefactor
                 pre_fit_unc += [0.0] * model.config.param_set(parameter).n_parameters
-
-    return np.asarray(asimov_parameters), np.asarray(pre_fit_unc)
+    return np.asarray(pre_fit_unc)
 
 
 def calculate_stdev(

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -302,9 +302,7 @@ def pulls(
 
 
 def ranking(
-    bestfit: np.ndarray,
-    uncertainty: np.ndarray,
-    labels: List[str],
+    fit_results: fit.FitResults,
     impact_prefit_up: np.ndarray,
     impact_prefit_down: np.ndarray,
     impact_postfit_up: np.ndarray,
@@ -317,9 +315,7 @@ def ranking(
     """Produces a ranking plot showing the impact of parameters on the POI.
 
     Args:
-        bestfit (np.ndarray): best-fit parameter results
-        uncertainty (np.ndarray): parameter uncertainties
-        labels (List[str]): parameter labels
+        fit_results (fit.FitResults): fit results to show best-fit points and uncertainties
         impact_prefit_up (np.ndarray): pre-fit impact in "up" direction per parameter
         impact_prefit_down (np.ndarray): pre-fit impact in "down" direction per parameter
         impact_postfit_up (np.ndarray): post-fit impact in "up" direction per parameter
@@ -336,9 +332,9 @@ def ranking(
     figure_path = pathlib.Path(figure_folder) / "ranking.pdf"
 
     # remove the POI results from bestfit, uncertainty, labels
-    bestfit = np.delete(bestfit, poi_index)
-    uncertainty = np.delete(uncertainty, poi_index)
-    labels = np.delete(labels, poi_index)
+    bestfit = np.delete(fit_results.bestfit, poi_index)
+    uncertainty = np.delete(fit_results.uncertainty, poi_index)
+    labels = np.delete(fit_results.labels, poi_index)
 
     # normalize staterrors - subtract 1
     # could also normalize width of staterrors here

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -134,7 +134,8 @@ def data_MC(
         # no fit results specified, draw a pre-fit plot
         prefit = True
         # use pre-fit parameter values and uncertainties, and diagonal correlation matrix
-        param_values, param_uncertainty = model_utils.get_asimov_parameters(model)
+        param_values = model_utils.get_asimov_parameters(model)
+        param_uncertainty = model_utils.get_prefit_uncertainties(model)
         corr_mat = np.zeros(shape=(len(param_values), len(param_values)))
         np.fill_diagonal(corr_mat, 1.0)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,3 +119,41 @@ def example_spec_multibin():
         "version": "1.0.0",
     }
     return spec
+
+
+@pytest.fixture
+def example_spec_shapefactor():
+    spec = {
+        "channels": [
+            {
+                "name": "Signal Region",
+                "samples": [
+                    {
+                        "data": [20, 10],
+                        "modifiers": [
+                            {
+                                "data": None,
+                                "name": "shape factor",
+                                "type": "shapefactor",
+                            },
+                            {
+                                "data": None,
+                                "name": "Signal strength",
+                                "type": "normfactor",
+                            },
+                        ],
+                        "name": "Signal",
+                    }
+                ],
+            }
+        ],
+        "measurements": [
+            {
+                "config": {"parameters": [], "poi": "Signal strength"},
+                "name": "shapefactor fit",
+            }
+        ],
+        "observations": [{"data": [25, 8], "name": "Signal Region"}],
+        "version": "1.0.0",
+    }
+    return spec

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -59,7 +59,7 @@ def test__fit_model_pyhf(example_spec):
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-def test__fit_model_custom(example_spec):
+def test__fit_model_custom(example_spec, example_spec_multibin):
     model, data = model_utils.model_and_data(example_spec)
     fit_results = fit._fit_model_custom(model, data)
     assert np.allclose(fit_results.bestfit, [1.1, 8.32985794])
@@ -78,6 +78,15 @@ def test__fit_model_custom(example_spec):
     assert fit_results.labels == ["staterror_Signal-Region", "Signal strength"]
     assert np.allclose(fit_results.best_twice_nll, 5.68851093)
     assert np.allclose(fit_results.corr_mat, [[0.0, 0.0], [0.0, 1.0]])
+
+    # parameters held constant via keyword argument
+    model, data = model_utils.model_and_data(example_spec_multibin)
+    fit_results = fit._fit_model_custom(
+        model, data, fixed_pars=[{"index": 0, "value": 0.9}, {"index": 1, "value": 1.1}]
+    )
+    assert np.allclose(fit_results.bestfit, [0.9, 1.1, 1.48041923, 0.97511112])
+    assert np.allclose(fit_results.uncertainty, [0.0, 0.0, 0.20694409, 0.11792805])
+    assert np.allclose(fit_results.best_twice_nll, 10.45318909)
 
 
 @mock.patch("cabinetry.fit.print_results")

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -96,7 +96,7 @@ def test__fit_model_custom(example_spec):
 @mock.patch("cabinetry.model_utils.model_and_data", return_value=("model", "data"))
 def test_fit(mock_load, mock_pyhf, mock_custom, mock_print, example_spec):
     fit.fit(example_spec)
-    assert mock_load.call_args_list == [[(example_spec, False), {}]]
+    assert mock_load.call_args_list == [[(example_spec,), {"asimov": False}]]
     assert mock_pyhf.call_args_list == [[("model", "data"), {}]]
     mock_print.assert_called_once()
     assert mock_print.call_args[0][0].bestfit == [1.0]
@@ -105,7 +105,7 @@ def test_fit(mock_load, mock_pyhf, mock_custom, mock_print, example_spec):
 
     # Asimov fit
     fit.fit(example_spec, asimov=True)
-    assert mock_load.call_args == [(example_spec, True), {}]
+    assert mock_load.call_args == [(example_spec,), {"asimov": True}]
 
     # custom fit
     fit.fit(example_spec, custom=True)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -138,3 +138,54 @@ def test_integration(tmp_path, ntuple_creator):
     assert np.allclose(fit_results.uncertainty, uncertainty_expected)
     assert np.allclose(fit_results.best_twice_nll, best_twice_nll_expected)
     assert np.allclose(fit_results.corr_mat, corr_mat_expected, rtol=5e-5)
+
+    # nuisance parameter ranking
+    ranking_results = cabinetry.fit.ranking(ws, fit_results)
+    assert np.allclose(
+        ranking_results.prefit_up,
+        [
+            -0.10470340,
+            0.14648429,
+            -0.10991236,
+            -0.05278778,
+            -0.14582642,
+            -1.67590283,
+            -1.51782965,
+        ],
+    )
+    assert np.allclose(
+        ranking_results.prefit_down,
+        [
+            0.11277466,
+            -0.14829532,
+            0.11949235,
+            0.06167027,
+            0.17465462,
+            1.41673474,
+            1.15103106,
+        ],
+    )
+    assert np.allclose(
+        ranking_results.postfit_up,
+        [
+            -0.10184155,
+            0.14165853,
+            -0.10464174,
+            -0.05181179,
+            -0.14457961,
+            -1.10093621,
+            -0.89766455,
+        ],
+    )
+    assert np.allclose(
+        ranking_results.postfit_down,
+        [
+            0.1097976,
+            -0.14270861,
+            0.11393967,
+            0.06079421,
+            0.17307896,
+            0.84412165,
+            0.76660498,
+        ],
+    )

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -38,49 +38,23 @@ def test_build_Asimov_data(example_spec):
     assert model_utils.build_Asimov_data(model, with_aux=False) == [51.839756]
 
 
-def test_get_asimov_parameters(example_spec):
+def test_get_asimov_parameters(example_spec, example_spec_shapefactor):
     model = pyhf.Workspace(example_spec).model()
-    pars, unc = model_utils.get_asimov_parameters(model)
+    pars = model_utils.get_asimov_parameters(model)
     assert np.allclose(pars, [1.0, 1.0])
+
+    model = pyhf.Workspace(example_spec_shapefactor).model()
+    pars = model_utils.get_asimov_parameters(model)
+    assert np.allclose(pars, [1.0, 1.0, 1.0])
+
+
+def test_get_prefit_uncertainties(example_spec, example_spec_shapefactor):
+    model = pyhf.Workspace(example_spec).model()
+    unc = model_utils.get_prefit_uncertainties(model)
     assert np.allclose(unc, [0.0495665682, 0.0])
 
-    spec = {
-        "channels": [
-            {
-                "name": "Signal Region",
-                "samples": [
-                    {
-                        "data": [20, 10],
-                        "modifiers": [
-                            {
-                                "data": None,
-                                "name": "shape factor",
-                                "type": "shapefactor",
-                            },
-                            {
-                                "data": None,
-                                "name": "Signal strength",
-                                "type": "normfactor",
-                            },
-                        ],
-                        "name": "Signal",
-                    }
-                ],
-            }
-        ],
-        "measurements": [
-            {
-                "config": {"parameters": [], "poi": "Signal strength"},
-                "name": "shapefactor fit",
-            }
-        ],
-        "observations": [{"data": [25, 8], "name": "Signal Region"}],
-        "version": "1.0.0",
-    }
-
-    model = pyhf.Workspace(spec).model()
-    pars, unc = model_utils.get_asimov_parameters(model)
-    assert np.allclose(pars, [1.0, 1.0, 1.0])
+    model = pyhf.Workspace(example_spec_shapefactor).model()
+    unc = model_utils.get_prefit_uncertainties(model)
     assert np.allclose(unc, [0.0, 0.0, 0.0])
 
 

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -115,11 +115,15 @@ def test_data_MC_from_histograms(mock_load, mock_draw, mock_stdev, tmp_path):
 )
 @mock.patch("cabinetry.model_utils.calculate_stdev", return_value=np.asarray([[0.3]]))
 @mock.patch(
+    "cabinetry.model_utils.get_prefit_uncertainties",
+    return_value=([0.04956657, 0.0]),
+)
+@mock.patch(
     "cabinetry.model_utils.get_asimov_parameters",
-    return_value=([1.0, 1.0], [0.04956657, 0.0]),
+    return_value=([1.0, 1.0]),
 )
 def test_data_MC(
-    mock_asimov, mock_stdev, mock_dict, mock_bins, mock_draw, example_spec
+    mock_asimov, mock_unc, mock_stdev, mock_dict, mock_bins, mock_draw, example_spec
 ):
     config = {}
     figure_folder = "tmp"
@@ -128,9 +132,11 @@ def test_data_MC(
     # pre-fit plot
     visualize.data_MC(config, figure_folder, example_spec)
 
-    # Asimov parameter calculation
+    # Asimov parameter calculation and pre-fit uncertainties
     assert mock_stdev.call_count == 1
     assert mock_asimov.call_args_list[0][0][0].spec == model_spec
+    assert mock_unc.call_count == 1
+    assert mock_unc.call_args_list[0][0][0].spec == model_spec
 
     # call to stdev calculation
     assert mock_stdev.call_count == 1

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -311,31 +311,30 @@ def test_pulls(mock_draw):
 
 @mock.patch("cabinetry.contrib.matplotlib_visualize.ranking")
 def test_ranking(mock_draw):
-    bestfit = np.asarray([1.2, 0.1, 0.9])
-    uncertainty = np.asarray([0.2, 0.8, 0.5])
-    labels = ["staterror_a", "modeling", "mu"]
-    fit_results = fit.FitResults(bestfit, uncertainty, labels, np.empty(0), 0.0)
+    bestfit = np.asarray([1.2, 0.1])
+    uncertainty = np.asarray([0.2, 0.8])
+    labels = ["staterror_a", "modeling"]
     impact_prefit_up = np.asarray([0.1, 0.5])
     impact_prefit_down = np.asarray([-0.2, -0.4])
     impact_postfit_up = np.asarray([0.1, 0.4])
     impact_postfit_down = np.asarray([-0.2, -0.3])
-    poi_index = 2
-    folder_path = "tmp"
-
-    figure_path = pathlib.Path(folder_path) / "ranking.pdf"
-    bestfit_expected = np.asarray([0.1, 0.2])
-    uncertainty_expected = np.asarray([0.8, 0.2])
-    labels_expected = ["modeling", "staterror_a"]
-
-    visualize.ranking(
-        fit_results,
+    ranking_results = fit.RankingResults(
+        bestfit,
+        uncertainty,
+        labels,
         impact_prefit_up,
         impact_prefit_down,
         impact_postfit_up,
         impact_postfit_down,
-        poi_index,
-        folder_path,
     )
+    folder_path = "tmp"
+
+    figure_path = pathlib.Path(folder_path) / "ranking.pdf"
+    bestfit_expected = np.asarray([0.1, 1.2])
+    uncertainty_expected = np.asarray([0.8, 0.2])
+    labels_expected = ["modeling", "staterror_a"]
+
+    visualize.ranking(ranking_results, folder_path)
     assert mock_draw.call_count == 1
     assert np.allclose(mock_draw.call_args[0][0], bestfit_expected)
     assert np.allclose(mock_draw.call_args[0][1], uncertainty_expected)
@@ -349,16 +348,7 @@ def test_ranking(mock_draw):
     assert mock_draw.call_args[1] == {}
 
     # maximum parameter amount specified
-    visualize.ranking(
-        fit_results,
-        impact_prefit_up,
-        impact_prefit_down,
-        impact_postfit_up,
-        impact_postfit_down,
-        poi_index,
-        folder_path,
-        max_pars=1,
-    )
+    visualize.ranking(ranking_results, folder_path, max_pars=1)
     assert mock_draw.call_count == 2
     assert np.allclose(mock_draw.call_args[0][0], bestfit_expected[0])
     assert np.allclose(mock_draw.call_args[0][1], uncertainty_expected[0])
@@ -372,16 +362,7 @@ def test_ranking(mock_draw):
 
     # unknown plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
-        visualize.ranking(
-            fit_results,
-            impact_prefit_up,
-            impact_prefit_down,
-            impact_postfit_up,
-            impact_postfit_down,
-            poi_index,
-            folder_path,
-            method="unknown",
-        )
+        visualize.ranking(ranking_results, folder_path, method="unknown")
 
 
 @mock.patch(

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -314,6 +314,7 @@ def test_ranking(mock_draw):
     bestfit = np.asarray([1.2, 0.1, 0.9])
     uncertainty = np.asarray([0.2, 0.8, 0.5])
     labels = ["staterror_a", "modeling", "mu"]
+    fit_results = fit.FitResults(bestfit, uncertainty, labels, np.empty(0), 0.0)
     impact_prefit_up = np.asarray([0.1, 0.5])
     impact_prefit_down = np.asarray([-0.2, -0.4])
     impact_postfit_up = np.asarray([0.1, 0.4])
@@ -327,9 +328,7 @@ def test_ranking(mock_draw):
     labels_expected = ["modeling", "staterror_a"]
 
     visualize.ranking(
-        bestfit,
-        uncertainty,
-        labels,
+        fit_results,
         impact_prefit_up,
         impact_prefit_down,
         impact_postfit_up,
@@ -351,9 +350,7 @@ def test_ranking(mock_draw):
 
     # maximum parameter amount specified
     visualize.ranking(
-        bestfit,
-        uncertainty,
-        labels,
+        fit_results,
         impact_prefit_up,
         impact_prefit_down,
         impact_postfit_up,
@@ -376,9 +373,7 @@ def test_ranking(mock_draw):
     # unknown plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
         visualize.ranking(
-            bestfit,
-            uncertainty,
-            labels,
+            fit_results,
             impact_prefit_up,
             impact_prefit_down,
             impact_postfit_up,


### PR DESCRIPTION
Adding new `fit.ranking` to calculate the impact of a nuisance parameter on a parameter of interest. The results are saved in a new `fit.RankingResults` class, and `visualize.ranking` is refactored to take this as input. The ranking visualization (#97) also no longer centers staterror parameters around 0, and no longer removes the parameter of interest from bestfit/uncertainty/labels (done now in `fit.ranking`).

The post-fit impact calculation agrees for both observed data and Asimov with an independent implementation.

Splitting up functionality in `model_utils.get_asimov_parameters`, which now only returns the parameter values. The pre-fit parameter uncertainties are provided by `model_utils.get_prefit_uncertainties` instead.

Closes #110.