### PR TITLE
fix: pyhf 0.5.3 compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ python_requires = >=3.6
 install_requires =
     numpy
     pyyaml
-    pyhf>=0.5.2  # return_by_sample #731
+    pyhf>=0.5.3  # paramset.suggested_fixed
     iminuit>1.5.1 # np_merrors(), parameter limit warning
     boost_histogram
     jsonschema

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -138,7 +138,7 @@ def get_prefit_uncertainties(model: pyhf.pdf.Model) -> np.ndarray:
         # obtain pre-fit uncertainty for constrained, non-fixed parameters
         if (
             model.config.param_set(parameter).constrained
-            and not model.config.param_set(parameter).fixed
+            and not model.config.param_set(parameter).suggested_fixed
         ):
             pre_fit_unc += model.config.param_set(parameter).width()
         else:


### PR DESCRIPTION
In https://github.com/scikit-hep/pyhf/pull/1110, `paramset.fixed` was renamed to `paramset.suggested_fixed`. This change will go into `pyhf` 0.5.3 when it is released.

This updates the naming and raises minimum `pyhf` version to 0.5.3.

This pull request should be merged directly after the next version of `pyhf` is released.