### PR TITLE
feat: skip ranking for fixed parameters

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -98,3 +98,45 @@ All conditions need to be fulfilled to apply a user-defined function, so
 
 means that for the decorated function to be executed, the region name needs to be `signal_region`, the sample needs to be called `signal`, the systematic needs to be `alpha_S`, but there is no restriction to the template name.
 Omitting ``template`` from the arguments, or using the default ``template=None`` has the same result.
+
+
+Fixed parameters
+----------------
+
+The ``cabinetry`` configuration file contains the ``Fixed`` option (in the ``General`` group of options), which allows for the creation of a workspace with parameters set to be constant (via the ``pyhf`` ``"fixed": true`` option in the workspace):
+
+.. code-block:: yaml
+
+    Fixed:
+      - Name: par_a
+        Value: 2
+      - Name: par_b
+        Value: 1
+
+The same can be written in a more compact way:
+
+.. code-block:: yaml
+
+    Fixed: [{"Name": "par_a", "Value": 2},{"Name": "par_b", "Value": 1}]
+
+The associated ``pyhf`` workspace will contain the following:
+
+.. code-block:: json
+
+    {
+      "measurements": [
+        {
+          "config": {
+            "parameters": [
+              {"fixed": true, "inits": [2], "name": "par_a"},
+              {"fixed": true, "inits": [1], "name": "par_b"}
+            ]
+          }
+        }
+      ]
+    }
+
+Fixed parameters are not allowed to vary in fits.
+Both their pre-fit and post-fit uncertainty are set to zero.
+This means that the associated nuisance parameters do not contribute to uncertainty bands in data/MC visualizations either.
+The impact of such parameters on the parameter of interest (for nuisance parameter ranking) is also zero.

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -103,7 +103,7 @@ Omitting ``template`` from the arguments, or using the default ``template=None``
 Fixed parameters
 ----------------
 
-The ``cabinetry`` configuration file contains the ``Fixed`` option (in the ``General`` group of options), which allows for the creation of a workspace with parameters set to be constant (via the ``pyhf`` ``"fixed": true`` option in the workspace):
+The ``cabinetry`` configuration file contains the ``Fixed`` option (in the ``General`` group of options), which allows for the creation of a workspace with parameters set to be constant.
 
 .. code-block:: yaml
 

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -262,18 +262,24 @@ def ranking(
             fit_results.bestfit[i_par] + fit_results.uncertainty[i_par],
             fit_results.bestfit[i_par] - fit_results.uncertainty[i_par],
         ]:
-            init_pars = init_pars_default.copy()
-            init_pars[i_par] = np_val  # set value of current nuisance parameter
-            # could skip pre-fit calculation for unconstrained parameters
-            fit_results_ranking = _fit_model_custom(
-                model, data, init_pars=init_pars, fix_pars=fix_pars
-            )
-            poi_val = fit_results_ranking.bestfit[model.config.poi_index]
-            parameter_impact = poi_val - nominal_poi
-            log.debug(
-                f"POI is {poi_val:.6f}, difference to nominal is {parameter_impact:.6f}"
-            )
-            parameter_impacts.append(parameter_impact)
+            # can skip pre-fit calculation for unconstrained parameters (their
+            # pre-fit uncertainty is set to 0), and pre- and post-fit calculation
+            # for fixed parameters (both uncertainties set to 0 as well)
+            if np_val == fit_results.bestfit[i_par]:
+                log.debug(f"impact of {label} is zero, skipping fit")
+                parameter_impacts.append(0.0)
+            else:
+                init_pars = init_pars_default.copy()
+                init_pars[i_par] = np_val  # set value of current nuisance parameter
+                fit_results_ranking = _fit_model_custom(
+                    model, data, init_pars=init_pars, fix_pars=fix_pars
+                )
+                poi_val = fit_results_ranking.bestfit[model.config.poi_index]
+                parameter_impact = poi_val - nominal_poi
+                log.debug(
+                    f"POI is {poi_val:.6f}, difference to nominal is {parameter_impact:.6f}"
+                )
+                parameter_impacts.append(parameter_impact)
         all_impacts.append(parameter_impacts)
 
     all_impacts_np = np.asarray(all_impacts)

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -119,7 +119,9 @@ def get_asimov_parameters(model: pyhf.pdf.Model) -> np.ndarray:
 def get_prefit_uncertainties(model: pyhf.pdf.Model) -> np.ndarray:
     """Returns a list of pre-fit parameter uncertainties for a model.
 
-    For unconstrained parameters the uncertainty is set to 0.
+    For unconstrained parameters the uncertainty is set to 0. It is also
+    set to 0 for fixed parameters (similarly to how their post-fit
+    uncertainties are defined to be 0).
 
     Args:
         model (pyhf.pdf.Model): model for which to extract the parameters
@@ -130,12 +132,15 @@ def get_prefit_uncertainties(model: pyhf.pdf.Model) -> np.ndarray:
     """
     pre_fit_unc = []  # pre-fit uncertainties for parameters
     for parameter in model.config.par_order:
-        # for constrained parameters, obtain their pre-fit uncertainty
-        if model.config.param_set(parameter).constrained:
+        # obtain pre-fit uncertainty for constrained and non-fixed parameters
+        if (
+            model.config.param_set(parameter).constrained
+            and not model.config.param_set(parameter).fixed
+        ):
             pre_fit_unc += model.config.param_set(parameter).width()
         else:
             if model.config.param_set(parameter).n_parameters == 1:
-                # unconstrained normfactor, do not add any uncertainties
+                # unconstrained normfactor or fixed parameter, uncertainty is 0
                 pre_fit_unc.append(0.0)
             else:
                 # shapefactor

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -132,7 +132,7 @@ def get_prefit_uncertainties(model: pyhf.pdf.Model) -> np.ndarray:
     """
     pre_fit_unc = []  # pre-fit uncertainties for parameters
     for parameter in model.config.par_order:
-        # obtain pre-fit uncertainty for constrained and non-fixed parameters
+        # obtain pre-fit uncertainty for constrained, non-fixed parameters
         if (
             model.config.param_set(parameter).constrained
             and not model.config.param_set(parameter).fixed

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -186,8 +186,8 @@ def test_ranking(mock_fit, example_spec):
     # fixed parameter in ranking
     example_spec["measurements"][0]["config"]["parameters"][0]["fixed"] = True
     ranking_results = fit.ranking(example_spec, fit_results)
-    # expect two more calls in this ranking: pre-fit uncertainty is 0 since parameter
-    # is fixed, but mock post-fit uncertainty is not 0
+    # expect two calls in this ranking (and had 4 before, so 6 total): pre-fit
+    # uncertainty is 0 since parameter is fixed, mock post-fit uncertainty is not 0
     assert mock_fit.call_count == 6
     assert np.allclose(ranking_results.prefit_up, [0.0])
     assert np.allclose(ranking_results.prefit_down, [0.0])

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -48,10 +48,16 @@ def test_get_asimov_parameters(example_spec, example_spec_shapefactor):
     assert np.allclose(pars, [1.0, 1.0, 1.0])
 
 
-def test_get_prefit_uncertainties(example_spec, example_spec_shapefactor):
+def test_get_prefit_uncertainties(
+    example_spec, example_spec_multibin, example_spec_shapefactor
+):
     model = pyhf.Workspace(example_spec).model()
     unc = model_utils.get_prefit_uncertainties(model)
-    assert np.allclose(unc, [0.0495665682, 0.0])
+    assert np.allclose(unc, [0.0, 0.0])  # fixed parameter and normfactor
+
+    model = pyhf.Workspace(example_spec_multibin).model()
+    unc = model_utils.get_prefit_uncertainties(model)
+    assert np.allclose(unc, [0.2, 0.4, 0.0, 0.125])
 
     model = pyhf.Workspace(example_spec_shapefactor).model()
     unc = model_utils.get_prefit_uncertainties(model)


### PR DESCRIPTION
Parameters that are set to be held constant in fits have no impact on the parameter of interest by construction. This skips the fit to calculate the impact, which instead is set to 0 directly.

Also changing the pre-fit uncertainty assigned to fixed parameters, which is no 0 (as is the post-fit uncertainty).

Adding a section in the docs to explain the behavior of fixed parameters.