### PR TITLE
feat: adding functionality to run MINOS

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     numpy
     pyyaml
     pyhf>=0.5.2  # return_by_sample #731
-    iminuit>1.4.0
+    iminuit>1.5.1 # np_merrors(), parameter limit warning
     boost_histogram
     jsonschema
     click


### PR DESCRIPTION
Allows to run `cabinetry.fit.fit` with optional argument that takes a single parameter or a list of parameters for which the MINOS algorithm is run. The resulting uncertainties are then reported.

related issue: #46