### PR TITLE
feat: goodness of fit test with saturated model

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -111,5 +111,8 @@ ignore_missing_imports = True
 [mypy-scipy.optimize]
 ignore_missing_imports = True
 
+[mypy-scipy.stats]
+ignore_missing_imports = True
+
 [pytype]
 inputs = src/cabinetry

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -22,6 +22,7 @@ class FitResults(NamedTuple):
         labels (List[str]): parameter labels
         corr_mat (np.ndarray): parameter correlation matrix
         best_twice_nll (float): -2 log(likelihood) at best-fit point
+        goodess_of_fit (float, optional): goodness-of-fit p-value, defaults to -1
     """
 
     bestfit: np.ndarray
@@ -29,6 +30,7 @@ class FitResults(NamedTuple):
     labels: List[str]
     corr_mat: np.ndarray
     best_twice_nll: float
+    goodness_of_fit: float = -1
 
 
 class RankingResults(NamedTuple):

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -287,7 +287,7 @@ def _fit_model(
 def _goodness_of_fit(
     spec: Dict[str, Any],
     model: pyhf.pdf.Model,
-    fit_results: FitResults,
+    best_twice_nll: float,
     asimov: bool = False,
     custom_fit: bool = False,
 ) -> float:
@@ -297,8 +297,8 @@ def _goodness_of_fit(
         spec (Dict[str, Any]): a ``pyhf`` workspace specification
         model (pyhf.pdf.Model): model used in the fit for which goodness-of-fit should
             be calculated
-        fit_results (FitResults): fit result of fit for which goodness-of-fit should be
-            calculated
+        best_twice_nll (float): best-fit -2 log(likelihood) of fit for which goodness-
+            of-fit should be calculated
         asimov (bool, optional): whether to fit the Asimov dataset, defaults to False
         custom_fit (bool, optional): whether to use the ``pyhf.infer`` API or
             ``iminuit``, defaults to False (using ``pyhf.infer``)
@@ -321,7 +321,7 @@ def _goodness_of_fit(
     )
 
     log.info("calculating goodness-of-fit")
-    delta_nll = (fit_results.best_twice_nll - fit_results_sat.best_twice_nll) / 2
+    delta_nll = (best_twice_nll - fit_results_sat.best_twice_nll) / 2
     log.debug(f"Delta NLL = {delta_nll:.6f}")
 
     # calculate difference in degrees of freedom between fits, given by the number
@@ -377,7 +377,11 @@ def fit(
     if goodness_of_fit:
         # calculate goodness-of-fit with saturated model
         p_val = _goodness_of_fit(
-            spec, model, fit_results, asimov=asimov, custom_fit=custom_fit
+            spec,
+            model,
+            fit_results.best_twice_nll,
+            asimov=asimov,
+            custom_fit=custom_fit,
         )
         fit_results = fit_results._replace(goodness_of_fit=p_val)
 

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -345,7 +345,7 @@ def fit(
         # of bins minus the number of unconstrained parameters
         n_dof = sum(
             model.config.channel_nbins.values()
-        ) - model_utils.count_unconstrained_parameters(model)
+        ) - model_utils.unconstrained_parameter_count(model)
         log.debug(f"number of degrees of freedom: {n_dof}")
         p_val = scipy.stats.chi2.sf(2 * delta_nll, n_dof)
         log.info(f"p-value for goodness-of-fit test: {p_val*100:.2f}%")

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -287,7 +287,7 @@ def _fit_model(
 def _goodness_of_fit(
     model: pyhf.pdf.Model, data: List[float], best_twice_nll: float
 ) -> float:
-    """Calculates goodness-of-fit p-value with the saturated model.
+    """Calculates goodness-of-fit p-value with a saturated model.
 
     Args:
         model (pyhf.pdf.Model): model used in the fit for which goodness-of-fit should

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -204,7 +204,7 @@ class Histogram(bh.Histogram):
                 f"{not_empty_but_nan}",
             )
 
-    def normalize_to_yield(self, reference_histogram: H) -> np.float64:
+    def normalize_to_yield(self, reference_histogram: H) -> float:
         """Normalizes a histogram to match the yield of a reference.
 
         Returns the normalization factor used to normalize the histogram.
@@ -214,7 +214,7 @@ class Histogram(bh.Histogram):
                 normalize to
 
         Returns:
-            np.float64: the yield ratio: un-normalized yield / normalized yield
+            float: the yield ratio: un-normalized yield / normalized yield
         """
         target_integrated_yield = sum(reference_histogram.yields)
         current_integrated_yield = sum(self.yields)

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -12,7 +12,6 @@ log = logging.getLogger(__name__)
 def model_and_data(
     spec: Dict[str, Any],
     asimov: bool = False,
-    saturated: bool = False,
     with_aux: bool = True,
 ) -> Tuple[pyhf.pdf.Model, List[float]]:
     """Returns model and data for a ``pyhf`` workspace specification.
@@ -20,8 +19,6 @@ def model_and_data(
     Args:
         spec (Dict[str, Any]): a ``pyhf`` workspace specification
         asimov (bool, optional): whether to return the Asimov dataset, defaults to False
-        saturated (bool, optional): whether to build a saturated model (by adding shape-
-            factors to all bins), defaults to False
         with_aux (bool, optional): whether to also return auxdata, defaults to True
 
     Returns:
@@ -30,18 +27,6 @@ def model_and_data(
             - the data (plus auxdata if requested) for the model
     """
     workspace = pyhf.Workspace(spec)
-
-    if saturated:
-        # build a saturated model with shapefactors in all bins
-        for region in workspace["channels"]:
-            for sample in region["samples"]:
-                sample["modifiers"].append(
-                    {
-                        "name": "shapefactor_saturated_" + region["name"],
-                        "type": "shapefactor",
-                        "data": None,
-                    }
-                )
 
     model = workspace.model(
         modifier_settings={

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -285,7 +285,8 @@ def unconstrained_parameter_count(model: pyhf.pdf.Model) -> int:
     """Returns the number of unconstrained parameters in a model.
 
     The number is the sum of all independent parameters in a fit. A shapefactor that
-    affects multiple bins enters the count once for each independent bin.
+    affects multiple bins enters the count once for each independent bin. Parameters
+    that are set to constant are not included in the count.
 
     Args:
         model (pyhf.pdf.Model): model to count parameters for
@@ -295,6 +296,9 @@ def unconstrained_parameter_count(model: pyhf.pdf.Model) -> int:
     """
     n_pars = 0
     for parname in model.config.par_order:
-        if not model.config.param_set(parname).constrained:
+        if (
+            not model.config.param_set(parname).constrained
+            and not model.config.param_set(parname).suggested_fixed
+        ):
             n_pars += model.config.param_set(parname).n_parameters
     return n_pars

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -10,9 +10,7 @@ log = logging.getLogger(__name__)
 
 
 def model_and_data(
-    spec: Dict[str, Any],
-    asimov: bool = False,
-    with_aux: bool = True,
+    spec: Dict[str, Any], asimov: bool = False, with_aux: bool = True
 ) -> Tuple[pyhf.pdf.Model, List[float]]:
     """Returns model and data for a ``pyhf`` workspace specification.
 
@@ -27,7 +25,6 @@ def model_and_data(
             - the data (plus auxdata if requested) for the model
     """
     workspace = pyhf.Workspace(spec)
-
     model = workspace.model(
         modifier_settings={
             "normsys": {"interpcode": "code4"},

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -32,7 +32,7 @@ def model_and_data(
     workspace = pyhf.Workspace(spec)
 
     if saturated:
-        # build a saturated model, with shapefactors in all bins
+        # build a saturated model with shapefactors in all bins
         for region in workspace["channels"]:
             for sample in region["samples"]:
                 sample["modifiers"].append(
@@ -281,7 +281,7 @@ def calculate_stdev(
     return total_stdev
 
 
-def count_unconstrained_parameters(model: pyhf.pdf.Model) -> int:
+def unconstrained_parameter_count(model: pyhf.pdf.Model) -> int:
     """Returns the number of unconstrained parameters in a model.
 
     The number is the sum of all independent parameters in a fit. A shapefactor that

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -279,3 +279,22 @@ def calculate_stdev(
     total_stdev = np.sqrt(total_variance)
     log.debug(f"total stdev is {total_stdev}")
     return total_stdev
+
+
+def count_unconstrained_parameters(model: pyhf.pdf.Model) -> int:
+    """Returns the number of unconstrained parameters in a model.
+
+    The number is the sum of all independent parameters in a fit. A shapefactor that
+    affects multiple bins enters the count once for each independent bin.
+
+    Args:
+        model (pyhf.pdf.Model): model to count parameters for
+
+    Returns:
+        int: number of unconstrained parameters
+    """
+    n_pars = 0
+    for parname in model.config.par_order:
+        if not model.config.param_set(parname).constrained:
+            n_pars += model.config.param_set(parname).n_parameters
+    return n_pars

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -12,17 +12,17 @@ log = logging.getLogger(__name__)
 def model_and_data(
     spec: Dict[str, Any],
     asimov: bool = False,
-    with_aux: bool = True,
     saturated: bool = False,
+    with_aux: bool = True,
 ) -> Tuple[pyhf.pdf.Model, List[float]]:
     """Returns model and data for a ``pyhf`` workspace specification.
 
     Args:
         spec (Dict[str, Any]): a ``pyhf`` workspace specification
         asimov (bool, optional): whether to return the Asimov dataset, defaults to False
-        with_aux (bool, optional): whether to also return auxdata, defaults to True
         saturated (bool, optional): whether to build a saturated model (by adding shape-
             factors to all bins), defaults to False
+        with_aux (bool, optional): whether to also return auxdata, defaults to True
 
     Returns:
         Tuple[pyhf.pdf.Model, List[float]]:

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -274,6 +274,7 @@ def test__goodness_of_fit(mock_count, example_spec_multibin, caplog):
     assert mock_count.call_args[1] == {}
     assert "Delta NLL = 0.084185" in [rec.message for rec in caplog.records]
     assert np.allclose(p_val, 0.91926079)
+    caplog.clear()
 
 
 @mock.patch("cabinetry.fit._goodness_of_fit", return_value=0.1)

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -21,6 +21,7 @@ def test_FitResults():
     assert fit_results.labels == labels
     assert np.allclose(fit_results.corr_mat, corr_mat)
     assert fit_results.best_twice_nll == best_twice_nll
+    assert fit_results.goodness_of_fit == -1
 
 
 def test_RankingResults():
@@ -262,6 +263,7 @@ def test__fit_model(mock_pyhf, mock_custom, example_spec):
     assert np.allclose(fit_results.bestfit, [1.2])
 
 
+@mock.patch("cabinetry.fit._goodness_of_fit", return_value=0.1)
 @mock.patch("cabinetry.fit.print_results")
 @mock.patch(
     "cabinetry.fit._fit_model",
@@ -270,7 +272,7 @@ def test__fit_model(mock_pyhf, mock_custom, example_spec):
     ),
 )
 @mock.patch("cabinetry.model_utils.model_and_data", return_value=("model", "data"))
-def test_fit(mock_load, mock_fit, mock_print, example_spec):
+def test_fit(mock_load, mock_fit, mock_print, mock_gof, example_spec):
     # fit through pyhf.infer API
     fit_results = fit.fit(example_spec)
     assert mock_load.call_args_list == [[(example_spec,), {"asimov": False}]]
@@ -309,6 +311,14 @@ def test_fit(mock_load, mock_fit, mock_print, example_spec):
     assert mock_fit.call_count == 5
     assert mock_fit.call_args[1] == {"minos": ["abc"], "custom_fit": True}
     assert fit_results.bestfit == [1.0]
+
+    # goodness-of-fit test
+    fit_results_gof = fit.fit(example_spec, goodness_of_fit=True)
+    # fit_results handed to function are from nominal fit
+    assert mock_gof.call_args_list == [
+        [(example_spec, "model", fit_results), {"asimov": False, "custom_fit": False}]
+    ]
+    assert fit_results_gof.goodness_of_fit == 0.1
 
 
 @mock.patch(

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -263,6 +263,51 @@ def test__fit_model(mock_pyhf, mock_custom, example_spec):
     assert np.allclose(fit_results.bestfit, [1.2])
 
 
+@mock.patch("cabinetry.model_utils.unconstrained_parameter_count", return_value=1)
+@mock.patch(
+    "cabinetry.fit._fit_model",
+    return_value=fit.FitResults(
+        np.asarray([1.0]), np.asarray([0.1]), ["par"], np.empty(0), 1.0
+    ),
+)
+def test__goodness_of_fit(mock_fit, mock_count, example_spec_multibin):
+    model, data = model_utils.model_and_data(example_spec_multibin)
+
+    p_val = fit._goodness_of_fit(example_spec_multibin, model, 2.0)
+    assert mock_fit.call_count == 1
+    for i in range(2):
+        assert mock_fit.call_args[0][0].spec["channels"][i]["samples"][0]["modifiers"][
+            -1
+        ] == {
+            "name": f"shapefactor_saturated_region_{i+1}",
+            "type": "shapefactor",
+            "data": None,
+        }
+    assert mock_fit.call_args[0][1] == data
+    assert mock_fit.call_args[1] == {
+        "fix_pars": [True, True, True, False, False, True, False],
+        "custom_fit": False,
+    }
+    assert mock_count.call_count == 1
+    assert mock_count.call_args[0][0].spec == model.spec
+    assert mock_count.call_args[1] == {}
+    assert np.allclose(p_val, 0.60653066)
+
+    # Asimov
+    with mock.patch(
+        "cabinetry.model_utils.model_and_data", return_value=(model, data)
+    ) as mock_load:
+        fit._goodness_of_fit(example_spec_multibin, model, 2.0, asimov=True)
+        assert mock_load.call_args[1] == {"asimov": True, "saturated": True}
+
+    # custom fit
+    fit._goodness_of_fit(example_spec_multibin, model, 2.0, custom_fit=True)
+    assert mock_fit.call_args[1] == {
+        "fix_pars": [True, True, True, False, False, True, False],
+        "custom_fit": True,
+    }
+
+
 @mock.patch("cabinetry.fit._goodness_of_fit", return_value=0.1)
 @mock.patch("cabinetry.fit.print_results")
 @mock.patch(
@@ -314,9 +359,8 @@ def test_fit(mock_load, mock_fit, mock_print, mock_gof, example_spec):
 
     # goodness-of-fit test
     fit_results_gof = fit.fit(example_spec, goodness_of_fit=True)
-    # fit_results handed to function are from nominal fit
     assert mock_gof.call_args_list == [
-        [(example_spec, "model", fit_results), {"asimov": False, "custom_fit": False}]
+        [(example_spec, "model", 2.0), {"asimov": False, "custom_fit": False}]
     ]
     assert fit_results_gof.goodness_of_fit == 0.1
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -142,7 +142,7 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     assert np.allclose(fit_results.uncertainty, uncertainty_expected)
     assert np.allclose(fit_results.best_twice_nll, best_twice_nll_expected)
     assert np.allclose(fit_results.corr_mat, corr_mat_expected, rtol=1e-4)
-    assert np.allclose(fit_results.goodness_of_fit, 0.24679939)
+    assert np.allclose(fit_results.goodness_of_fit, 0.24679341)
 
     # minos result
     assert "Signal_norm                    = 1.6895 -0.9580 +0.9052" in [

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -33,7 +33,7 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     ws = cabinetry.workspace.build(cabinetry_config)
     cabinetry.workspace.save(ws, workspace_path)
     ws = cabinetry.workspace.load(workspace_path)
-    fit_results = cabinetry.fit.fit(ws, minos="Signal_norm")
+    fit_results = cabinetry.fit.fit(ws, minos="Signal_norm", goodness_of_fit=True)
 
     bestfit_expected = [
         1.00102289,
@@ -142,6 +142,7 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     assert np.allclose(fit_results.uncertainty, uncertainty_expected)
     assert np.allclose(fit_results.best_twice_nll, best_twice_nll_expected)
     assert np.allclose(fit_results.corr_mat, corr_mat_expected, rtol=1e-4)
+    assert np.allclose(fit_results.goodness_of_fit, 0.24679939)
 
     # minos result
     assert "Signal_norm                    = 1.6895 -0.9580 +0.9052" in [

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -20,16 +20,6 @@ def test_model_and_data(example_spec, example_spec_multibin):
     model, data = model_utils.model_and_data(example_spec, asimov=True)
     assert data == [51.839756, 1.0]
 
-    # saturated model
-    model, data = model_utils.model_and_data(example_spec_multibin, saturated=True)
-    for channel in model.spec["channels"]:
-        for sample in channel["samples"]:
-            assert sample["modifiers"][-1] == {
-                "name": "shapefactor_saturated_" + channel["name"],
-                "type": "shapefactor",
-                "data": None,
-            }
-
     # without auxdata
     model, data = model_utils.model_and_data(example_spec, with_aux=False)
     assert data == [475]

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -139,3 +139,11 @@ def test_calculate_stdev(example_spec, example_spec_multibin):
     expected_stdev = [[8.056054, 1.670629], [2.775377]]
     for i_reg in range(2):
         assert np.allclose(ak.to_list(total_stdev[i_reg]), expected_stdev[i_reg])
+
+
+def test_unconstrained_parameter_count(example_spec, example_spec_shapefactor):
+    model = pyhf.Workspace(example_spec).model()
+    assert model_utils.unconstrained_parameter_count(model) == 1
+
+    model = pyhf.Workspace(example_spec_shapefactor).model()
+    assert model_utils.unconstrained_parameter_count(model) == 3

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -147,3 +147,10 @@ def test_unconstrained_parameter_count(example_spec, example_spec_shapefactor):
 
     model = pyhf.Workspace(example_spec_shapefactor).model()
     assert model_utils.unconstrained_parameter_count(model) == 3
+
+    # fixed parameters are skipped in counting
+    example_spec_shapefactor["measurements"][0]["config"]["parameters"].append(
+        {"name": "Signal strength", "fixed": True}
+    )
+    model = pyhf.Workspace(example_spec_shapefactor).model()
+    assert model_utils.unconstrained_parameter_count(model) == 2

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -7,7 +7,7 @@ import pyhf
 from cabinetry import model_utils
 
 
-def test_model_and_data(example_spec):
+def test_model_and_data(example_spec, example_spec_multibin):
     model, data = model_utils.model_and_data(example_spec)
     assert model.spec["channels"] == example_spec["channels"]
     assert model.config.modifier_settings == {
@@ -23,6 +23,16 @@ def test_model_and_data(example_spec):
     # without auxdata
     model, data = model_utils.model_and_data(example_spec, with_aux=False)
     assert data == [475]
+
+    # saturated model
+    model, data = model_utils.model_and_data(example_spec_multibin, saturated=True)
+    for channel in model.spec["channels"]:
+        for sample in channel["samples"]:
+            assert sample["modifiers"][-1] == {
+                "name": "shapefactor_saturated_" + channel["name"],
+                "type": "shapefactor",
+                "data": None,
+            }
 
 
 def test_get_parameter_names(example_spec):

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -7,7 +7,7 @@ import pyhf
 from cabinetry import model_utils
 
 
-def test_model_and_data(example_spec, example_spec_multibin):
+def test_model_and_data(example_spec):
     model, data = model_utils.model_and_data(example_spec)
     assert model.spec["channels"] == example_spec["channels"]
     assert model.config.modifier_settings == {

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -20,10 +20,6 @@ def test_model_and_data(example_spec, example_spec_multibin):
     model, data = model_utils.model_and_data(example_spec, asimov=True)
     assert data == [51.839756, 1.0]
 
-    # without auxdata
-    model, data = model_utils.model_and_data(example_spec, with_aux=False)
-    assert data == [475]
-
     # saturated model
     model, data = model_utils.model_and_data(example_spec_multibin, saturated=True)
     for channel in model.spec["channels"]:
@@ -33,6 +29,10 @@ def test_model_and_data(example_spec, example_spec_multibin):
                 "type": "shapefactor",
                 "data": None,
             }
+
+    # without auxdata
+    model, data = model_utils.model_and_data(example_spec, with_aux=False)
+    assert data == [475]
 
 
 def test_get_parameter_names(example_spec):


### PR DESCRIPTION
Adding a goodness-of-fit-calculation based on the [saturated model](http://www.physics.ucla.edu/~cousins/stats/cousins_saturated.pdf). A chi^2 test is performed using the likelihood ratio between the nominal fit and the saturated likelihood. The resulting p-value is added to the `FitResults` object, and defaults to `-1` if the calculation is not performed.

This implementation makes use of https://github.com/scikit-hep/pyhf/issues/1169, enabling a significant simplification over the previous implementation(which was complete as of 90a40b2e21b4a1be17ea325d12323f1b1ffaeaa6, related issue https://github.com/scikit-hep/pyhf/issues/1098 would have allowed for an alternative implementation with a `model_utils` function that translates model -> saturated model).

resolves #127