### PR TITLE
chore: updating version to 0.1.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cabinetry
-version = 0.1.2
+version = 0.1.3
 author = Alexander Held
 description = design and steer profile likelihood fits
 long_description = file: README.md

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -8,4 +8,4 @@ from . import visualize  # NOQA
 from . import workspace  # NOQA
 
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"


### PR DESCRIPTION
Updating version to 0.1.3. Includes a fix to make `awkward1` a core dependency and likelihood scans. 