### PR TITLE
feat: command line interface for ranking and scan

### DIFF
--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -124,8 +124,8 @@ def ranking(ws_path: str, asimov: bool, max_pars: int, figfolder: str) -> None:
 def scan(
     ws_path: str,
     par_name: str,
-    lower_bound: float,
-    upper_bound: float,
+    lower_bound: Optional[float],
+    upper_bound: Optional[float],
     n_steps: int,
     asimov: bool,
     figfolder: str,
@@ -141,17 +141,17 @@ def scan(
     """
     _set_logging()
     par_range: Optional[Tuple[float, float]]
-    if lower_bound and upper_bound:
+    if (lower_bound is not None) and (upper_bound is not None):
         # both bounds specified
         par_range = (lower_bound, upper_bound)
-    elif (not lower_bound) and (not upper_bound):
-        # no bounds specified
-        par_range = None
-    if (not lower_bound and upper_bound) or (lower_bound and not upper_bound):
+    elif (lower_bound is not None) or (upper_bound is not None):
         # mixed case not supported
         raise ValueError(
             "Need to either specify both lower_bound and upper_bound, or neither."
         )
+    else:
+        # no bounds specified
+        par_range = None
 
     ws = cabinetry_workspace.load(ws_path)
     scan_results = cabinetry_fit.scan(

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -91,7 +91,25 @@ def fit(ws_path: str, pulls: bool, corrmat: bool, figfolder: str) -> None:
         cabinetry_visualize.correlation_matrix(fit_results, figfolder)
 
 
+@click.command()
+@click.argument("ws_path", type=click.Path(exists=True))
+@click.option("--asimov", is_flag=True, help="fit Asimov dataset")
+@click.option("--max_pars", default=10, help="maximum amount of parameters in plot")
+@click.option("--figfolder", default="figures/", help="folder to save figures to")
+def ranking(ws_path: str, asimov: bool, max_pars: int, figfolder: str) -> None:
+    """Ranks nuisance parameters and visualizes the result.
+
+    WS_PATH: path to workspace used in fit
+    """
+    _set_logging()
+    ws = cabinetry_workspace.load(ws_path)
+    fit_results = cabinetry_fit.fit(ws, asimov=asimov, custom=True)
+    ranking_results = cabinetry_fit.ranking(ws, fit_results, asimov=asimov)
+    cabinetry_visualize.ranking(ranking_results, figfolder, max_pars=max_pars)
+
+
 cabinetry.add_command(templates)
 cabinetry.add_command(postprocess)
 cabinetry.add_command(workspace)
 cabinetry.add_command(fit)
+cabinetry.add_command(ranking)

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -104,7 +104,7 @@ def ranking(ws_path: str, asimov: bool, max_pars: int, figfolder: str) -> None:
     """
     _set_logging()
     ws = cabinetry_workspace.load(ws_path)
-    fit_results = cabinetry_fit.fit(ws, asimov=asimov, custom=True)
+    fit_results = cabinetry_fit.fit(ws, asimov=asimov)
     ranking_results = cabinetry_fit.ranking(ws, fit_results, asimov=asimov)
     cabinetry_visualize.ranking(ranking_results, figfolder, max_pars=max_pars)
 

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -33,7 +33,11 @@ def cabinetry() -> None:
 
 @click.command()
 @click.argument("config_path", type=click.Path(exists=True))
-@click.option("--method", default="uproot", help="backend for histogram production")
+@click.option(
+    "--method",
+    default="uproot",
+    help="backend for histogram production (default: uproot)",
+)
 def templates(config_path: str, method: str) -> None:
     """Produces template histograms.
 
@@ -74,10 +78,16 @@ def workspace(config_path: str, ws_path: str) -> None:
 
 @click.command()
 @click.argument("ws_path", type=click.Path(exists=True))
-@click.option("--asimov", is_flag=True, help="fit Asimov dataset")
-@click.option("--pulls", is_flag=True, help="produce pull plot")
-@click.option("--corrmat", is_flag=True, help="produce correlation matrix")
-@click.option("--figfolder", default="figures/", help="folder to save figures to")
+@click.option("--asimov", is_flag=True, help="fit Asimov dataset (default: False)")
+@click.option("--pulls", is_flag=True, help="produce pull plot (default: False)")
+@click.option(
+    "--corrmat", is_flag=True, help="produce correlation matrix (default: False)"
+)
+@click.option(
+    "--figfolder",
+    default="figures/",
+    help="folder to save figures to (default: figures/)",
+)
 def fit(ws_path: str, asimov: bool, pulls: bool, corrmat: bool, figfolder: str) -> None:
     """Fits a workspace and optionally visualize the results.
 
@@ -94,9 +104,15 @@ def fit(ws_path: str, asimov: bool, pulls: bool, corrmat: bool, figfolder: str) 
 
 @click.command()
 @click.argument("ws_path", type=click.Path(exists=True))
-@click.option("--asimov", is_flag=True, help="fit Asimov dataset")
-@click.option("--max_pars", default=10, help="maximum amount of parameters in plot")
-@click.option("--figfolder", default="figures/", help="folder to save figures to")
+@click.option("--asimov", is_flag=True, help="fit Asimov dataset (default: False)")
+@click.option(
+    "--max_pars", default=10, help="maximum amount of parameters in plot (default: 10)"
+)
+@click.option(
+    "--figfolder",
+    default="figures/",
+    help="folder to save figures to (default: figures/)",
+)
 def ranking(ws_path: str, asimov: bool, max_pars: int, figfolder: str) -> None:
     """Ranks nuisance parameters and visualizes the result.
 
@@ -113,14 +129,24 @@ def ranking(ws_path: str, asimov: bool, max_pars: int, figfolder: str) -> None:
 @click.argument("ws_path", type=click.Path(exists=True))
 @click.argument("par_name", type=str)
 @click.option(
-    "--lower_bound", default=None, type=float, help="lower parameter bound in scan"
+    "--lower_bound",
+    default=None,
+    type=float,
+    help="lower parameter bound in scan (default: auto)",
 )
 @click.option(
-    "--upper_bound", default=None, type=float, help="upper parameter bound in scan"
+    "--upper_bound",
+    default=None,
+    type=float,
+    help="upper parameter bound in scan (default: auto)",
 )
-@click.option("--n_steps", default=11, help="number of steps in scan")
-@click.option("--asimov", is_flag=True, help="fit Asimov dataset")
-@click.option("--figfolder", default="figures/", help="folder to save figures to")
+@click.option("--n_steps", default=11, help="number of steps in scan (default: 11)")
+@click.option("--asimov", is_flag=True, help="fit Asimov dataset (default: False)")
+@click.option(
+    "--figfolder",
+    default="figures/",
+    help="folder to save figures to (default: figures/)",
+)
 def scan(
     ws_path: str,
     par_name: str,

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -74,17 +74,18 @@ def workspace(config_path: str, ws_path: str) -> None:
 
 @click.command()
 @click.argument("ws_path", type=click.Path(exists=True))
+@click.option("--asimov", is_flag=True, help="fit Asimov dataset")
 @click.option("--pulls", is_flag=True, help="produce pull plot")
 @click.option("--corrmat", is_flag=True, help="produce correlation matrix")
 @click.option("--figfolder", default="figures/", help="folder to save figures to")
-def fit(ws_path: str, pulls: bool, corrmat: bool, figfolder: str) -> None:
+def fit(ws_path: str, asimov: bool, pulls: bool, corrmat: bool, figfolder: str) -> None:
     """Fits a workspace and optionally visualize the results.
 
     WS_PATH: path to workspace used in fit
     """
     _set_logging()
     ws = cabinetry_workspace.load(ws_path)
-    fit_results = cabinetry_fit.fit(ws)
+    fit_results = cabinetry_fit.fit(ws, asimov=asimov)
     if pulls:
         cabinetry_visualize.pulls(fit_results, figfolder)
     if corrmat:

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -339,7 +339,7 @@ def scan(
     par_mle = fit_results.bestfit[par_index]
     par_unc = fit_results.uncertainty[par_index]
 
-    if not par_range:
+    if par_range is None:
         # if no parameter range is specified, use +/-2 sigma from the MLE
         par_range = (par_mle - 2 * par_unc, par_mle + 2 * par_unc)
 

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -123,7 +123,7 @@ def data_MC(
     """
     model, data_combined = model_utils.model_and_data(spec, with_aux=False)
 
-    if fit_results:
+    if fit_results is not None:
         # fit results specified, draw a post-fit plot with them applied
         prefit = False
         param_values = fit_results.bestfit

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -137,7 +137,7 @@ def test_fit(mock_load, mock_fit, mock_pulls, mock_corrmat, tmp_path):
     result = runner.invoke(cli.fit, [workspace_path])
     assert result.exit_code == 0
     assert mock_load.call_args_list == [((workspace_path,), {})]
-    assert mock_fit.call_args_list == [((workspace,), {})]
+    assert mock_fit.call_args_list == [((workspace,), {"asimov": False})]
 
     # pull plot
     result = runner.invoke(cli.fit, ["--pulls", workspace_path])

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -226,3 +226,89 @@ def test_ranking(mock_load, mock_fit, mock_rank, mock_vis, tmp_path):
     assert mock_fit.call_args_list[-1] == ((workspace,), {"asimov": True})
     assert mock_rank.call_args_list[-1] == ((workspace, fit_results), {"asimov": True})
     assert mock_vis.call_args_list[-1][1] == {"max_pars": 3}
+
+
+@mock.patch("cabinetry.visualize.scan", autospec=True)
+@mock.patch(
+    "cabinetry.fit.scan",
+    return_value=fit.ScanResults("par", 1.0, 0.1, np.asarray([1.5]), np.asarray([3.5])),
+    autospec=True,
+)
+@mock.patch(
+    "cabinetry.workspace.load", return_value={"workspace": "mock"}, autospec=True
+)
+def test_scan(mock_load, mock_scan, mock_vis, tmp_path):
+    workspace = {"workspace": "mock"}
+    workspace_path = str(tmp_path / "workspace.json")
+
+    # need to save workspace to file since click looks for it
+    with open(workspace_path, "w") as f:
+        f.write("{'workspace': 'mock'}")
+
+    par_name = "par"
+    scan_results = fit.ScanResults(
+        par_name, 1.0, 0.1, np.asarray([1.5]), np.asarray([3.5])
+    )
+
+    runner = CliRunner()
+
+    # default
+    result = runner.invoke(cli.scan, [workspace_path, par_name])
+    assert result.exit_code == 0
+    assert mock_load.call_args_list == [((workspace_path,), {})]
+    assert mock_scan.call_args_list == [
+        ((workspace, par_name), {"par_range": None, "n_steps": 11, "asimov": False})
+    ]
+    assert mock_vis.call_count == 1
+    assert mock_vis.call_args[0][0].name == scan_results.name
+    assert mock_vis.call_args[0][0].bestfit == scan_results.bestfit
+    assert mock_vis.call_args[0][0].uncertainty == scan_results.uncertainty
+    assert np.allclose(
+        mock_vis.call_args[0][0].scanned_values, scan_results.scanned_values
+    )
+    assert np.allclose(mock_vis.call_args[0][0].delta_nlls, scan_results.delta_nlls)
+    assert mock_vis.call_args[0][1] == "figures/"
+
+    # only one bound
+    with pytest.raises(
+        ValueError,
+        match="Need to either specify both lower_bound and upper_bound, or neither.",
+    ):
+        runner.invoke(
+            cli.scan,
+            ["--lower_bound", 1.0, workspace_path, par_name],
+            catch_exceptions=False,
+        )
+    with pytest.raises(
+        ValueError,
+        match="Need to either specify both lower_bound and upper_bound, or neither.",
+    ):
+        runner.invoke(
+            cli.scan,
+            ["--upper_bound", 1.0, workspace_path, par_name],
+            catch_exceptions=False,
+        )
+
+    # custom bounds, number of steps and Asimov
+    result = runner.invoke(
+        cli.scan,
+        [
+            "--lower_bound",
+            0.0,
+            "--upper_bound",
+            2.0,
+            "--n_steps",
+            21,
+            "--asimov",
+            "--figfolder",
+            "folder/",
+            workspace_path,
+            par_name,
+        ],
+    )
+    assert result.exit_code == 0
+    assert mock_scan.call_args_list[-1] == (
+        (workspace, par_name),
+        {"par_range": (0.0, 2.0), "n_steps": 21, "asimov": True},
+    )
+    assert mock_vis.call_args[0][1] == "folder/"

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -226,6 +226,7 @@ def test_ranking(mock_load, mock_fit, mock_rank, mock_vis, tmp_path):
     assert mock_fit.call_args_list[-1] == ((workspace,), {"asimov": True})
     assert mock_rank.call_args_list[-1] == ((workspace, fit_results), {"asimov": True})
     assert mock_vis.call_args_list[-1][1] == {"max_pars": 3}
+    assert mock_vis.call_args_list[-1][0][1] == "folder/"
 
 
 @mock.patch("cabinetry.visualize.scan", autospec=True)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -139,6 +139,11 @@ def test_fit(mock_load, mock_fit, mock_pulls, mock_corrmat, tmp_path):
     assert mock_load.call_args_list == [((workspace_path,), {})]
     assert mock_fit.call_args_list == [((workspace,), {"asimov": False})]
 
+    # Asimov
+    result = runner.invoke(cli.fit, ["--asimov", workspace_path])
+    assert result.exit_code == 0
+    assert mock_fit.call_args_list[-1] == ((workspace,), {"asimov": True})
+
     # pull plot
     result = runner.invoke(cli.fit, ["--pulls", workspace_path])
     assert result.exit_code == 0
@@ -156,3 +161,68 @@ def test_fit(mock_load, mock_fit, mock_pulls, mock_corrmat, tmp_path):
     assert result.exit_code == 0
     assert mock_corrmat.call_args_list[-1] == ((fit_results, "folder/"), {})
     assert mock_pulls.call_args_list[-1] == ((fit_results, "folder/"), {})
+
+
+@mock.patch("cabinetry.visualize.ranking", autospec=True)
+@mock.patch(
+    "cabinetry.fit.ranking",
+    return_value=fit.RankingResults(
+        np.asarray([1.0]),
+        np.asarray([0.1]),
+        ["label"],
+        np.asarray([[1.2]]),
+        np.asarray([[0.8]]),
+        np.asarray([[1.1]]),
+        np.asarray([[0.9]]),
+    ),
+    autospec=True,
+)
+@mock.patch(
+    "cabinetry.fit.fit",
+    return_value=fit.FitResults(
+        np.asarray([1.0]), np.asarray([0.1]), ["label"], np.asarray([[1.0]]), 1.0
+    ),
+    autospec=True,
+)
+@mock.patch(
+    "cabinetry.workspace.load", return_value={"workspace": "mock"}, autospec=True
+)
+def test_ranking(mock_load, mock_fit, mock_rank, mock_vis, tmp_path):
+    workspace = {"workspace": "mock"}
+    bestfit = np.asarray([1.0])
+    uncertainty = np.asarray([0.1])
+    labels = ["label"]
+    corr_mat = np.asarray([[1.0]])
+    fit_results = fit.FitResults(bestfit, uncertainty, labels, corr_mat, 1.0)
+
+    workspace_path = str(tmp_path / "workspace.json")
+
+    # need to save workspace to file since click looks for it
+    with open(workspace_path, "w") as f:
+        f.write("{'workspace': 'mock'}")
+
+    runner = CliRunner()
+
+    # default
+    result = runner.invoke(cli.ranking, [workspace_path])
+    assert result.exit_code == 0
+    assert mock_load.call_args_list == [((workspace_path,), {})]
+    assert mock_fit.call_args_list == [((workspace,), {"asimov": False})]
+    assert mock_rank.call_args_list == [((workspace, fit_results), {"asimov": False})]
+    assert mock_vis.call_count == 1
+    assert np.allclose(mock_vis.call_args[0][0].prefit_up, [[1.2]])
+    assert np.allclose(mock_vis.call_args[0][0].prefit_down, [[0.8]])
+    assert np.allclose(mock_vis.call_args[0][0].postfit_up, [[1.1]])
+    assert np.allclose(mock_vis.call_args[0][0].postfit_down, [[0.9]])
+    assert mock_vis.call_args[0][1] == "figures/"
+    assert mock_vis.call_args[1] == {"max_pars": 10}
+
+    # Asimov, maximum amount of parameters, custom folder
+    result = runner.invoke(
+        cli.ranking,
+        ["--asimov", "--max_pars", 3, "--figfolder", "folder/", workspace_path],
+    )
+    assert result.exit_code == 0
+    assert mock_fit.call_args_list[-1] == ((workspace,), {"asimov": True})
+    assert mock_rank.call_args_list[-1] == ((workspace, fit_results), {"asimov": True})
+    assert mock_vis.call_args_list[-1][1] == {"max_pars": 3}


### PR DESCRIPTION
Adding nuisance parameter ranking and likelihood scan to the command line interface, see:

- `cabinetry ranking --help`
- `cabinetry scan --help`

Two small fixes: comparisons to None via `is None`.