### PR TITLE
style: consistent maximum line length

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ filterwarnings =
 
 [flake8]
 max-complexity = 12
-max-line-length = 127
+max-line-length = 88
 exclude = docs/conf.py
 count = True
 statistics = True

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -154,10 +154,12 @@ def histogram_is_needed(
                 # no histogram needed for normalization variation
                 histo_needed = False
             elif systematic["Type"] == "NormPlusShape":
-                # for a variation defined via a template, a histogram is needed (if sample is affected)
+                # for a variation defined via a template, a histogram is needed (if
+                # sample is affected)
                 histo_needed = sample_affected_by_modifier(sample, systematic)
-                # if symmetrization is specified for the template under consideration, a histogram
-                # is not needed (since it will later on be obtained via symmetrization)
+                # if symmetrization is specified for the template under consideration,
+                # a histogram is not needed (since it will later on be obtained via
+                # symmetrization)
                 if systematic.get(template, {}).get("Symmetrize", False):
                     histo_needed = False
             else:

--- a/src/cabinetry/contrib/matplotlib_visualize.py
+++ b/src/cabinetry/contrib/matplotlib_visualize.py
@@ -27,8 +27,9 @@ def data_MC(
             defaults to None
         bin_edges (np.ndarray): bin edges of histogram
         figure_path (pathlib.Path): path where figure should be saved
-        log_scale (Optional[bool], optional): whether to use a logarithmic vertical axis,
-            defaults to None (automatically determine whether to use linear or log scale)
+        log_scale (Optional[bool], optional): whether to use a logarithmic vertical
+            axis, defaults to None (automatically determine whether to use linear or log
+            scale)
     """
     mc_histograms_yields = []
     mc_labels = []
@@ -198,7 +199,8 @@ def correlation_matrix(
 
     Args:
         corr_mat (np.ndarray): the correlation matrix to plot
-        labels (Union[List[str], np.ndarray]): names of parameters in the correlation matrix
+        labels (Union[List[str], np.ndarray]): names of parameters in the correlation
+            matrix
         figure_path (pathlib.Path): path where figure should be saved
     """
     # rounding for test in CI to match reference
@@ -288,9 +290,11 @@ def ranking(
         uncertainty (np.ndarray): parameter uncertainties
         labels (Union[List[str], np.ndarray]): parameter labels
         impact_prefit_up (np.ndarray): pre-fit impact in "up" direction per parameter
-        impact_prefit_down (np.ndarray): pre-fit impact in "down" direction per parameter
+        impact_prefit_down (np.ndarray): pre-fit impact in "down" direction per
+            parameter
         impact_postfit_up (np.ndarray): post-fit impact in "up" direction per parameter
-        impact_postfit_down (np.ndarray): post-fit impact in "down" direction per parameter
+        impact_postfit_down (np.ndarray): post-fit impact in "down" direction per
+            parameter
         figure_path (pathlib.Path): path where figure should be saved
     """
     num_pars = len(bestfit)

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -83,7 +83,8 @@ def print_results(
     max_label_length = max([len(label) for label in fit_result.labels])
     for i, label in enumerate(fit_result.labels):
         log.info(
-            f"{label.ljust(max_label_length)}: {fit_result.bestfit[i]: .6f} +/- {fit_result.uncertainty[i]:.6f}"
+            f"{label.ljust(max_label_length)}: {fit_result.bestfit[i]: .6f} +/- "
+            f"{fit_result.uncertainty[i]:.6f}"
         )
 
 
@@ -277,7 +278,8 @@ def ranking(
                 poi_val = fit_results_ranking.bestfit[model.config.poi_index]
                 parameter_impact = poi_val - nominal_poi
                 log.debug(
-                    f"POI is {poi_val:.6f}, difference to nominal is {parameter_impact:.6f}"
+                    f"POI is {poi_val:.6f}, difference to nominal is "
+                    f"{parameter_impact:.6f}"
                 )
                 parameter_impacts.append(parameter_impact)
         all_impacts.append(parameter_impacts)
@@ -327,7 +329,8 @@ def scan(
         ValueError: if parameter is not found in model
 
     Returns:
-        ScanResults: includes parameter name, scanned values and 2*log(likelihood) offset
+        ScanResults: includes parameter name, scanned values and 2*log(likelihood)
+        offset
     """
     model, data = model_utils.model_and_data(spec, asimov=asimov)
     labels = model_utils.get_parameter_names(model)

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -30,10 +30,12 @@ class Histogram(bh.Histogram):
         Args:
             bins (Union[List[float], np.ndarray]): edges of histogram bins
             yields (Union[List[float], np.ndarray]): yield per histogram bin
-            stdev (Union[List[float], np.ndarray]): statistical uncertainty of yield per bin
+            stdev (Union[List[float], np.ndarray]): statistical uncertainty of yield per
+                bin
 
         Raises:
-            ValueError: when amount of bins specified via bin edges and bin contents do not match
+            ValueError: when amount of bins specified via bin edges and bin contents do
+                not match
             ValueError: when length of yields and stdev do not match
 
         Returns:
@@ -72,7 +74,8 @@ class Histogram(bh.Histogram):
             histo_path_modified = histo_path.parent / (histo_path.name + "_modified")
             if not histo_path_modified.with_suffix(".npz").exists():
                 log.warning(
-                    f"the modified histogram {histo_path_modified.with_suffix('.npz')} does not exist",
+                    f"the modified histogram {histo_path_modified.with_suffix('.npz')} "
+                    f"does not exist",
                 )
                 log.warning("loading the un-modified histogram instead!")
             else:
@@ -197,7 +200,8 @@ class Histogram(bh.Histogram):
         not_empty_but_nan = [b for b in nan_pos if b not in empty_bins]
         if len(not_empty_but_nan) > 0:
             log.warning(
-                f"{name} has non-empty bins with ill-defined stat. unc.: {not_empty_but_nan}",
+                f"{name} has non-empty bins with ill-defined stat. unc.: "
+                f"{not_empty_but_nan}",
             )
 
     def normalize_to_yield(self, reference_histogram: H) -> np.float64:

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -227,7 +227,7 @@ def calculate_stdev(
                     labels[i_par][0:10] == "staterror_"
                     and labels[j_par][0:10] == "staterror_"
                 ):
-                    continue  # two different staterrors are orthogonal and will not contribute
+                    continue  # two different staterrors are orthogonal, no contribution
                 sym_unc_i = (up_variations[i_par] - down_variations[i_par]) / 2
                 sym_unc_j = (up_variations[j_par] - down_variations[j_par]) / 2
                 # factor of two below is there since loop is only over half the matrix

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -88,7 +88,7 @@ def get_asimov_parameters(model: pyhf.pdf.Model) -> np.ndarray:
 
     Returns:
         np.ndarray: the Asimov parameters, in the same order as
-            ``model.config.suggested_init()``
+        ``model.config.suggested_init()``
     """
     # create a list of parameter names, one entry per single parameter
     # (vectors like staterror expanded)
@@ -128,7 +128,7 @@ def get_prefit_uncertainties(model: pyhf.pdf.Model) -> np.ndarray:
 
     Returns:
         np.ndarray: pre-fit uncertainties for the parameters, in the same
-            order as ``model.config.suggested_init()``
+        order as ``model.config.suggested_init()``
     """
     pre_fit_unc = []  # pre-fit uncertainties for parameters
     for parameter in model.config.par_order:

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -14,8 +14,8 @@ log = logging.getLogger(__name__)
 # returns None
 ProcessorFunc = Callable[[Dict[str, Any], Dict[str, Any], Dict[str, Any], str], None]
 
-# type of a user-defined function for template processing, takes sample-region-systematic-template,
-# returns a boost_histogram.Histogram
+# type of a user-defined function for template processing, takes sample-region-
+# systematic-template, returns a boost_histogram.Histogram
 UserTemplateFunc = Callable[
     [Dict[str, Any], Dict[str, Any], Dict[str, Any], str], bh.Histogram
 ]
@@ -28,15 +28,21 @@ GenericProcessorFunc = Union[ProcessorFunc, UserTemplateFunc]
 # which returns either a ProcessorFunc or None
 MatchFunc = Callable[[str, str, str, str], Optional[ProcessorFunc]]
 
+# type of wrapper function that that turns a user-defined template processing function
+# (which returns a histogram) into a function that returns None
+WrapperFunc = Callable[[UserTemplateFunc], ProcessorFunc]
+
 
 class Router:
     """Holds user-defined processing functions and matches functions to templates.
 
-    Provides functions for matching a pattern to apply the right function to each template.
+    Provides functions for matching a pattern to apply the right function to each
+    template.
 
     Attributes:
-        template_builders (List[Dict[str, Any]]): user-defined processors for template building
-        template_builder_wrapper (Optional[Callable[[UserTemplateFunc], ProcessorFunc]]):
+        template_builders (List[Dict[str, Any]]): user-defined processors for template
+            building
+        template_builder_wrapper (Optional[WrapperFunc]):
             wrapper to apply on user-defined template builders
     """
 
@@ -45,13 +51,11 @@ class Router:
         # initialize all lists of processor types the user can specify
         self.template_builders: List[Dict[str, Any]] = []
 
-        # initialize the wrapper to be used for template building to turn the user-defined function
-        # (which returns a histogram) into one that saves the histogram instead
-        # this wrapper needs to be set before using _find_template_builder_match to properly handle
-        # the user-defined template builder
-        self.template_builder_wrapper: Optional[
-            Callable[[UserTemplateFunc], ProcessorFunc]
-        ] = None
+        # initialize the wrapper to be used for template building to turn the user-
+        # defined function (which returns a histogram) into one that saves the histogram
+        # this wrapper needs to be set before using _find_template_builder_match to
+        # properly handle the user-defined template builder
+        self.template_builder_wrapper: Optional[WrapperFunc] = None
 
     @staticmethod
     def _register_processor(
@@ -68,14 +72,14 @@ class Router:
                 or None to apply to all regions
             sample_name  (Optional[str]): name of the sample to apply the function to,
                 or None to apply to all samples
-            systematic_name  (Optional[str]): name of the systematic to apply the function to,
-                or None to apply to all systematics
+            systematic_name  (Optional[str]): name of the systematic to apply the
+                function to, or None to apply to all systematics
             template (Optional[str]): name of the template to apply the function to,
                 or None to apply to all templates
 
         Returns:
-            Callable[[GenericProcessorFunc], GenericProcessorFunc]: the function to register
-            a processor
+            Callable[[GenericProcessorFunc], GenericProcessorFunc]: the function to
+            register a processor
         """
         if region_name is None:
             region_name = "*"
@@ -118,17 +122,18 @@ class Router:
         """Decorator for registering a template builder function.
 
         Args:
-            region_name (Optional[str], optional): name of the region to apply the function to,
-                defaults to None (apply to all regions)
-            sample_name (Optional[str], optional): name of the sample to apply the function to,
-                defaults to None (apply to all samples)
-            systematic_name (Optional[str], optional): name of the systematic to apply the function to,
-                defaults to None (apply to all systematics)
-            template (Optional[str], optional): name of the template to apply the function to,
-                defaults to None (apply to all templates)
+            region_name (Optional[str], optional): name of the region to apply the
+                function to, defaults to None (apply to all regions)
+            sample_name (Optional[str], optional): name of the sample to apply the
+                function to, defaults to None (apply to all samples)
+            systematic_name (Optional[str], optional): name of the systematic to apply
+                the function to, defaults to None (apply to all systematics)
+            template (Optional[str], optional): name of the template to apply the
+                function to, defaults to None (apply to all templates)
 
         Returns:
-            Callable[[Callable], UserTemplateFunc]: the generic function to register a processor
+            Callable[[Callable], UserTemplateFunc]: the generic function to register a
+            processor
         """
         return self._register_processor(
             self.template_builders, region_name, sample_name, systematic_name, template
@@ -198,12 +203,12 @@ class Router:
             ValueError: when no template wrapper is set
 
         Returns:
-            Optional[ProcessorFunc]: wrapped template builder function matching the description,
-            or None if no matches are found
+            Optional[ProcessorFunc]: wrapped template builder function matching the
+            description, or None if no matches are found
         """
         if self.template_builder_wrapper is None:
-            # a wrapper needs to be defined already to convert the user-defined UserTemplateFunc
-            # into a ProcessorFunc
+            # a wrapper needs to be defined already to convert the user-defined
+            # UserTemplateFunc into a ProcessorFunc
             raise ValueError("no template builder wrapper defined")
 
         match = self._find_match(
@@ -211,7 +216,7 @@ class Router:
         )
 
         if match is not None:
-            # if a user-defined function was found, wrap the user-defined function and return it
+            # if user-defined function was found, wrap and return it
             return self.template_builder_wrapper(match)
         return None
 
@@ -231,14 +236,16 @@ def apply_to_all_templates(
     - the dict specifying systematic information
     - name of the template being considered: "Nominal", "Up", "Down"
 
-    In addition it is possible to specify a function that returns custom overrides. If one
-    is found for a given template, it is used instead of the default.
+    In addition it is possible to specify a function that returns custom overrides. If
+    one is found for a given template, it is used instead of the default.
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        default_func (ProcessorFunc): function to be called for every template by default
-        match_func: (Optional[MatchFunc], optional): function that returns user-defined functions
-            to override the call to ``default_func``, defaults to None (then it is not used)
+        default_func (ProcessorFunc): function to be called for every template by
+            default
+        match_func: (Optional[MatchFunc], optional): function that returns user-defined
+            functions to override the call to ``default_func``, defaults to None (then
+            it is not used)
     """
     for region in config["Regions"]:
         log.debug(f"  in region {region['Name']}")

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -42,8 +42,8 @@ class Router:
     Attributes:
         template_builders (List[Dict[str, Any]]): user-defined processors for template
             building
-        template_builder_wrapper (Optional[WrapperFunc]):
-            wrapper to apply on user-defined template builders
+        template_builder_wrapper (Optional[WrapperFunc]): wrapper to apply on user-
+            defined template builders
     """
 
     def __init__(self) -> None:

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -329,9 +329,10 @@ class _Builder:
     def _wrap_custom_template_builder(
         self, func: route.UserTemplateFunc
     ) -> route.ProcessorFunc:
-        """Returns a function that executes a custom template builder and saves the histogram.
+        """Returns function that executes custom template builder and saves histogram.
 
-        Wrapper for custom template builder functions that return a ``boost_histogram.Histogram``.
+        Wrapper for custom template builder functions that return a
+        ``boost_histogram.Histogram``.
 
         Args:
             func (cabinetry.route.UserTemplateFunc): user-defined template builder
@@ -339,9 +340,9 @@ class _Builder:
         Returns:
             cabinetry.route.ProcessorFunc: wrapped template builder
         """
-        # decorating this with functools.wraps will keep the name of the wrapped function the same,
-        # however the signature of the wrapped function is slightly different (the return value
-        # becomes None)
+        # decorating this with functools.wraps will keep the name of the wrapped
+        # function the same, however the signature of the wrapped function is slightly
+        # different (the return value becomes None)
         @functools.wraps(func)
         def wrapper(
             region: Dict[str, Any],
@@ -384,7 +385,8 @@ def create_histograms(
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        method (str, optional): backend to use for histogram production, defaults to "uproot"
+        method (str, optional): backend to use for histogram production, defaults to
+            "uproot"
         router (Optional[route.Router], optional): instance of cabinetry.route.Router
             that contains user-defined overrides, defaults to None
     """

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -60,9 +60,9 @@ def data_MC_from_histograms(
     Args:
         config (Dict[str, Any]): cabinetry configuration
         figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
-        log_scale (Optional[bool], optional): whether to use a logarithmic vertical axis,
-            defaults to None (automatically determine whether to use linear or log scale)
-        method (str, optional): what backend to use for plotting, defaults to "matplotlib"
+        log_scale (Optional[bool], optional): whether to use logarithmic vertical axis,
+            defaults to None (automatically determine whether to use linear/log scale)
+        method (str, optional): backend to use for plotting, defaults to "matplotlib"
 
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
@@ -126,9 +126,9 @@ def data_MC(
         fit_results (Optional[fit.FitResults]): parameter configuration to use for plot,
             includes best-fit settings and uncertainties, as well as correlation matrix,
             defaults to None (then the pre-fit configuration is drawn)
-        log_scale (Optional[bool], optional): whether to use a logarithmic vertical axis,
-            defaults to None (automatically determine whether to use linear or log scale)
-        method (str, optional): what backend to use for plotting, defaults to "matplotlib"
+        log_scale (Optional[bool], optional): whether to use logarithmic vertical axis,
+            defaults to None (automatically determine whether to use linear/log scale)
+        method (str, optional): backend to use for plotting, defaults to "matplotlib"
 
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
@@ -145,7 +145,7 @@ def data_MC(
     else:
         # no fit results specified, draw a pre-fit plot
         prefit = True
-        # use pre-fit parameter values and uncertainties, and diagonal correlation matrix
+        # use pre-fit parameter values, uncertainties, and diagonal correlation matrix
         param_values = model_utils.get_asimov_parameters(model)
         param_uncertainty = model_utils.get_prefit_uncertainties(model)
         corr_mat = np.zeros(shape=(len(param_values), len(param_values)))
@@ -234,23 +234,27 @@ def correlation_matrix(
         figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
         pruning_threshold (float, optional): minimum correlation for a parameter to
             have with any other parameters to not get pruned, defaults to 0.0
-        method (str, optional): what backend to use for plotting, defaults to "matplotlib"
+        method (str, optional): backend to use for plotting, defaults to "matplotlib"
 
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
     """
-    # create a matrix that is True if a correlation is below threshold, and True on the diagonal
+    # create a matrix that is True if a correlation is below threshold, and True on the
+    # diagonal
     below_threshold = np.where(
         np.abs(fit_results.corr_mat) < pruning_threshold, True, False
     )
     np.fill_diagonal(below_threshold, True)
     # get list of booleans specifying if everything in rows/columns is below threshold
     all_below_threshold = np.all(below_threshold, axis=0)
-    # get list of booleans specifying if rows/columns correspond to fixed parameter (0 correlations)
+    # get list of booleans specifying if rows/columns correspond to fixed parameter
+    # (0 correlations)
     fixed_parameter = np.all(np.equal(fit_results.corr_mat, 0.0), axis=0)
-    # get indices of rows/columns where everything is below threshold, or the parameter is fixed
+    # get indices of rows/columns where everything is below threshold, or the parameter
+    # is fixed
     delete_indices = np.where(np.logical_or(all_below_threshold, fixed_parameter))
-    # delete rows and columns where all correlations are below threshold / parameter is fixed
+    # delete rows and columns where all correlations are below threshold / parameter is
+    # fixed
     corr_mat = np.delete(
         np.delete(fit_results.corr_mat, delete_indices, axis=1), delete_indices, axis=0
     )
@@ -277,9 +281,9 @@ def pulls(
         fit_results (fit.FitResults): fit results, including correlation matrix
             and parameter labels
         figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
-        exclude_list (Optional[List[str]], optional): list of parameters to exclude from plot,
-            defaults to None (nothing excluded)
-        method (str, optional): what backend to use for plotting, defaults to "matplotlib"
+        exclude_list (Optional[List[str]], optional): list of parameters to exclude from
+            plot, defaults to None (nothing excluded)
+        method (str, optional): backend to use for plotting, defaults to "matplotlib"
 
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
@@ -325,9 +329,9 @@ def ranking(
     Args:
         ranking_results (fit.RankingResults): fit results, and pre- and post-fit impacts
         figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
-        max_pars (Optional[int], optional): number of parameters to include, defaults to None
-            (which means all parameters are included)
-        method (str, optional): what backend to use for plotting, defaults to "matplotlib"
+        max_pars (Optional[int], optional): number of parameters to include, defaults to
+            None (which means all parameters are included)
+        method (str, optional): backend to use for plotting, defaults to "matplotlib"
 
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
@@ -386,7 +390,7 @@ def templates(
     Args:
         config (Dict[str, Any]): cabinetry configuration
         figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
-        method (str, optional): what backend to use for plotting, defaults to "matplotlib"
+        method (str, optional): backend to use for plotting, defaults to "matplotlib"
 
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
@@ -479,7 +483,7 @@ def scan(
     Args:
         scan_results (fit.ScanResults): results of a likelihood scan
         figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
-        method (str, optional): what backend to use for plotting, defaults to "matplotlib"
+        method (str, optional): backend to use for plotting, defaults to "matplotlib"
 
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -74,8 +74,8 @@ class WorkspaceBuilder:
         Args:
             region (Dict[str, Any]): specific region to use
             sample (Dict[str, Any]): specific sample to use
-            systematic (Optional[Dict[str, Any]], optional): specific systematic variation to use,
-                defaults to None -> {"Name": "Nominal"}
+            systematic (Optional[Dict[str, Any]], optional): specific systematic
+                variation to use, defaults to None -> {"Name": "Nominal"}
 
         Returns:
             List[float]: yields per bin for the sample
@@ -100,8 +100,8 @@ class WorkspaceBuilder:
         Args:
             region (Dict[str, Any]): specific region to use
             sample (Dict[str, Any]): specific sample to use
-            systematic (Optional[Dict[str, Any]], optional): specific systematic variation to use,
-                defaults to None -> {"Name": "Nominal"}
+            systematic (Optional[Dict[str, Any]], optional): specific systematic
+                variation to use, defaults to None -> {"Name": "Nominal"}
 
         Returns:
             List[float]: statistical uncertainty of yield per bin for the sample
@@ -140,7 +140,7 @@ class WorkspaceBuilder:
         """Returns a normalization modifier (OverallSys in `HistFactory`).
 
         Args:
-            systematic (Dict[str, Any]): systematic for which the modifier is constructed
+            systematic (Dict[str, Any]): systematic for which modifier is constructed
 
         Returns:
             Dict[str, Any]: single `normsys` modifier for ``pyhf`` workspace
@@ -167,8 +167,8 @@ class WorkspaceBuilder:
         """Returns modifiers for a correlated shape + normalization effect.
 
         For a variation including a correlated shape + normalization effect, this
-        provides the `histosys` and `normsys` modifiers for ``pyhf`` (in `HistFactory` language,
-        this corresponds to a `HistoSys` and an `OverallSys`).
+        provides the `histosys` and `normsys` modifiers for ``pyhf`` (in `HistFactory`
+        language, this corresponds to a `HistoSys` and an `OverallSys`).
         Symmetrization could happen either at this stage (this is the case currently),
         or somewhere earlier, such as during template postprocessing.
 
@@ -178,7 +178,8 @@ class WorkspaceBuilder:
             systematic (Dict[str, Any]): the systematic variation under consideration
 
         Returns:
-            List[Dict[str, Any]]: a list with a ``pyhf`` `normsys` modifier and a `histosys` modifier
+            List[Dict[str, Any]]: a list with a ``pyhf`` `normsys` modifier and a
+            `histosys` modifier
         """
         # load the systematic variation histogram
         histogram_up = histo.Histogram.from_config(
@@ -196,10 +197,11 @@ class WorkspaceBuilder:
         )
 
         if systematic.get("Down", {}).get("Symmetrize", False):
-            # need to add support for two-sided variations that do not require symmetrization here
+            # add support for two-sided variations that do not require symmetrization
             # if symmetrization is desired, should support different implementations
 
-            # symmetrization according to "method 1" from issue #26: first normalization, then symmetrization
+            # symmetrization according to "method 1" from issue #26:
+            # first normalization, then symmetrization
 
             # normalize the variation to the same yield as nominal
             norm_effect = histogram_up.normalize_to_yield(histogram_nominal)
@@ -207,10 +209,11 @@ class WorkspaceBuilder:
             norm_effect_down = 2 - norm_effect
             histo_yield_up = histogram_up.yields.tolist()
             log.debug(
-                f"normalization impact of systematic {systematic['Name']} on sample {sample['Name']}"
-                f" in region {region['Name']} is {norm_effect:.3f}"
+                f"normalization impact of systematic {systematic['Name']} on sample "
+                f"{sample['Name']} in region {region['Name']} is {norm_effect:.3f}"
             )
-            # need another histogram that corresponds to the "down" variation, which is 2*nominal - up
+            # need another histogram that corresponds to the "down" variation, which is
+            # 2*nominal - up
             histo_yield_down = (
                 2 * histogram_nominal.yields - histogram_up.yields
             ).tolist()
@@ -270,14 +273,16 @@ class WorkspaceBuilder:
                 if systematic["Type"] == "Normalization":
                     # OverallSys (norm uncertainty with Gaussian constraint)
                     log.debug(
-                        f"adding OverallSys {systematic['Name']} to sample {sample['Name']}",
+                        f"adding OverallSys {systematic['Name']} to sample"
+                        f" {sample['Name']}",
                     )
                     modifiers.append(self.get_Normalization_modifier(systematic))
                 elif systematic["Type"] == "NormPlusShape":
                     # two modifiers are needed - an OverallSys for the norm effect,
                     # and a HistoSys for the shape variation
                     log.debug(
-                        f"adding OverallSys and HistoSys {systematic['Name']} to sample {sample['Name']}",
+                        f"adding OverallSys and HistoSys {systematic['Name']} to sample"
+                        f" {sample['Name']}",
                     )
                     modifiers += self.get_NormPlusShape_modifiers(
                         region, sample, systematic
@@ -325,7 +330,7 @@ class WorkspaceBuilder:
                 nf_modifier_list = self.get_NF_modifiers(sample)
                 modifiers += nf_modifier_list
 
-                # check if systematic uncertainties affect the samples, add modifiers as needed
+                # check if systematic uncertainties affect the samples, add modifiers
                 sys_modifier_list = self.get_sys_modifiers(region, sample)
                 modifiers += sys_modifier_list
 
@@ -438,7 +443,8 @@ def build(config: Dict[str, Any], with_validation: bool = True) -> Dict[str, Any
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        with_validation (bool, optional): validate workspace validity with pyhf, defaults to True
+        with_validation (bool, optional): validate workspace validity with pyhf,
+            defaults to True
 
     Returns:
         Dict[str, Any]: ``pyhf``-compatible `HistFactory` workspace
@@ -467,7 +473,8 @@ def save(ws: Dict[str, Any], file_path_string: Union[str, pathlib.Path]) -> None
 
     Args:
         ws (Dict[str, Any]): ``pyhf``-compatible `HistFactory` workspace
-        file_path_string (Union[str, pathlib.Path]): path to the file to save the workspace in
+        file_path_string (Union[str, pathlib.Path]): path to the file to save the
+            workspace in
     """
     file_path = pathlib.Path(file_path_string)
     log.debug(f"saving workspace to {file_path}")
@@ -482,7 +489,8 @@ def load(file_path_string: Union[str, pathlib.Path]) -> Dict[str, Any]:
     """Loads a workspace from a file.
 
     Args:
-        file_path_string (Union[str, pathlib.Path]): path to the file to load the workspace from
+        file_path_string (Union[str, pathlib.Path]): path to the file to load the
+            workspace from
 
     Returns:
         Dict[str, Any]: ``pyhf``-compatible `HistFactory` workspace

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -117,7 +117,8 @@ def test_Histogram_from_path(tmp_path, caplog, example_histograms, histogram_hel
     fname_modified = tmp_path / (histo_name + "_modified")
     fname_original = tmp_path / histo_name
     h_ref.save(fname_modified)
-    # load the modified histogram by specifying the original name, which should produce no warning
+    # load the modified histogram by specifying the original name, which should produce
+    # no warning
     h_from_path_modified = histo.Histogram.from_path(fname_original, modified=True)
     histogram_helpers.assert_equal(h_ref, h_from_path_modified)
     assert [rec.message for rec in caplog.records] == []

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -194,7 +194,7 @@ def test_integration(tmp_path, ntuple_creator):
     scan_results = cabinetry.fit.scan(
         ws, "Signal_norm", par_range=(1.18967971, 2.18967971), n_steps=3
     )
-    # lower edge of scan is beyond the normalization factor bounds specified in workspace
+    # lower edge of scan is beyond normalization factor bounds specified in workspace
     assert np.allclose(
         scan_results.delta_nlls, [0.27154057, 0.0, 0.29018711], atol=5e-5
     )

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -189,7 +189,7 @@ def test_Router__find_template_builder_match(processor_examples):
         wrapped_builder = example_router._find_template_builder_match("reg", "", "", "")
         assert mock_find.call_args_list == [(([], "reg", "", "", ""), {})]
 
-        # need to verify that the wrapped template builder is wrapped with the right function
+        # need to verify that wrapped template builder is wrapped with right function
         expected_wrap = example_wrapper(example_template_builder)
         assert wrapped_builder.__name__ == expected_wrap.__name__
 


### PR DESCRIPTION
The code is formatted by `black` to have a maximum line length of 88 characters. The current version of `black` does not re-format strings or comments. This updates all comments / docstrings to be limited to 88 characters per line, and re-formats strings as well. The `flake8` setting for `max-line-length` is updated to 88.