### PR TITLE
fix: visualization of three and more channels

### DIFF
--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -157,9 +157,7 @@ def data_MC(
 
     # slice the yields into an array where the first index is the channel,
     # and the second index is the sample
-    region_split_indices = [
-        model.config.channel_nbins[chan] for chan in model.config.channels
-    ][:-1]
+    region_split_indices = model_utils._get_channel_boundary_indices(model)
     model_yields = np.split(yields_combined, region_split_indices, axis=1)
     data = np.split(data_combined, region_split_indices)  # data just indexed by channel
 

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -1,3 +1,5 @@
+import copy
+
 import awkward1 as ak
 import numpy as np
 import pyhf
@@ -62,6 +64,23 @@ def test_get_prefit_uncertainties(
     model = pyhf.Workspace(example_spec_shapefactor).model()
     unc = model_utils.get_prefit_uncertainties(model)
     assert np.allclose(unc, [0.0, 0.0, 0.0])
+
+
+def test__get_channel_boundary_indices(example_spec_multibin):
+    model = pyhf.Workspace(example_spec_multibin).model()
+    indices = model_utils._get_channel_boundary_indices(model)
+    assert indices == [2]
+
+    # add extra channel to model to test three channels (two indices needed)
+    three_channel_model = copy.deepcopy(example_spec_multibin)
+    extra_channel = copy.deepcopy(three_channel_model["channels"][0])
+    extra_channel["name"] = "region_3"
+    extra_channel["samples"][0]["modifiers"][0]["name"] = "staterror_region_3"
+    three_channel_model["channels"].append(extra_channel)
+    three_channel_model["observations"].append({"data": [35, 8], "name": "region_3"})
+    model = pyhf.Workspace(three_channel_model).model()
+    indices = model_utils._get_channel_boundary_indices(model)
+    assert indices == [2, 3]
 
 
 def test_calculate_stdev(example_spec, example_spec_multibin):

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -66,7 +66,11 @@ def test_get_prefit_uncertainties(
     assert np.allclose(unc, [0.0, 0.0, 0.0])
 
 
-def test__get_channel_boundary_indices(example_spec_multibin):
+def test__get_channel_boundary_indices(example_spec, example_spec_multibin):
+    model = pyhf.Workspace(example_spec).model()
+    indices = model_utils._get_channel_boundary_indices(model)
+    assert indices == []
+
     model = pyhf.Workspace(example_spec_multibin).model()
     indices = model_utils._get_channel_boundary_indices(model)
     assert indices == [2]


### PR DESCRIPTION
This fixes the data/MC visualizations for workspaces with at least three channels. The split of `pyhf.pdf.Model.expected_data`  into channels was using wrong indices if more than two channels are in the workspace. This produced a crash.