### PR TITLE
ci: Add nightly tests using HEAD of dependencies

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         python -m pytest -r sx
 
-  uproot:
+  uproot4:
 
     runs-on: ${{ matrix.os }}
     strategy:
@@ -73,7 +73,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
-        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/uproot.git
+        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/uproot4.git
         python -m pip list
     - name: Test with pytest
       run: |

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -2,7 +2,6 @@ name: HEAD of dependencies
 
 on:
   workflow_dispatch:
-  push:
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         python -m pytest -r sx
 
-  boost_histogram:
+  boost-histogram:
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -31,6 +31,54 @@ jobs:
       run: |
         python -m pytest -r sx
 
+  awkward1:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/awkward-1.0.git
+        python -m pip list
+    - name: Test with pytest
+      run: |
+        python -m pytest -r sx
+
+  uproot:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/uproot.git
+        python -m pip list
+    - name: Test with pytest
+      run: |
+        python -m pytest -r sx
+
   iminuit:
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -1,0 +1,81 @@
+name: HEAD of dependencies
+
+on:
+  workflow_dispatch:
+  # Run daily at 0:01 UTC
+  schedule:
+  - cron:  '1 0 * * *'
+
+jobs:
+  pyhf:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/pyhf.git
+        python -m pip list
+    - name: Test with pytest
+      run: |
+        python -m pytest -r sx
+
+  iminuit:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip install --upgrade --no-cache-dir cython
+        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/iminuit.git
+        python -m pip list
+    - name: Test with pytest
+      run: |
+        python -m pytest -r sx
+
+  boost_histogram:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/boost-histogram.git
+        python -m pip list
+    - name: Test with pytest
+      run: |
+        python -m pytest -r sx

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -2,6 +2,7 @@ name: HEAD of dependencies
 
 on:
   workflow_dispatch:
+  push:
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'


### PR DESCRIPTION
This PR is a migration of https://github.com/scikit-hep/pyhf/pull/1071 and adds nightly tests that run at the `HEAD` of dependencies that are the most reasonable to check and interact with. If breaking changes are detected in these dependencies at their `HEAD` then there should be time to either proactively address this in `cabinetry` or work with the dependency dev team to mitigate them. They can also be run on demand with workflow dispatch.

Note that these tests only run on CRON jobs and on demand, but never on pushes of PRs.

Example workflow: https://github.com/matthewfeickert/cabinetry/actions/runs/266365012

**Suggested squash and merge commit message**

```
* Add nightly tests to run test suite at HEAD of dependencies
   - Use as early alert for breaking changes in dependencies
   - Run for pyhf, awkard1, uproot, iminuit, and boost-histogram
```