### PR TITLE
feat: support reading multiple input files per sample

### DIFF
--- a/config_example.yml
+++ b/config_example.yml
@@ -2,7 +2,7 @@ General:
   Measurement: "minimal_example"
   POI: "Signal_norm"
   HistogramFolder: "histograms/"
-  InputPath: "ntuples/{SamplePath}"
+  InputPath: "ntuples/{SamplePaths}"
 
 Regions:
   - Name: "Signal_region"
@@ -13,17 +13,17 @@ Regions:
 Samples:
   - Name: "Data"
     Tree: "pseudodata"
-    SamplePath: "data.root"
+    SamplePaths: "data.root"
     Data: True
 
   - Name: "Background"
     Tree: "background"
-    SamplePath: "prediction.root"
+    SamplePaths: "prediction.root"
     Weight: "weight"
 
   - Name: "Signal"
     Tree: "signal"
-    SamplePath: "prediction.root"
+    SamplePaths: "prediction.root"
     Weight: "weight"
 
 Systematics:
@@ -37,7 +37,7 @@ Systematics:
 
   - Name: "Modeling"
     Up:
-      SamplePath: "prediction.root"
+      SamplePaths: "prediction.root"
       Tree: "background_varied"
     Down:
       Symmetrize: True

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -1,5 +1,5 @@
-Advanced topics
-===============
+Advanced concepts
+=================
 
 Accessing vector branches
 -------------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,63 +10,63 @@ cabinetry.configuration
 -----------------------
 
 .. automodule:: cabinetry.configuration
-   :members:
+    :members:
 
 
 cabinetry.route
 ---------------
 
 .. automodule:: cabinetry.route
-   :members:
+    :members:
 
 
 cabinetry.histo
 ---------------
 
 .. automodule:: cabinetry.histo
-   :members:
+    :members:
 
 
 cabinetry.template_builder
 --------------------------
 
 .. automodule:: cabinetry.template_builder
-   :members:
+    :members:
 
 
 cabinetry.template_postprocessor
 --------------------------------
 
 .. automodule:: cabinetry.template_postprocessor
-   :members:
+    :members:
 
 
 cabinetry.workspace
 -------------------
 
 .. automodule:: cabinetry.workspace
-   :members:
+    :members:
 
 
 cabinetry.fit
 -------------
 
 .. automodule:: cabinetry.fit
-   :members:
+    :members:
 
 
 cabinetry.visualize
 -------------------
 
 .. automodule:: cabinetry.visualize
-   :members:
+    :members:
 
 
 cabinetry.model_utils
 ---------------------
 
 .. automodule:: cabinetry.model_utils
-   :members:
+    :members:
 
 
 cabinetry.contrib
@@ -75,7 +75,7 @@ cabinetry.contrib
 .. automodule:: cabinetry.contrib
 
 .. automodule:: cabinetry.contrib.histogram_creation
-   :members:
+    :members:
 
 .. automodule:: cabinetry.contrib.matplotlib_visualize
-   :members:
+    :members:

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -8,26 +8,26 @@ The resulting correlation matrix and pull plot are saved to the default output f
 
 .. code-block:: bash
 
-   cabinetry templates config_example.yml
-   cabinetry postprocess config_example.yml
-   cabinetry workspace config_example.yml workspaces/example_workspace.json
-   cabinetry fit --pulls --corrmat workspaces/example_workspace.json
+    cabinetry templates config_example.yml
+    cabinetry postprocess config_example.yml
+    cabinetry workspace config_example.yml workspaces/example_workspace.json
+    cabinetry fit --pulls --corrmat workspaces/example_workspace.json
 
 The ``--help`` flag can be used to obtain more information on the command line:
 
 .. code-block:: bash
 
-   cabinetry --help
+    cabinetry --help
 
 shows the available commands, while
 
 .. code-block:: bash
 
-   cabinetry fit --help
+    cabinetry fit --help
 
 shows what the ``fit`` command does, and which options it accepts.
 
 
 .. click:: cabinetry.cli:cabinetry
-   :prog: cabinetry
-   :nested: full
+    :prog: cabinetry
+    :nested: full

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -34,4 +34,6 @@ Common options:
 
 .. jsonschema:: ../src/cabinetry/schemas/config.json#/definitions/samples_setting
 
+.. jsonschema:: ../src/cabinetry/schemas/config.json#/definitions/samplepath_setting
+
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -34,6 +34,6 @@ Common options:
 
 .. jsonschema:: ../src/cabinetry/schemas/config.json#/definitions/samples_setting
 
-.. jsonschema:: ../src/cabinetry/schemas/config.json#/definitions/samplepath_setting
+.. jsonschema:: ../src/cabinetry/schemas/config.json#/definitions/samplepaths_setting
 
 

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -1,0 +1,85 @@
+Core concepts
+=============
+
+Input file path specification
+-----------------------------
+
+Paths to input files for histogram production are specified with the mandatory ``InputPath`` setting in the ``General`` config section.
+If everything is in one file, the value should be the path to this file.
+It is common to have multiple input files, split across phase space regions or samples.
+For this purpose, the ``InputPath`` value can take two placeholders: ``{RegionPath}`` and ``{SamplePaths}``.
+
+RegionPath
+^^^^^^^^^^
+
+When building histograms for a specific region, the ``{RegionPath}`` placeholder takes the value specified in the ``RegionPath`` setting of the corresponding region.
+The value of ``RegionPath`` has to be a string.
+
+SamplePaths
+^^^^^^^^^^^
+
+The ``{SamplePaths}`` placeholder takes the value given by ``SamplePaths`` of the sample currently processed.
+This value can either be a string or a list of strings.
+If it is a list, multiple copies of ``InputPath`` are created, and in each of them the ``{SamplePaths}`` placeholder takes the value of a different entry in the list.
+All input files are processed, and their contributions are summed together.
+The histogram created by ``SamplePaths: ["a.root", "b.root"]`` is equivalent to the histogram created with ``SamplePaths: "a_plus_b.root"``, where ``a_plus_b.root`` is produced by merging both files.
+
+Systematics
+^^^^^^^^^^^
+
+It is possible to specify overrides for the ``RegionPath`` and ``SamplePaths`` values in systematic templates.
+If those settings are specified in the ``Up`` or ``Down`` template section of a systematic uncertainty, then the corresponding values are used when building the path to the file used to construct the histogram for this specific template.
+
+An example
+^^^^^^^^^^
+
+The following configuration file excerpt shows an example of specifying paths to input files.
+
+.. code-block:: yaml
+
+    General:
+      InputPath: "ntuples/{RegionPath}/{SamplePaths}"
+
+    Regions:
+      - Name: "Signal_region"
+        RegionPath: "signal_region"
+
+      - Name: "Control_region"
+        RegionPath: "control_region"
+
+    Samples:
+      - Name: "Data"
+        SamplePaths: "data.root"
+
+      - Name: "Signal"
+        SamplePaths: ["signal_1.root", "signal_2.root"]
+
+    Systematics:
+      - Name: "Signal_modeling"
+        Up:
+          SamplePaths: "signal_variation_up.root"
+        Down:
+          SamplePaths: "signal_variation_down.root"
+        Samples: "Signal"
+
+The following files will be read to create histograms:
+
+- for *Signal_region*:
+
+    - *Data*: ``ntuples/signal_region/data.root``
+    - *Signal*: ``ntuples/signal_region/signal_1.root``, ``ntuples/signal_region/signal_2.root``
+
+        - systematic uncertainty:
+
+            - *up*: ``ntuples/signal_region/signal_variation_up.root``
+            - *down*: ``ntuples/signal_region/signal_variation_down.root``
+
+- for *Control_region*:
+
+    - *Data*: ``ntuples/control_region/data.root``
+    - *Signal*: ``ntuples/control_region/signal_1.root``, ``ntuples/control_region/signal_2.root``
+
+        - systematic uncertainty:
+
+            - *up*: ``ntuples/control_region/signal_variation_up.root``
+            - *down*: ``ntuples/control_region/signal_variation_down.root``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,14 +2,15 @@ cabinetry
 ==============================
 
 .. toctree::
-   :hidden:
-   :maxdepth: 1
+    :hidden:
+    :maxdepth: 1
 
-   config
-   cli
-   advanced
-   api
-   license
+    core
+    advanced
+    config
+    cli
+    api
+    license
 
 ``cabinetry`` is a tool to build and steer (profile likelihood) template fits with applications in high energy physics in mind.
 It acts as an interface to many powerful tools to make it easier for an analyzer to run their statistical inference pipeline.
@@ -18,8 +19,8 @@ This documentation can be viewed `on Read the Docs <https://cabinetry.readthedoc
 
 .. code-block:: bash
 
-   sphinx-build docs docs/_build
-   open docs/_build/index.html
+    sphinx-build docs docs/_build
+    open docs/_build/index.html
 
 It contains a description of the ``cabinetry`` configuration file schema, as well as the public facing API.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ filterwarnings =
     ignore:no type annotations present:UserWarning:typeguard:
 
 [flake8]
-max-complexity = 10
+max-complexity = 12
 max-line-length = 127
 exclude = docs/conf.py
 count = True

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-extras_require = {"contrib": ["matplotlib", "uproot", "uproot4"]}
+extras_require = {"contrib": ["matplotlib", "uproot", "uproot4>=0.0.19"]}
 extras_require["test"] = sorted(
     set(
         extras_require["contrib"]

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -76,22 +76,24 @@ def print_overview(config: Dict[str, Any]) -> None:
         log.info(f"  {len(config['Systematics'])} Systematic(s)")
 
 
-def _convert_samples_to_list(samples: Union[str, List[str]]) -> List[str]:
-    """the config can allow for two ways of specifying samples, a single sample:
-    "Samples": "ABC"
-    or a list of samples:
-    "Samples": ["ABC", "DEF"]
-    for consistent treatment, convert the single sample into a single-element list
+def _convert_setting_to_list(setting: Union[str, List[str]]) -> List[str]:
+    """Converts a configuration setting to a list.
+
+    The config allows for two ways of specifying some settings, for example
+    samples. A single sample is specified as ``"Samples": "ABC"``, a list
+    of samples as ``"Samples": ["ABC", "DEF"]``. For consistent treatment,
+    the single sample is converted to a list.
 
     Args:
-        samples (Union[str, List[str]]): name of single sample or list of sample names
+        setting (Union[str, List[str]]): name of single setting value or
+            list of values
 
     Returns:
         list: name(s) of sample(s)
     """
-    if not isinstance(samples, list):
-        samples = [samples]
-    return samples
+    if not isinstance(setting, list):
+        setting = [setting]
+    return setting
 
 
 def sample_affected_by_modifier(
@@ -106,7 +108,7 @@ def sample_affected_by_modifier(
     Returns:
         bool: True if sample is affected, False otherwise
     """
-    affected_samples = _convert_samples_to_list(modifier["Samples"])
+    affected_samples = _convert_setting_to_list(modifier["Samples"])
     affected = sample["Name"] in affected_samples
     return affected
 

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -151,8 +151,7 @@
                     "type": "string"
                 },
                 "SamplePath": {
-                    "description": "(part of) path to file containing sample",
-                    "type": "string"
+                    "$ref": "#/definitions/samplepath_setting"
                 },
                 "Data": {
                     "description": "if it is a data sample",
@@ -253,6 +252,7 @@
         "samples_setting": {
             "title": "Sample setting",
             "$$target": "#/definitions/samples_setting",
+            "description": "name(s) of affected sample(s)",
             "oneOf": [
                 {
                     "description": "single affected sample",
@@ -264,6 +264,27 @@
                     "minItems": 1,
                     "items": {
                         "description": "single affected sample",
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "samplepath_setting": {
+            "title": "SamplePath setting",
+            "$$target": "#/definitions/samplepath_setting",
+            "description": "path(s) to input file(s) for ntuple production",
+            "oneOf": [
+                {
+                    "description": "path to single file",
+                    "type": "string"
+                },
+                {
+                    "description": "list of paths",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "description": "path to single file",
                         "type": "string"
                     },
                     "uniqueItems": true

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -7,6 +7,7 @@
     "required": ["General", "Regions", "Samples", "NormFactors"],
     "properties": {
         "General": {
+            "description": "general settings",
             "$ref": "#/definitions/general"
         },
         "Regions": {
@@ -14,6 +15,7 @@
             "type": "array",
             "minItems": 1,
             "items": {
+                "description": "a region",
                 "$ref": "#/definitions/region"
             },
             "uniqueItems": true
@@ -23,6 +25,7 @@
             "type": "array",
             "minItems": 1,
             "items": {
+                "description": "a sample",
                 "$ref": "#/definitions/sample"
             },
             "uniqueItems": true
@@ -32,6 +35,7 @@
             "type": "array",
             "minItems": 1,
             "items": {
+                "description": "a normalization factor",
                 "$ref": "#/definitions/normfactor"
             },
             "uniqueItems": true
@@ -41,6 +45,7 @@
             "type": "array",
             "minItems": 0,
             "items": {
+                "description": "a systematic uncertainty",
                 "$ref": "#/definitions/systematic"
             },
             "uniqueItems": true
@@ -150,8 +155,9 @@
                     "description": "weight to apply to events",
                     "type": "string"
                 },
-                "SamplePath": {
-                    "$ref": "#/definitions/samplepath_setting"
+                "SamplePaths": {
+                    "description": "(part of) path(s) to input file(s)",
+                    "$ref": "#/definitions/samplepaths_setting"
                 },
                 "Data": {
                     "description": "if it is a data sample",
@@ -172,6 +178,7 @@
                     "type": "string"
                 },
                 "Samples": {
+                    "description": "affected sample(s)",
                     "$ref": "#/definitions/samples_setting"
                 },
                 "Nominal": {
@@ -204,6 +211,7 @@
                     "type": "string"
                 },
                 "Samples": {
+                    "description": "affected sample(s)",
                     "$ref": "#/definitions/samples_setting"
                 },
                 "Type": {
@@ -212,9 +220,11 @@
                     "enum": ["Normalization", "NormPlusShape"]
                 },
                 "Up": {
+                    "description": "template for \"up\" variation",
                     "$ref": "#/definitions/template"
                 },
                 "Down": {
+                    "description": "template for \"down\" variation",
                     "$ref": "#/definitions/template"
                 }
             },
@@ -226,9 +236,9 @@
             "description": "a systematics template (up/down)",
             "type": "object",
             "properties": {
-                "SamplePath": {
-                    "description": "(part of) path to file containing template, override for sample path",
-                    "type": "string"
+                "SamplePaths": {
+                    "description": "override for nominal setting",
+                    "$ref": "#/definitions/samplepaths_setting"
                 },
                 "Tree": {
                     "description": "name of tree",
@@ -270,9 +280,9 @@
                 }
             ]
         },
-        "samplepath_setting": {
-            "title": "SamplePath setting",
-            "$$target": "#/definitions/samplepath_setting",
+        "samplepaths_setting": {
+            "title": "SamplePaths setting",
+            "$$target": "#/definitions/samplepaths_setting",
             "description": "path(s) to input file(s) for ntuple production",
             "oneOf": [
                 {

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 import pathlib
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import boost_histogram as bh
 import numpy as np
@@ -16,10 +16,12 @@ log = logging.getLogger(__name__)
 
 def _check_for_override(
     systematic: Dict[str, Any], template: str, option: str
-) -> Optional[str]:
-    """Given a systematic and a string specifying which template is currently under consideration,
-    check whether the systematic defines an override for an option. Return the override if it
-    exists, otherwise return None.
+) -> Optional[Union[str, List[str]]]:
+    """Returns an override if specified by a template of a systematic.
+
+    Given a systematic and a string specifying which template is currently
+    under consideration, check whether the systematic defines an override
+    for an option. Return the override if it exists, otherwise return None.
 
     Args:
         systematic (Dict[str, Any]): containing all systematic information
@@ -27,7 +29,8 @@ def _check_for_override(
         option (str): the option for which the presence of an override is checked
 
     Returns:
-        Optional[str]: either None if no override exists, or the override
+        Optional[Union[str, List[str]]]: either None if no override exists,
+        or the override
     """
     return systematic.get(template, {}).get(option, None)
 

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -68,7 +68,12 @@ def _get_ntuple_paths(
 
     # check whether a systematic is being processed, and whether overrides exist
     if systematic.get("Name", "Nominal") != "Nominal":
-        # determine whether the template has an override specified
+        # determine whether the template has an override for RegionPath specified
+        region_override = _check_for_override(systematic, template, "RegionPath")
+        if region_override is not None:
+            region_path = region_override
+
+        # check for SamplePaths override
         sample_override = _check_for_override(systematic, template, "SamplePaths")
         if sample_override is not None:
             sample_paths = sample_override

--- a/tests/contrib/test_histogram_creation.py
+++ b/tests/contrib/test_histogram_creation.py
@@ -4,7 +4,7 @@ from cabinetry.contrib import histogram_creation
 
 
 def test_from_uproot(tmp_path, utils):
-    fname = tmp_path / "test.root"
+    fnames = [tmp_path / "test.root"]
     treename = "tree"
     varname = "var"
     var_array = [1.1, 2.3, 3.0, 3.2]
@@ -13,18 +13,18 @@ def test_from_uproot(tmp_path, utils):
     bins = np.asarray([1, 2, 3, 4])
     # create something to read
     utils.create_ntuple(
-        fname, treename, varname, var_array, weightname_write, weight_array
+        fnames[0], treename, varname, var_array, weightname_write, weight_array
     )
 
     # read - no weights or selection
-    yields, stdev = histogram_creation.from_uproot(fname, treename, varname, bins)
+    yields, stdev = histogram_creation.from_uproot(fnames, treename, varname, bins)
     assert np.allclose(yields, [1, 1, 2])
     assert np.allclose(stdev, [1, 1, 1.41421356])
 
     # read - with selection cut
     selection = "var < 3.1"
     yields, stdev = histogram_creation.from_uproot(
-        fname, treename, varname, bins, selection_filter=selection
+        fnames, treename, varname, bins, selection_filter=selection
     )
     assert np.allclose(yields, [1, 1, 1])
     assert np.allclose(stdev, [1, 1, 1])
@@ -32,7 +32,7 @@ def test_from_uproot(tmp_path, utils):
     # read - with weight
     weightname_apply = "weight*2"
     yields, stdev = histogram_creation.from_uproot(
-        fname, treename, varname, bins, weight=weightname_apply
+        fnames, treename, varname, bins, weight=weightname_apply
     )
     assert np.allclose(yields, [2, 2, 6])
     assert np.allclose(stdev, [2, 2, 4.47213595])
@@ -40,10 +40,28 @@ def test_from_uproot(tmp_path, utils):
     # read - with weight that is only a float
     weight_float = "2.0"
     yields, stdev = histogram_creation.from_uproot(
-        fname, treename, varname, bins, weight=weight_float
+        fnames, treename, varname, bins, weight=weight_float
     )
     assert np.allclose(yields, [2, 2, 4])
     assert np.allclose(stdev, [2, 2, 2.82842712])
+
+    # create an additional file to test wildcards / input lists
+    extra_path = tmp_path / "test_2.root"
+    utils.create_ntuple(
+        extra_path, treename, varname, var_array, weightname_write, weight_array
+    )
+
+    # read - with wildcard, matching two files
+    fnames = [tmp_path / "test*.root"]
+    yields, stdev = histogram_creation.from_uproot(fnames, treename, varname, bins)
+    assert np.allclose(yields, [2, 2, 4])
+    assert np.allclose(stdev, [1.41421356, 1.41421356, 2])
+
+    # read - with two list entries
+    fnames = [tmp_path / "test.root", tmp_path / "test_2.root"]
+    yields, stdev = histogram_creation.from_uproot(fnames, treename, varname, bins)
+    assert np.allclose(yields, [2, 2, 4])
+    assert np.allclose(stdev, [1.41421356, 1.41421356, 2])
 
 
 def test__bin_data():

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -91,8 +91,8 @@ def test_print_overview(caplog):
 @pytest.mark.parametrize(
     "samples, converted", [("sample", ["sample"]), (["sample"], ["sample"])]
 )
-def test__convert_samples_to_list(samples, converted):
-    assert configuration._convert_samples_to_list(samples) == converted
+def test__convert_setting_to_list(samples, converted):
+    assert configuration._convert_setting_to_list(samples) == converted
 
 
 @pytest.mark.parametrize(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,7 +21,7 @@ def test_integration(tmp_path, ntuple_creator):
 
     # override config options to point to tmp_path
     cabinetry_config["General"]["HistogramFolder"] = str(tmp_path / "histograms")
-    cabinetry_config["General"]["InputPath"] = str(tmp_path / "{SamplePath}")
+    cabinetry_config["General"]["InputPath"] = str(tmp_path / "{SamplePaths}")
 
     cabinetry.template_builder.create_histograms(cabinetry_config, method="uproot")
     cabinetry.template_postprocessor.run(cabinetry_config)

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -69,19 +69,22 @@ def test__get_ntuple_paths(caplog):
         == [pathlib.Path("region/sample.root"), pathlib.Path("region/new.root")]
     )
 
-    # systematic with override
+    # systematic with override for RegionPath and SamplePaths
     assert (
         template_builder._get_ntuple_paths(
-            "{SamplePaths}",
-            {},
+            "{RegionPath}/{SamplePaths}",
+            {"RegionPath": "reg_1"},
             {"SamplePaths": "path.root"},
             {
                 "Name": "variation",
-                "Up": {"SamplePaths": ["variation.root", "new.root"]},
+                "Up": {
+                    "SamplePaths": ["variation.root", "new.root"],
+                    "RegionPath": "reg_2",
+                },
             },
             "Up",
         )
-        == [pathlib.Path("variation.root"), pathlib.Path("new.root")]
+        == [pathlib.Path("reg_2/variation.root"), pathlib.Path("reg_2/new.root")]
     )
 
     # systematic without override


### PR DESCRIPTION
Updates the `uproot` backend for ntuple reading to support building histograms from multiple input samples. It is now possible to use wildcards in the input paths, and lists for `SamplePaths`. A new section in [the docs](http://cabinetry.readthedocs.io/) explains the functionality.

**Breaking change:** The `SamplePath` option is renamed to `SamplePaths`. It takes either a single path, or a list of paths. If a list is specified, the sample histogram is built by combining the contributions from all files in the list. The entries of the list may have wildcards (with `*`).

Fixing systematic template overrides for `RegionPath`, which did not work before.

Raising minimum `uproot4` version to 0.0.19, which fixes a bug with lists in `uproot4.iterate`.
