### PR TITLE
style: docstring line length

### DIFF
--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -30,8 +30,8 @@ def load(file_path_string: Union[str, pathlib.Path]) -> Dict[str, Any]:
 def validate(config: Dict[str, Any]) -> bool:
     """Returns True if the config file is validated, otherwise raises exceptions.
 
-    Checks that the config satisfies the json schema, and performs additional
-    checks to validate the config further.
+    Checks that the config satisfies the json schema, and performs additional checks to
+    validate the config further.
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
@@ -81,14 +81,13 @@ def print_overview(config: Dict[str, Any]) -> None:
 def _convert_setting_to_list(setting: Union[str, List[str]]) -> List[str]:
     """Converts a configuration setting to a list.
 
-    The config allows for two ways of specifying some settings, for example
-    samples. A single sample is specified as ``"Samples": "ABC"``, a list
-    of samples as ``"Samples": ["ABC", "DEF"]``. For consistent treatment,
-    the single sample is converted to a list.
+    The config allows for two ways of specifying some settings, for example samples. A
+    single sample is specified as ``"Samples": "ABC"``, a list of samples as
+    ``"Samples": ["ABC", "DEF"]``. For consistent treatment, the single sample is
+    converted to a list.
 
     Args:
-        setting (Union[str, List[str]]): name of single setting value or
-            list of values
+        setting (Union[str, List[str]]): name of single setting value or list of values
 
     Returns:
         list: name(s) of sample(s)
@@ -105,8 +104,8 @@ def sample_affected_by_modifier(
 
     Args:
         sample (Dict[str, Any]): containing all sample information
-        modifier (Dict[str, Any]): containing all modifier information
-            (a Systematic or a NormFactor)
+        modifier (Dict[str, Any]): containing all modifier information (a Systematic or
+            a NormFactor)
 
     Returns:
         bool: True if sample is affected, False otherwise
@@ -134,8 +133,8 @@ def histogram_is_needed(
         template (str): which template is considered: "Nominal", "Up", "Down"
 
     Raises:
-        NotImplementedError: non-supported systematic variations based on histograms
-            are requested
+        NotImplementedError: non-supported systematic variations based on histograms are
+            requested
 
     Returns:
         bool: whether a histogram is needed

--- a/src/cabinetry/contrib/histogram_creation.py
+++ b/src/cabinetry/contrib/histogram_creation.py
@@ -24,10 +24,10 @@ def from_uproot(
         pos_in_file (str): name of tree within ntuple
         variable (str): variable to bin histogram in
         bins (numpy.ndarray): bin edges for histogram
-        weight (Optional[str], optional): event weight to extract,
-            defaults to None (no weights applied)
-        selection_filter (Optional[str], optional): filter to be applied
-            on events, defaults to None (no filter)
+        weight (Optional[str], optional): event weight to extract, defaults to None (no
+            weights applied)
+        selection_filter (Optional[str], optional): filter to be applied on events,
+            defaults to None (no filter)
 
     Returns:
         Tuple[np.ndarray, np.ndarray]:

--- a/src/cabinetry/contrib/matplotlib_visualize.py
+++ b/src/cabinetry/contrib/matplotlib_visualize.py
@@ -20,11 +20,10 @@ def data_MC(
     """Draws a data/MC histogram with uncertainty bands and ratio panel.
 
     Args:
-        histogram_dict_list (List[Dict[str, Any]]): list of samples (with info
-            stored in one dict per sample)
-        total_model_unc (np.ndarray): total model uncertainty, if specified
-            this is used instead of calculating it via sum in quadrature,
-            defaults to None
+        histogram_dict_list (List[Dict[str, Any]]): list of samples (with info stored in
+            one dict per sample)
+        total_model_unc (np.ndarray): total model uncertainty, if specified this is used
+            instead of calculating it via sum in quadrature, defaults to None
         bin_edges (np.ndarray): bin edges of histogram
         figure_path (pathlib.Path): path where figure should be saved
         log_scale (Optional[bool], optional): whether to use a logarithmic vertical
@@ -243,7 +242,7 @@ def pulls(
     """Draws a pull plot.
 
     Args:
-        bestfit (np.ndarray): [description]
+        bestfit (np.ndarray): best-fit parameter results
         uncertainty (np.ndarray): parameter uncertainties
         labels (Union[List[str], np.ndarray]): parameter names
         figure_path (pathlib.Path): path where figure should be saved

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -59,13 +59,13 @@ class Histogram(bh.Histogram):
     def from_path(cls: Type[H], histo_path: pathlib.Path, modified: bool = True) -> H:
         """Builds a histogram from disk.
 
-        Loads the "modified" version of the histogram by default (which received
-        post-processing).
+        Loads the "modified" version of the histogram by default (which received post-
+        processing).
 
         Args:
             histo_path (pathlib.Path): where the histogram is located
-            modified (bool, optional): whether to load the modified histogram
-                (after post-processing), defaults to True
+            modified (bool, optional): whether to load the modified histogram (after
+                post-processing), defaults to True
 
         Returns:
             cabinetry.histo.Histogram: the loaded histogram
@@ -177,8 +177,8 @@ class Histogram(bh.Histogram):
     def validate(self, name: str) -> None:
         """Runs consistency checks on a histogram.
 
-        Checks for empty bins and ill-defined statistical uncertainties.
-        Logs warnings if issues are founds, but does not raise exceptions.
+        Checks for empty bins and ill-defined statistical uncertainties. Logs warnings
+        if issues are founds, but does not raise exceptions.
 
         Args:
             name (str): name of the histogram for logging purposes
@@ -210,8 +210,8 @@ class Histogram(bh.Histogram):
         Returns the normalization factor used to normalize the histogram.
 
         Args:
-            reference_histogram (cabinetry.histo.Histogram): reference histogram
-                to normalize to
+            reference_histogram (cabinetry.histo.Histogram): reference histogram to
+                normalize to
 
         Returns:
             np.float64: the yield ratio: un-normalized yield / normalized yield
@@ -236,8 +236,8 @@ def build_name(
         region (Dict[str, Any]): containing all region information
         sample (Dict[str, Any]): containing all sample information
         systematic (Dict[str, Any]): containing all systematic information
-        template (str): which template (nominal/up/down) to consider,
-            defaults to "Nominal"
+        template (str): which template (nominal/up/down) to consider, defaults to
+            "Nominal"
 
     Returns:
         str: unique name for the histogram

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -16,10 +16,8 @@ def model_and_data(
 
     Args:
         spec (Dict[str, Any]): a ``pyhf`` workspace specification
-        asimov (bool, optional): whether to return the Asimov dataset, defaults
-            to False
-        with_aux (bool, optional): whether to also return auxdata, defaults
-            to True
+        asimov (bool, optional): whether to return the Asimov dataset, defaults to False
+        with_aux (bool, optional): whether to also return auxdata, defaults to True
 
     Returns:
         Tuple[pyhf.pdf.Model, List[float]]:
@@ -66,10 +64,8 @@ def build_Asimov_data(model: pyhf.Model, with_aux: bool = True) -> List[float]:
     """Returns the Asimov dataset (optionally with auxdata) for a model.
 
     Args:
-        model (pyhf.Model): the model from which to construct the
-            dataset
-        with_aux (bool, optional): whether to also return auxdata, defaults
-            to True
+        model (pyhf.Model): the model from which to construct the dataset
+        with_aux (bool, optional): whether to also return auxdata, defaults to True
 
     Returns:
         List[float]: the Asimov dataset
@@ -119,16 +115,15 @@ def get_asimov_parameters(model: pyhf.pdf.Model) -> np.ndarray:
 def get_prefit_uncertainties(model: pyhf.pdf.Model) -> np.ndarray:
     """Returns a list of pre-fit parameter uncertainties for a model.
 
-    For unconstrained parameters the uncertainty is set to 0. It is also
-    set to 0 for fixed parameters (similarly to how their post-fit
-    uncertainties are defined to be 0).
+    For unconstrained parameters the uncertainty is set to 0. It is also set to 0 for
+    fixed parameters (similarly to how the post-fit uncertainties are defined to be 0).
 
     Args:
         model (pyhf.pdf.Model): model for which to extract the parameters
 
     Returns:
-        np.ndarray: pre-fit uncertainties for the parameters, in the same
-        order as ``model.config.suggested_init()``
+        np.ndarray: pre-fit uncertainties for the parameters, in the same order as
+        ``model.config.suggested_init()``
     """
     pre_fit_unc = []  # pre-fit uncertainties for parameters
     for parameter in model.config.par_order:
@@ -179,15 +174,15 @@ def calculate_stdev(
     """Calculates the symmetrized yield standard deviation of a model.
 
     Args:
-        model (pyhf.pdf.Model): the model for which to calculate the standard
-            deviations for all bins
+        model (pyhf.pdf.Model): the model for which to calculate the standard deviations
+            for all bins
         parameters (np.ndarray): central values of model parameters
         uncertainty (np.ndarray): uncertainty of model parameters
         corr_mat (np.ndarray): correlation matrix
 
     Returns:
-        ak.highlevel.Array: array of channels, each channel
-        is an array of standard deviations per bin
+        ak.highlevel.Array: array of channels, each channel is an array of standard
+        deviations per bin
     """
     # indices where to split to separate all bins into regions
     region_split_indices = _get_channel_boundary_indices(model)

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -74,8 +74,8 @@ class Router:
                 or None to apply to all samples
             systematic_name  (Optional[str]): name of the systematic to apply the
                 function to, or None to apply to all systematics
-            template (Optional[str]): name of the template to apply the function to,
-                or None to apply to all templates
+            template (Optional[str]): name of the template to apply the function to, or
+                None to apply to all templates
 
         Returns:
             Callable[[GenericProcessorFunc], GenericProcessorFunc]: the function to

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -19,9 +19,9 @@ def _check_for_override(
 ) -> Optional[Union[str, List[str]]]:
     """Returns an override if specified by a template of a systematic.
 
-    Given a systematic and a string specifying which template is currently
-    under consideration, check whether the systematic defines an override
-    for an option. Return the override if it exists, otherwise return None.
+    Given a systematic and a string specifying which template is currently under
+    consideration, check whether the systematic defines an override for an option.
+    Return the override if it exists, otherwise return None.
 
     Args:
         systematic (Dict[str, Any]): containing all systematic information
@@ -29,8 +29,8 @@ def _check_for_override(
         option (str): the option for which the presence of an override is checked
 
     Returns:
-        Optional[Union[str, List[str]]]: either None if no override exists,
-        or the override
+        Optional[Union[str, List[str]]]: either None if no override exists, or the
+        override
     """
     return systematic.get(template, {}).get(option, None)
 
@@ -44,16 +44,16 @@ def _get_ntuple_paths(
 ) -> List[pathlib.Path]:
     """Returns the paths to ntuples for a region-sample-systematic-template.
 
-    A path is built starting from the path specified in the general options
-    in the configuration file. This path can contain placeholders for region-
-    and sample-specific overrides, via ``{Region}`` and ``{Sample}``. For
-    non-nominal templates, it is possible to override the sample path if the
-    ``SamplePaths`` option is specified for the template. If ``SamplePaths``
-    is a list, return a list of paths (one per entry in the list).
+    A path is built starting from the path specified in the general options in the
+    configuration file. This path can contain placeholders for region- and sample-
+    specific overrides, via ``{Region}`` and ``{Sample}``. For non-nominal templates, it
+    is possible to override the sample path if the ``SamplePaths`` option is specified
+    for the template. If ``SamplePaths`` is a list, return a list of paths (one per
+    entry in the list).
 
     Args:
-        general_path (str): path specified in general settings, with sections
-            that can be overridden by region / sample settings
+        general_path (str): path specified in general settings, with sections that can
+            be overridden by region / sample settings
         region (Dict[str, Any]): containing all region information
         sample (Dict[str, Any]): containing all sample information
         systematic (Dict[str, Any]): containing all systematic information
@@ -172,8 +172,8 @@ def _get_weight(
         template (str): which template is considered: "Nominal", "Up", "Down"
 
     Returns:
-        Optional[str]: weight used for events when filled into histograms, or
-        None for no weight
+        Optional[str]: weight used for events when filled into histograms, or None for
+        no weight
     """
     weight = sample.get("Weight", None)
     # check whether a systematic is being processed
@@ -214,8 +214,8 @@ def _get_position_in_file(
 def _get_binning(region: Dict[str, Any]) -> np.ndarray:
     """Returns the binning to be used in a region.
 
-    Should eventually also support other ways of specifying bins,
-    such as the amount of bins and the range to bin in.
+    Should eventually also support other ways of specifying bins, such as the amount of
+    bins and the range to bin in.
 
     Args:
         region (Dict[str, Any]): containing all region information
@@ -258,8 +258,8 @@ class _Builder:
     ) -> None:
         """Creates a histogram and writes it to a file.
 
-        The histogram is created for the region-sample-systematic-template
-        specified in the argument.
+        The histogram is created for the region-sample-systematic-template specified in
+        the argument.
 
         Args:
             region (Dict[str, Any]): specifying region information
@@ -380,8 +380,8 @@ def create_histograms(
 ) -> None:
     """Produces all required histograms specified by the configuration file.
 
-    Uses either a default method specified via ``method``, or a custom
-    user-defined override through ``router``.
+    Uses either a default method specified via ``method``, or a custom user-defined
+    override through ``router``.
 
     Args:
         config (Dict[str, Any]): cabinetry configuration

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -30,9 +30,9 @@ def _fix_stat_unc(histogram: histo.Histogram, name: str) -> None:
 def apply_postprocessing(histogram: histo.Histogram, name: str) -> histo.Histogram:
     """Returns a new histogram with post-processing applied.
 
-    The histogram handed to the function stays unchanged. A copy of the
-    histogram receives post-processing (currently only the stat. uncertainty
-    fix) and is then returned.
+    The histogram handed to the function stays unchanged. A copy of the histogram
+    receives post-processing (currently only the stat. uncertainty fix) and is then
+    returned.
 
     Args:
         histogram (cabinetry.histo.Histogram): the histogram to postprocess
@@ -50,8 +50,8 @@ def apply_postprocessing(histogram: histo.Histogram, name: str) -> histo.Histogr
 def _get_postprocessor(histogram_folder: pathlib.Path) -> route.ProcessorFunc:
     """Returns the post-processing function to be applied to template histograms.
 
-    Needed by ``cabinetry.route.apply_to_all_templates``. Could alternatively
-    create a ``Postprocessor`` class that contains processors.
+    Needed by ``cabinetry.route.apply_to_all_templates``. Could alternatively create a
+    ``Postprocessor`` class that contains processors.
 
     Args:
         histogram_folder (Union[str, pathlib.Path]): folder containing histograms

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -227,8 +227,8 @@ def correlation_matrix(
     """Draws a correlation matrix.
 
     Args:
-        fit_results (fit.FitResults): fit results, including correlation matrix
-            and parameter labels
+        fit_results (fit.FitResults): fit results, including correlation matrix and
+            parameter labels
         figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
         pruning_threshold (float, optional): minimum correlation for a parameter to
             have with any other parameters to not get pruned, defaults to 0.0
@@ -276,8 +276,8 @@ def pulls(
     """Draws a pull plot of parameter results and uncertainties.
 
     Args:
-        fit_results (fit.FitResults): fit results, including correlation matrix
-            and parameter labels
+        fit_results (fit.FitResults): fit results, including correlation matrix and
+            parameter labels
         figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
         exclude_list (Optional[List[str]], optional): list of parameters to exclude from
             plot, defaults to None (nothing excluded)

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -41,16 +41,16 @@ class WorkspaceBuilder:
     def _get_constant_parameter_setting(self, par_name: str) -> Optional[float]:
         """Determines whether a parameter should be set to constant, and to which value.
 
-        For a given parameter, determines if it is supposed to be set to constant.
-        If not, returns None, otherwise returns the value it should be fixed to.
-        This only looks for the first occurrence of the parameter in the list.
+        For a given parameter, determines if it is supposed to be set to constant. If
+        not, returns None, otherwise returns the value it should be fixed to. This only
+        looks for the first occurrence of the parameter in the list.
 
         Args:
             par_name (str): name of parameter to check
 
         Returns:
-            Optional[float]: returns None if parameter is not supposed to be
-            held constant, or the value it has to be fixed to
+            Optional[float]: returns None if parameter is not supposed to be held
+            constant, or the value it has to be fixed to
         """
         fixed_parameters = self.config["General"].get("Fixed", [])
         fixed_value = next(
@@ -168,9 +168,9 @@ class WorkspaceBuilder:
 
         For a variation including a correlated shape + normalization effect, this
         provides the `histosys` and `normsys` modifiers for ``pyhf`` (in `HistFactory`
-        language, this corresponds to a `HistoSys` and an `OverallSys`).
-        Symmetrization could happen either at this stage (this is the case currently),
-        or somewhere earlier, such as during template postprocessing.
+        language, this corresponds to a `HistoSys` and an `OverallSys`). Symmetrization
+        could happen either at this stage (this is the case currently), or somewhere
+        earlier, such as during template postprocessing.
 
         Args:
             region (Dict[str, Any]): region the systematic variation acts in
@@ -343,9 +343,9 @@ class WorkspaceBuilder:
     def get_measurements(self) -> List[Dict[str, Any]]:
         """Returns the measurements object for the workspace.
 
-        Constructs the measurements, including POI setting and parameter bounds,
-        initial values and whether they are set to constant.
-        Only supports a single measurement so far.
+        Constructs the measurements, including POI setting and parameter bounds, initial
+        values and whether they are set to constant. Only supports a single measurement
+        so far.
 
         Returns:
             List[Dict[str, Any]]: measurements for ``pyhf`` workspace


### PR DESCRIPTION
Updating docstrings to maximum line length of 88, which was introduced in #128.