### PR TITLE
feat: treat initial normalization factor settings as nominal values

### DIFF
--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -77,8 +77,8 @@ def build_Asimov_data(model: pyhf.Model, with_aux: bool = True) -> List[float]:
     """
     asimov_data = model.expected_data(
         get_asimov_parameters(model), include_auxdata=with_aux
-    )
-    return asimov_data.tolist()
+    ).tolist()
+    return asimov_data
 
 
 def get_asimov_parameters(model: pyhf.pdf.Model) -> np.ndarray:

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -63,6 +63,11 @@ def get_parameter_names(model: pyhf.pdf.Model) -> List[str]:
 def build_Asimov_data(model: pyhf.Model, with_aux: bool = True) -> List[float]:
     """Returns the Asimov dataset (optionally with auxdata) for a model.
 
+    Initial parameter settings for normalization factors in the workspace are treated as
+    the default settings for that parameter. Fitting the Asimov dataset will recover
+    these initial settings as the maximum likelihood estimate for normalization factors.
+    Initial settings for other modifiers are ignored.
+
     Args:
         model (pyhf.Model): the model from which to construct the dataset
         with_aux (bool, optional): whether to also return auxdata, defaults to True
@@ -70,14 +75,17 @@ def build_Asimov_data(model: pyhf.Model, with_aux: bool = True) -> List[float]:
     Returns:
         List[float]: the Asimov dataset
     """
-    asimov_data = np.sum(model.nominal_rates, axis=1)[0][0].tolist()
-    if with_aux:
-        return asimov_data + model.config.auxdata
-    return asimov_data
+    asimov_data = model.expected_data(
+        get_asimov_parameters(model), include_auxdata=with_aux
+    )
+    return asimov_data.tolist()
 
 
 def get_asimov_parameters(model: pyhf.pdf.Model) -> np.ndarray:
     """Returns a list of Asimov parameter values for a model.
+
+    For normalization factors, initial parameter settings (specified in the workspace)
+    are treated as nominal settings.
 
     Args:
         model (pyhf.pdf.Model): model for which to extract the parameters

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -39,6 +39,14 @@ def test_build_Asimov_data(example_spec):
     # without auxdata
     assert model_utils.build_Asimov_data(model, with_aux=False) == [51.839756]
 
+    # respect nominal settings for normfactors
+    example_spec["measurements"][0]["config"]["parameters"].append(
+        {"name": "Signal strength", "inits": [2.0]}
+    )
+    ws = pyhf.Workspace(example_spec)
+    model = ws.model()
+    assert model_utils.build_Asimov_data(model, with_aux=False) == [103.679512]
+
 
 def test_get_asimov_parameters(example_spec, example_spec_shapefactor):
     model = pyhf.Workspace(example_spec).model()
@@ -48,6 +56,14 @@ def test_get_asimov_parameters(example_spec, example_spec_shapefactor):
     model = pyhf.Workspace(example_spec_shapefactor).model()
     pars = model_utils.get_asimov_parameters(model)
     assert np.allclose(pars, [1.0, 1.0, 1.0])
+
+    # respect nominal settings for normfactors
+    example_spec["measurements"][0]["config"]["parameters"].append(
+        {"name": "Signal strength", "inits": [2.0]}
+    )
+    model = pyhf.Workspace(example_spec).model()
+    pars = model_utils.get_asimov_parameters(model)
+    assert np.allclose(pars, [1.0, 2.0])
 
 
 def test_get_prefit_uncertainties(


### PR DESCRIPTION
The nominal prediction from `pyhf.Model.nominal_rates` does not treat initial values for `normfactors` set in the workspace as nominal (see https://github.com/scikit-hep/pyhf/issues/1106). Since there is no other way to specify the nominal values for these unconstrained parameters, `cabinetry` treats the initial value as the nominal value. This updates the Asimov dataset generation to achieve the desired behavior.