### PR TITLE
refactor: configuration loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To run the following example, first generate the input files via the script `uti
 ```python
 import cabinetry
 
-cabinetry_config = cabinetry.configuration.read("config_example.yml")
+cabinetry_config = cabinetry.configuration.load("config_example.yml")
 
 # create template histograms
 cabinetry.template_builder.create_histograms(cabinetry_config)

--- a/example.py
+++ b/example.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
         raise SystemExit
 
     # import example config file
-    cabinetry_config = cabinetry.configuration.read("config_example.yml")
+    cabinetry_config = cabinetry.configuration.load("config_example.yml")
     cabinetry.configuration.print_overview(cabinetry_config)
 
     # create template histograms

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -12,14 +12,14 @@ from .. import workspace as cabinetry_workspace
 
 
 class OrderedGroup(click.Group):
-    """a group that shows commands in the order they were added"""
+    """A group that shows commands in the order they were added."""
 
     def list_commands(self, _: Any) -> KeysView[str]:
         return self.commands.keys()
 
 
 def _set_logging() -> None:
-    """set log levels and format for CLI"""
+    """Sets log levels and format for CLI."""
     logging.basicConfig(
         level=logging.INFO, format="%(levelname)s - %(name)s - %(message)s"
     )
@@ -35,7 +35,7 @@ def cabinetry() -> None:
 @click.argument("config_path", type=click.Path(exists=True))
 @click.option("--method", default="uproot", help="backend for histogram production")
 def templates(config_path: str, method: str) -> None:
-    """Produce template histograms.
+    """Produces template histograms.
 
     CONFIG_PATH: path to cabinetry configuration file
     """
@@ -47,7 +47,7 @@ def templates(config_path: str, method: str) -> None:
 @click.command()
 @click.argument("config_path", type=click.Path(exists=True))
 def postprocess(config_path: str) -> None:
-    """Post-process template histograms.
+    """Post-processes template histograms.
 
     CONFIG_PATH: path to cabinetry configuration file
     """
@@ -60,7 +60,7 @@ def postprocess(config_path: str) -> None:
 @click.argument("config_path", type=click.Path(exists=True))
 @click.argument("ws_path", type=click.Path(exists=False))
 def workspace(config_path: str, ws_path: str) -> None:
-    """Produce a ``pyhf`` workspace.
+    """Produces a ``pyhf`` workspace.
 
     CONFIG_PATH: path to cabinetry configuration file
 
@@ -78,7 +78,7 @@ def workspace(config_path: str, ws_path: str) -> None:
 @click.option("--corrmat", is_flag=True, help="produce correlation matrix")
 @click.option("--figfolder", default="figures/", help="folder to save figures to")
 def fit(ws_path: str, pulls: bool, corrmat: bool, figfolder: str) -> None:
-    """Fit a workspace and optionally visualize the results.
+    """Fits a workspace and optionally visualize the results.
 
     WS_PATH: path to workspace used in fit
     """

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -40,7 +40,7 @@ def templates(config_path: str, method: str) -> None:
     CONFIG_PATH: path to cabinetry configuration file
     """
     _set_logging()
-    cabinetry_config = cabinetry_configuration.read(config_path)
+    cabinetry_config = cabinetry_configuration.load(config_path)
     cabinetry_template_builder.create_histograms(cabinetry_config, method=method)
 
 
@@ -52,7 +52,7 @@ def postprocess(config_path: str) -> None:
     CONFIG_PATH: path to cabinetry configuration file
     """
     _set_logging()
-    cabinetry_config = cabinetry_configuration.read(config_path)
+    cabinetry_config = cabinetry_configuration.load(config_path)
     cabinetry_template_postprocessor.run(cabinetry_config)
 
 
@@ -67,7 +67,7 @@ def workspace(config_path: str, ws_path: str) -> None:
     WS_PATH: where to save the workspace containing the fit model
     """
     _set_logging()
-    cabinetry_config = cabinetry_configuration.read(config_path)
+    cabinetry_config = cabinetry_configuration.load(config_path)
     ws = cabinetry_workspace.build(cabinetry_config)
     cabinetry_workspace.save(ws, ws_path)
 

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -106,7 +106,7 @@ def sample_affected_by_modifier(
     Args:
         sample (Dict[str, Any]): containing all sample information
         modifier (Dict[str, Any]): containing all modifier information
-            (a Systematic of a NormFactor)
+            (a Systematic or a NormFactor)
 
     Returns:
         bool: True if sample is affected, False otherwise

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -11,8 +11,8 @@ import yaml
 log = logging.getLogger(__name__)
 
 
-def read(file_path_string: Union[str, pathlib.Path]) -> Dict[str, Any]:
-    """read a config file from a provided path and return it
+def load(file_path_string: Union[str, pathlib.Path]) -> Dict[str, Any]:
+    """Loads, validates, and returns a config file from the provided path.
 
     Args:
         file_path_string (Union[str, pathlib.Path]): path to config file

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -28,8 +28,10 @@ def load(file_path_string: Union[str, pathlib.Path]) -> Dict[str, Any]:
 
 
 def validate(config: Dict[str, Any]) -> bool:
-    """check whether the config satisfies the json schema, and perform additional
-    checks to validate it
+    """Returns True if the config file is validated, otherwise raises exceptions.
+
+    Checks that the config satisfies the json schema, and performs additional
+    checks to validate the config further.
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
@@ -63,7 +65,7 @@ def validate(config: Dict[str, Any]) -> bool:
 
 
 def print_overview(config: Dict[str, Any]) -> None:
-    """output a compact summary of a config file
+    """Prints a compact summary of a config file.
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
@@ -99,11 +101,12 @@ def _convert_setting_to_list(setting: Union[str, List[str]]) -> List[str]:
 def sample_affected_by_modifier(
     sample: Dict[str, Any], modifier: Dict[str, Any]
 ) -> bool:
-    """check if a sample is affected by a given modifier (Systematic, NormFactor)
+    """Checks if a sample is affected by a given modifier (Systematic, NormFactor).
 
     Args:
         sample (Dict[str, Any]): containing all sample information
-        modifier (Dict[str, Any]): containing all modifier information (a Systematic of a NormFactor)
+        modifier (Dict[str, Any]): containing all modifier information
+            (a Systematic of a NormFactor)
 
     Returns:
         bool: True if sample is affected, False otherwise
@@ -119,8 +122,10 @@ def histogram_is_needed(
     systematic: Dict[str, Any],
     template: str,
 ) -> bool:
-    """determine whether for a given sample-region-systematic pairing, there is
-    an associated histogram
+    """Determines whether a histogram is needed for a specific configuration.
+
+    The configuration is defined by the region, sample, systematic and template
+    ("Nominal", "Up" or "Down").
 
     Args:
         region (Dict[str, Any]): containing all region information
@@ -129,7 +134,8 @@ def histogram_is_needed(
         template (str): which template is considered: "Nominal", "Up", "Down"
 
     Raises:
-        NotImplementedError: non-supported systematic variations based on histograms are requested
+        NotImplementedError: non-supported systematic variations based on histograms
+            are requested
 
     Returns:
         bool: whether a histogram is needed

--- a/src/cabinetry/contrib/__init__.py
+++ b/src/cabinetry/contrib/__init__.py
@@ -1,5 +1,1 @@
-"""
-this contains basic implementations of functionality that will eventually be
-provided via external tools, these basic implementations mostly exist to help
-with API design
-"""
+"""Basic implementations of functionality that can be provided by external tools."""

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -14,9 +14,7 @@ H = TypeVar("H", bound="Histogram")
 
 
 class Histogram(bh.Histogram):
-    """class to hold histogram information, extends functionality provided
-    by boost_histogram.Histogram
-    """
+    """Holds histogram information, extends boost_histogram.Histogram."""
 
     @classmethod
     def from_arrays(
@@ -25,8 +23,9 @@ class Histogram(bh.Histogram):
         yields: Union[List[float], np.ndarray],
         stdev: Union[List[float], np.ndarray],
     ) -> H:
-        """construct a histogram from arrays of yields and uncertainties, the input
-        can be lists of ints or floats, or numpy.ndarrays
+        """Constructs a histogram from arrays of yields and uncertainties.
+
+        The input can be lists of ints or floats, or numpy.ndarrays.
 
         Args:
             bins (Union[List[float], np.ndarray]): edges of histogram bins
@@ -56,13 +55,15 @@ class Histogram(bh.Histogram):
 
     @classmethod
     def from_path(cls: Type[H], histo_path: pathlib.Path, modified: bool = True) -> H:
-        """build a histogram from disk
-        try to load the "modified" version of the histogram by default
-        (which received post-processing)
+        """Builds a histogram from disk.
+
+        Loads the "modified" version of the histogram by default (which received
+        post-processing).
 
         Args:
             histo_path (pathlib.Path): where the histogram is located
-            modified (bool, optional): whether to load the modified histogram (after post-processing), defaults to True
+            modified (bool, optional): whether to load the modified histogram
+                (after post-processing), defaults to True
 
         Returns:
             cabinetry.histo.Histogram: the loaded histogram
@@ -92,16 +93,21 @@ class Histogram(bh.Histogram):
         modified: bool = True,
         template: str = "Nominal",
     ) -> H:
-        """load a histogram, given a folder the histogram is located in and the
-        relevant information from the config: region, sample, systematic
+        """Loads a histogram, using information specified in the configuration file.
+
+        To find the histogram, need to provide the folder the histogram is located in
+        and the relevant information from the config: region, sample, systematic,
+        template.
 
         Args:
             histo_folder (Union[str, patlib.Path]): folder containing all histograms
             region (Dict[str, Any]): containing all region information
             sample (Dict[str, Any]): containing all sample information
             systematic (Dict[str, Any]): containing all systematic information
-            modified (bool, optional): whether to load the modified histogram (after post-processing), defaults to True
-            template (str): which template (nominal/up/down) to consider, defaults to "Nominal"
+            modified (bool, optional): whether to load the modified histogram (after
+                post-processing), defaults to True
+            template (str): which template (nominal/up/down) to consider, defaults to
+                "Nominal"
 
         Returns:
             cabinetry.histo.Histogram: the loaded histogram
@@ -113,7 +119,7 @@ class Histogram(bh.Histogram):
 
     @property
     def yields(self) -> np.ndarray:
-        """get the yields per histogram bin
+        """Returns the yields per histogram bin.
 
         Returns:
             numpy.ndarray: yields per bin
@@ -122,7 +128,7 @@ class Histogram(bh.Histogram):
 
     @property
     def stdev(self) -> np.ndarray:
-        """get the stat. uncertainty per histogram bin
+        """Returns the stat. uncertainty per histogram bin.
 
         Returns:
             numpy.ndarray: stat. uncertainty per bin
@@ -131,7 +137,7 @@ class Histogram(bh.Histogram):
 
     @stdev.setter
     def stdev(self, value: np.ndarray) -> None:
-        """update the variance (by specifying the standard deviation)
+        """Updates the variance (by specifying the standard deviation).
 
         Args:
             value (numpy.ndarray): the standard deviation
@@ -140,7 +146,7 @@ class Histogram(bh.Histogram):
 
     @property
     def bins(self) -> np.ndarray:
-        """get the bin edges
+        """Returns the bin edges.
 
         Returns:
             numpy.ndarray: bin edges
@@ -148,7 +154,7 @@ class Histogram(bh.Histogram):
         return self.axes[0].edges
 
     def save(self, histo_path: pathlib.Path) -> None:
-        """save a histogram to disk
+        """Saves a histogram to disk.
 
         Args:
             histo_path (pathlib.Path): where to save the histogram
@@ -166,8 +172,10 @@ class Histogram(bh.Histogram):
         )
 
     def validate(self, name: str) -> None:
-        """run consistency checks on a histogram, checking for empty bins
-        and ill-defined statistical uncertainties
+        """Runs consistency checks on a histogram.
+
+        Checks for empty bins and ill-defined statistical uncertainties.
+        Logs warnings if issues are founds, but does not raise exceptions.
 
         Args:
             name (str): name of the histogram for logging purposes
@@ -193,11 +201,13 @@ class Histogram(bh.Histogram):
             )
 
     def normalize_to_yield(self, reference_histogram: H) -> np.float64:
-        """normalize a histogram to match the yield of a reference, and return the
-        normalization factor
+        """Normalizes a histogram to match the yield of a reference.
+
+        Returns the normalization factor used to normalize the histogram.
 
         Args:
-            reference_histogram (cabinetry.histo.Histogram): reference histogram to normalize to
+            reference_histogram (cabinetry.histo.Histogram): reference histogram
+                to normalize to
 
         Returns:
             np.float64: the yield ratio: un-normalized yield / normalized yield
@@ -216,13 +226,14 @@ def build_name(
     systematic: Dict[str, Any],
     template: str = "Nominal",
 ) -> str:
-    """construct a unique name for each histogram
+    """Returns a unique name for each histogram.
 
     Args:
         region (Dict[str, Any]): containing all region information
         sample (Dict[str, Any]): containing all sample information
         systematic (Dict[str, Any]): containing all systematic information
-        template (str): which template (nominal/up/down) to consider, defaults to "Nominal"
+        template (str): which template (nominal/up/down) to consider,
+            defaults to "Nominal"
 
     Returns:
         str: unique name for the histogram

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -41,8 +41,9 @@ def model_and_data(
 
 
 def get_parameter_names(model: pyhf.pdf.Model) -> List[str]:
-    """Returns the labels of all fit parameters, expanding vectors that act on
-    one bin per vector entry (gammas).
+    """Returns the labels of all fit parameters.
+
+    Vectors that act on one bin per vector entry (gammas) are expanded.
 
     Args:
         model (pyhf.pdf.Model): a HistFactory-style model in ``pyhf`` format

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -30,8 +30,9 @@ MatchFunc = Callable[[str, str, str, str], Optional[ProcessorFunc]]
 
 
 class Router:
-    """Holds user-defined processing functions, and provides functions for matching
-    a pattern to apply the right function to each template.
+    """Holds user-defined processing functions and matches functions to templates.
+
+    Provides functions for matching a pattern to apply the right function to each template.
 
     Attributes:
         template_builders (List[Dict[str, Any]]): user-defined processors for template building
@@ -60,7 +61,7 @@ class Router:
         systematic_name: Optional[str],
         template: Optional[str],
     ) -> Callable[[GenericProcessorFunc], GenericProcessorFunc]:
-        """decorator for registering a custom processor function
+        """Decorator for registering a custom processor function.
 
         Args:
             region_name  (Optional[str]): name of the region to apply the function to,
@@ -73,7 +74,8 @@ class Router:
                 or None to apply to all templates
 
         Returns:
-            Callable[[GenericProcessorFunc], GenericProcessorFunc]: the function to register a processor
+            Callable[[GenericProcessorFunc], GenericProcessorFunc]: the function to register
+            a processor
         """
         if region_name is None:
             region_name = "*"
@@ -85,8 +87,9 @@ class Router:
             template = "*"
 
         def _register(func: GenericProcessorFunc) -> GenericProcessorFunc:
-            """register a processor function to be applied when matching the patterns of a
-            given region-sample-systematic-template
+            """Registers a processor function to be applied when matching a pattern.
+
+            The pattern is specified by region-sample-systematic-template.
 
             Args:
                 func (GenericProcessorFunc): the function to register
@@ -112,7 +115,7 @@ class Router:
         systematic_name: Optional[str] = None,
         template: Optional[str] = None,
     ) -> Callable[[Callable], UserTemplateFunc]:
-        """decorator for registering a template builder function
+        """Decorator for registering a template builder function.
 
         Args:
             region_name (Optional[str], optional): name of the region to apply the function to,
@@ -139,7 +142,7 @@ class Router:
         systematic_name: str,
         template: str,
     ) -> Optional[GenericProcessorFunc]:
-        """return a function matching the provided specification
+        """Returns a function matching the provided specification.
 
         Args:
             processor_list (List[Dict[str, Any]]): list of processors to search in
@@ -180,9 +183,10 @@ class Router:
     def _find_template_builder_match(
         self, region_name: str, sample_name: str, systematic_name: str, template: str
     ) -> Optional[ProcessorFunc]:
-        """Return a template builder function matching the provided specification, or
-        None if no matches are found. Wrap the user-defined function in the provided wrapper,
-        if no wrapper is found raise an error.
+        """Returns a template builder function matching the provided specification.
+
+        If no matches are found, returns None. Wraps the user-defined function in the
+        provided wrapper, if no wrapper is found raises an error.
 
         Args:
             region_name (str): region name
@@ -217,8 +221,10 @@ def apply_to_all_templates(
     default_func: ProcessorFunc,
     match_func: Optional[MatchFunc] = None,
 ) -> None:
-    """Apply the supplied function ``default_func`` to all templates specified by the
-    configuration file. This function takes four arguments in this order:
+    """Applies the supplied function ``default_func`` to all templates.
+
+    The templates are specified by the configuration file. The function takes four
+    arguments in this order:
 
     - the dict specifying region information
     - the dict specifying sample information

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -112,7 +112,7 @@ def _get_ntuple_paths(
 
 
 def _get_variable(region: Dict[str, Any]) -> str:
-    """construct the variable the histogram will be binned in
+    """Returns the variable the histogram will be binned in.
 
     Args:
         region (Dict[str, Any]): containing all region information
@@ -130,9 +130,10 @@ def _get_filter(
     systematic: Dict[str, Any],
     template: str,
 ) -> Optional[str]:
-    """construct the filter to be applied for event selection
-    for non-nominal templates, override the nominal filter if an alternative is
-    specified for the template
+    """Returns the filter to be applied for event selection.
+
+    For non-nominal templates, overrides the nominal filter if an alternative is
+    specified for the template.
 
     Args:
         region (Dict[str, Any]): containing all region information
@@ -159,9 +160,10 @@ def _get_weight(
     systematic: Dict[str, Any],
     template: str,
 ) -> Optional[str]:
-    """find the weight to be used for the events in the histogram
-    for non-nominal templates, override the nominal weight if an alternative is
-    specified for the template
+    """Returns the weight to be used for events in histograms.
+
+    For non-nominal templates, overrides the nominal weight if an alternative is
+    specified for the template.
 
     Args:
         region (Dict[str, Any]): containing all region information
@@ -170,7 +172,8 @@ def _get_weight(
         template (str): which template is considered: "Nominal", "Up", "Down"
 
     Returns:
-        Optional[str]: weight used for events when filled into histograms, or None for no weight
+        Optional[str]: weight used for events when filled into histograms, or
+        None for no weight
     """
     weight = sample.get("Weight", None)
     # check whether a systematic is being processed
@@ -185,10 +188,10 @@ def _get_weight(
 def _get_position_in_file(
     sample: Dict[str, Any], systematic: Dict[str, Any], template: str
 ) -> str:
-    """the file might have some substructure, this specifies where in the file
-    the data is
-    for non-nominal templates, override the nominal position if an alternative is
-    specified for the template
+    """Returns the location of data within a file (e.g. a tree name).
+
+    For non-nominal templates, overrides the nominal position if an alternative is
+    specified for the template.
 
     Args:
         sample (Dict[str, Any]): containing all sample information
@@ -196,7 +199,7 @@ def _get_position_in_file(
         template (str): which template is considered: "Nominal", "Up", "Down"
 
     Returns:
-        str: where in the file to find the data (right now the name of a tree)
+        str: where in the file to find the data (the name of a tree)
     """
     position = sample["Tree"]
     # check whether a systematic is being processed
@@ -209,9 +212,10 @@ def _get_position_in_file(
 
 
 def _get_binning(region: Dict[str, Any]) -> np.ndarray:
-    """determine the binning to be used in a given region
-    should eventually also support other ways of specifying bins,
-    such as the amount of bins and the range to bin in
+    """Returns the binning to be used in a region.
+
+    Should eventually also support other ways of specifying bins,
+    such as the amount of bins and the range to bin in.
 
     Args:
         region (Dict[str, Any]): containing all region information
@@ -252,8 +256,10 @@ class _Builder:
         systematic: Dict[str, Any],
         template: str,
     ) -> None:
-        """function to create a histogram and write it to a file for the template
-        specified via the region-sample-systematic-template information
+        """Creates a histogram and writes it to a file.
+
+        The histogram is created for the region-sample-systematic-template
+        specified in the argument.
 
         Args:
             region (Dict[str, Any]): specifying region information
@@ -301,7 +307,7 @@ class _Builder:
         systematic: Dict[str, Any],
         template: str,
     ) -> None:
-        """generate a unique name for the histogram and save it
+        """Generates a unique name for a histogram and saves the histogram.
 
         Args:
             histogram (histo.Histogram): histogram to save
@@ -323,9 +329,9 @@ class _Builder:
     def _wrap_custom_template_builder(
         self, func: route.UserTemplateFunc
     ) -> route.ProcessorFunc:
-        """Wrapper for custom template builder functions that return a ``boost_histogram.Histogram``.
-        Returns a function that executes the custom template builder and saves the resulting
-        histogram.
+        """Returns a function that executes a custom template builder and saves the histogram.
+
+        Wrapper for custom template builder functions that return a ``boost_histogram.Histogram``.
 
         Args:
             func (cabinetry.route.UserTemplateFunc): user-defined template builder
@@ -343,9 +349,10 @@ class _Builder:
             systematic: Dict[str, Any],
             template: str,
         ) -> None:
-            """Takes a user-defined function that returns a histogram, executes that function and
-            saves the histogram. Returns None, to turn the user-defined function into a
-            ProcessorFunc when wrapped with this.
+            """Executes a user-defined function that returns a histogram and saves it.
+
+            Returns None, to turn the user-defined function into a ProcessorFunc when
+            wrapped with this.
 
             Args:
                 region (Dict[str, Any]): dict with region information
@@ -370,9 +377,10 @@ def create_histograms(
     method: str = "uproot",
     router: Optional[route.Router] = None,
 ) -> None:
-    """generate all required histograms specified by the configuration file,
-    calling either a default method specified via ``method``, or a custom
-    user-defined override through ``router``
+    """Produces all required histograms specified by the configuration file.
+
+    Uses either a default method specified via ``method``, or a custom
+    user-defined override through ``router``.
 
     Args:
         config (Dict[str, Any]): cabinetry configuration

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -13,8 +13,9 @@ log = logging.getLogger(__name__)
 
 
 def _fix_stat_unc(histogram: histo.Histogram, name: str) -> None:
-    """replace nan stat. unc. by zero for a histogram, modifies the
-    histogram handed over in the argument
+    """Replaces nan stat. unc. by zero for a histogram.
+
+    Modifies the histogram handed over in the argument.
 
     Args:
         histogram (cabinetry.histo.Histogram): the histogram to fix
@@ -27,9 +28,11 @@ def _fix_stat_unc(histogram: histo.Histogram, name: str) -> None:
 
 
 def apply_postprocessing(histogram: histo.Histogram, name: str) -> histo.Histogram:
-    """Create a new modified histogram, currently only calling the
-    stat. uncertainty fix. The histogram in the function argument
-    stays unchanged.
+    """Returns a new histogram with post-processing applied.
+
+    The histogram handed to the function stays unchanged. A copy of the
+    histogram receives post-processing (currently only the stat. uncertainty
+    fix) and is then returned.
 
     Args:
         histogram (cabinetry.histo.Histogram): the histogram to postprocess
@@ -45,9 +48,10 @@ def apply_postprocessing(histogram: histo.Histogram, name: str) -> histo.Histogr
 
 
 def _get_postprocessor(histogram_folder: pathlib.Path) -> route.ProcessorFunc:
-    """return the postprocessing function to be applied to template histograms, for
-    example via ``cabinetry.route.apply_to_all_templates``
-    could alternatively create a ``Postprocessor`` class that contains processors
+    """Returns the post-processing function to be applied to template histograms.
+
+    Needed by ``cabinetry.route.apply_to_all_templates``. Could alternatively
+    create a ``Postprocessor`` class that contains processors.
 
     Args:
         histogram_folder (Union[str, pathlib.Path]): folder containing histograms
@@ -62,7 +66,7 @@ def _get_postprocessor(histogram_folder: pathlib.Path) -> route.ProcessorFunc:
         systematic: Dict[str, Any],
         template: str,
     ) -> None:
-        """apply post-processing to a single histogram
+        """Applies post-processing to a single histogram.
 
         Args:
             region (Dict[str, Any]): specifying region information
@@ -88,7 +92,7 @@ def _get_postprocessor(histogram_folder: pathlib.Path) -> route.ProcessorFunc:
 
 
 def run(config: Dict[str, Any]) -> None:
-    """apply postprocessing to all histograms
+    """Applies postprocessing to all histograms.
 
     Args:
         config (Dict[str, Any]): cabinetry configuration

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -31,7 +31,7 @@ def test_cabinetry():
 # using autospec to catch changes in public API
 @mock.patch("cabinetry.template_builder.create_histograms", autospec=True)
 @mock.patch(
-    "cabinetry.configuration.read",
+    "cabinetry.configuration.load",
     return_value={"General": {"Measurement": "test_config"}},
     autospec=True,
 )
@@ -60,7 +60,7 @@ def test_templates(mock_read, mock_create_histograms, cli_helpers, tmp_path):
 
 @mock.patch("cabinetry.template_postprocessor.run", autospec=True)
 @mock.patch(
-    "cabinetry.configuration.read",
+    "cabinetry.configuration.load",
     return_value={"General": {"Measurement": "test_config"}},
     autospec=True,
 )
@@ -83,7 +83,7 @@ def test_postprocess(mock_read, mock_postprocess, cli_helpers, tmp_path):
     "cabinetry.workspace.build", return_value={"workspace": "mock"}, autospec=True
 )
 @mock.patch(
-    "cabinetry.configuration.read",
+    "cabinetry.configuration.load",
     return_value={"General": {"Measurement": "test_config"}},
     autospec=True,
 )

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -8,8 +8,8 @@ from cabinetry import configuration
 
 
 @mock.patch("cabinetry.configuration.validate")
-def test_read(mock_validation):
-    conf = configuration.read("config_example.yml")
+def test_load(mock_validation):
+    conf = configuration.load("config_example.yml")
     assert isinstance(conf, dict)
     mock_validation.assert_called_once()
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,7 +17,7 @@ def test_integration(tmp_path, ntuple_creator):
     """
     ntuple_creator(str(tmp_path))
 
-    cabinetry_config = cabinetry.configuration.read("config_example.yml")
+    cabinetry_config = cabinetry.configuration.load("config_example.yml")
 
     # override config options to point to tmp_path
     cabinetry_config["General"]["HistogramFolder"] = str(tmp_path / "histograms")


### PR DESCRIPTION
**Breaking change:** renaming `configuration.read` to `configuration.load`.

Also updating docstrings to have a full sentence on one line as a summary. This resolves many issues flagged by
```
pydocstyle --convention google src/cabinetry/
```