### PR TITLE
feat: support stdin/stdout piping in command line interface

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -27,6 +27,17 @@ shows the available commands, while
 
 shows what the ``fit`` command does, and which options it accepts.
 
+It is possible to read the ``cabinetry`` config and workspaces from stdin, and to write workspaces to stdout:
+
+.. code-block:: bash
+
+    # read config from stdin
+    cat config_example.yml | cabinetry workspace - workspaces/example_workspace.json
+    # read workspace from stdin
+    cat workspaces/example_workspace.json | cabinetry fit -
+    # write workspace to stdout
+    cabinetry workspace config_example.yml -
+
 
 .. click:: cabinetry.cli:cabinetry
     :prog: cabinetry

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -1,3 +1,5 @@
+import io
+import json
 import logging
 from typing import Any, KeysView, Optional, Tuple
 
@@ -77,7 +79,7 @@ def workspace(config_path: str, ws_path: str) -> None:
 
 
 @click.command()
-@click.argument("ws_path", type=click.Path(exists=True))
+@click.argument("ws_path", type=click.File("r"))
 @click.option("--asimov", is_flag=True, help="fit Asimov dataset (default: False)")
 @click.option("--pulls", is_flag=True, help="produce pull plot (default: False)")
 @click.option(
@@ -88,13 +90,15 @@ def workspace(config_path: str, ws_path: str) -> None:
     default="figures/",
     help="folder to save figures to (default: figures/)",
 )
-def fit(ws_path: str, asimov: bool, pulls: bool, corrmat: bool, figfolder: str) -> None:
+def fit(
+    ws_path: io.TextIOWrapper, asimov: bool, pulls: bool, corrmat: bool, figfolder: str
+) -> None:
     """Fits a workspace and optionally visualize the results.
 
     WS_PATH: path to workspace used in fit
     """
     _set_logging()
-    ws = cabinetry_workspace.load(ws_path)
+    ws = json.load(ws_path)
     fit_results = cabinetry_fit.fit(ws, asimov=asimov)
     if pulls:
         cabinetry_visualize.pulls(fit_results, figfolder)
@@ -103,7 +107,7 @@ def fit(ws_path: str, asimov: bool, pulls: bool, corrmat: bool, figfolder: str) 
 
 
 @click.command()
-@click.argument("ws_path", type=click.Path(exists=True))
+@click.argument("ws_path", type=click.File("r"))
 @click.option("--asimov", is_flag=True, help="fit Asimov dataset (default: False)")
 @click.option(
     "--max_pars", default=10, help="maximum amount of parameters in plot (default: 10)"
@@ -113,20 +117,22 @@ def fit(ws_path: str, asimov: bool, pulls: bool, corrmat: bool, figfolder: str) 
     default="figures/",
     help="folder to save figures to (default: figures/)",
 )
-def ranking(ws_path: str, asimov: bool, max_pars: int, figfolder: str) -> None:
+def ranking(
+    ws_path: io.TextIOWrapper, asimov: bool, max_pars: int, figfolder: str
+) -> None:
     """Ranks nuisance parameters and visualizes the result.
 
     WS_PATH: path to workspace used in fit
     """
     _set_logging()
-    ws = cabinetry_workspace.load(ws_path)
+    ws = json.load(ws_path)
     fit_results = cabinetry_fit.fit(ws, asimov=asimov)
     ranking_results = cabinetry_fit.ranking(ws, fit_results, asimov=asimov)
     cabinetry_visualize.ranking(ranking_results, figfolder, max_pars=max_pars)
 
 
 @click.command()
-@click.argument("ws_path", type=click.Path(exists=True))
+@click.argument("ws_path", type=click.File("r"))
 @click.argument("par_name", type=str)
 @click.option(
     "--lower_bound",
@@ -148,7 +154,7 @@ def ranking(ws_path: str, asimov: bool, max_pars: int, figfolder: str) -> None:
     help="folder to save figures to (default: figures/)",
 )
 def scan(
-    ws_path: str,
+    ws_path: io.TextIOWrapper,
     par_name: str,
     lower_bound: Optional[float],
     upper_bound: Optional[float],
@@ -179,7 +185,7 @@ def scan(
         # no bounds specified
         par_range = None
 
-    ws = cabinetry_workspace.load(ws_path)
+    ws = json.load(ws_path)
     scan_results = cabinetry_fit.scan(
         ws, par_name, par_range=par_range, n_steps=n_steps, asimov=asimov
     )

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -1,6 +1,7 @@
 import io
 import json
 import logging
+import pathlib
 from typing import Any, KeysView, Optional, Tuple
 
 import click
@@ -67,8 +68,8 @@ def postprocess(config: io.TextIOWrapper) -> None:
 
 @click.command()
 @click.argument("config", type=click.File("r"))
-@click.argument("ws_spec", type=click.Path(exists=False))
-def workspace(config: io.TextIOWrapper, ws_spec: str) -> None:
+@click.argument("ws_spec", type=click.File("w"))
+def workspace(config: io.TextIOWrapper, ws_spec: io.TextIOWrapper) -> None:
     """Produces a ``pyhf`` workspace.
 
     CONFIG: (path to) cabinetry configuration file
@@ -79,7 +80,9 @@ def workspace(config: io.TextIOWrapper, ws_spec: str) -> None:
     cabinetry_config = yaml.safe_load(config)
     cabinetry_configuration.validate(cabinetry_config)
     ws = cabinetry_workspace.build(cabinetry_config)
-    cabinetry_workspace.save(ws, ws_spec)
+    # create folder containing workspace if needed
+    pathlib.Path(ws_spec.name).parent.mkdir(parents=True, exist_ok=True)
+    ws_spec.write(json.dumps(ws, sort_keys=True, indent=4))
 
 
 @click.command()

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -45,7 +45,7 @@ def cabinetry() -> None:
 def templates(config: io.TextIOWrapper, method: str) -> None:
     """Produces template histograms.
 
-    CONFIG: (path to) cabinetry configuration file
+    CONFIG: path to cabinetry configuration file
     """
     _set_logging()
     cabinetry_config = yaml.safe_load(config)
@@ -58,7 +58,7 @@ def templates(config: io.TextIOWrapper, method: str) -> None:
 def postprocess(config: io.TextIOWrapper) -> None:
     """Post-processes template histograms.
 
-    CONFIG: (path to) cabinetry configuration file
+    CONFIG: path to cabinetry configuration file
     """
     _set_logging()
     cabinetry_config = yaml.safe_load(config)
@@ -72,7 +72,7 @@ def postprocess(config: io.TextIOWrapper) -> None:
 def workspace(config: io.TextIOWrapper, ws_spec: io.TextIOWrapper) -> None:
     """Produces a ``pyhf`` workspace.
 
-    CONFIG: (path to) cabinetry configuration file
+    CONFIG: path to cabinetry configuration file
 
     WS_SPEC: where to save the workspace containing the fit model
     """

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import pathlib
 from typing import Any, Dict, List, Optional, Union
 
@@ -479,8 +478,7 @@ def save(ws: Dict[str, Any], file_path_string: Union[str, pathlib.Path]) -> None
     file_path = pathlib.Path(file_path_string)
     log.debug(f"saving workspace to {file_path}")
     # create output directory if it does not exist yet
-    if not os.path.exists(file_path.parent):
-        os.mkdir(file_path.parent)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
     # save workspace to file
     file_path.write_text(json.dumps(ws, sort_keys=True, indent=4))
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,3 +1,5 @@
+import json
+import pathlib
 from unittest import mock
 
 from click.testing import CliRunner
@@ -70,12 +72,11 @@ def test_postprocess(mock_validate, mock_postprocess, cli_helpers, tmp_path):
     assert mock_postprocess.call_args_list == [((config,), {})]
 
 
-@mock.patch("cabinetry.workspace.save", autospec=True)
 @mock.patch(
     "cabinetry.workspace.build", return_value={"workspace": "mock"}, autospec=True
 )
 @mock.patch("cabinetry.configuration.validate", autospec=True)
-def test_workspace(mock_validate, mock_build, mock_save, cli_helpers, tmp_path):
+def test_workspace(mock_validate, mock_build, cli_helpers, tmp_path):
     config = {"General": {"Measurement": "test_config"}}
 
     config_path = str(tmp_path / "config.yml")
@@ -85,12 +86,11 @@ def test_workspace(mock_validate, mock_build, mock_save, cli_helpers, tmp_path):
 
     runner = CliRunner()
 
-    # default histogram folder
     result = runner.invoke(cli.workspace, [config_path, workspace_path])
     assert result.exit_code == 0
     assert mock_validate.call_args_list == [((config,), {})]
     assert mock_build.call_args_list == [((config,), {})]
-    assert mock_save.call_args_list == [(({"workspace": "mock"}, workspace_path), {})]
+    assert json.loads(pathlib.Path(workspace_path).read_text()) == {"workspace": "mock"}
 
 
 @mock.patch("cabinetry.visualize.correlation_matrix", autospec=True)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -114,10 +114,7 @@ def test_workspace(mock_read, mock_build, mock_save, cli_helpers, tmp_path):
     ),
     autospec=True,
 )
-@mock.patch(
-    "cabinetry.workspace.load", return_value={"workspace": "mock"}, autospec=True
-)
-def test_fit(mock_load, mock_fit, mock_pulls, mock_corrmat, tmp_path):
+def test_fit(mock_fit, mock_pulls, mock_corrmat, tmp_path):
     workspace = {"workspace": "mock"}
     bestfit = np.asarray([1.0])
     uncertainty = np.asarray([0.1])
@@ -129,14 +126,13 @@ def test_fit(mock_load, mock_fit, mock_pulls, mock_corrmat, tmp_path):
 
     # need to save workspace to file since click looks for it
     with open(workspace_path, "w") as f:
-        f.write("{'workspace': 'mock'}")
+        f.write('{"workspace": "mock"}')
 
     runner = CliRunner()
 
     # default
     result = runner.invoke(cli.fit, [workspace_path])
     assert result.exit_code == 0
-    assert mock_load.call_args_list == [((workspace_path,), {})]
     assert mock_fit.call_args_list == [((workspace,), {"asimov": False})]
 
     # Asimov
@@ -184,10 +180,7 @@ def test_fit(mock_load, mock_fit, mock_pulls, mock_corrmat, tmp_path):
     ),
     autospec=True,
 )
-@mock.patch(
-    "cabinetry.workspace.load", return_value={"workspace": "mock"}, autospec=True
-)
-def test_ranking(mock_load, mock_fit, mock_rank, mock_vis, tmp_path):
+def test_ranking(mock_fit, mock_rank, mock_vis, tmp_path):
     workspace = {"workspace": "mock"}
     bestfit = np.asarray([1.0])
     uncertainty = np.asarray([0.1])
@@ -199,14 +192,13 @@ def test_ranking(mock_load, mock_fit, mock_rank, mock_vis, tmp_path):
 
     # need to save workspace to file since click looks for it
     with open(workspace_path, "w") as f:
-        f.write("{'workspace': 'mock'}")
+        f.write('{"workspace": "mock"}')
 
     runner = CliRunner()
 
     # default
     result = runner.invoke(cli.ranking, [workspace_path])
     assert result.exit_code == 0
-    assert mock_load.call_args_list == [((workspace_path,), {})]
     assert mock_fit.call_args_list == [((workspace,), {"asimov": False})]
     assert mock_rank.call_args_list == [((workspace, fit_results), {"asimov": False})]
     assert mock_vis.call_count == 1
@@ -235,16 +227,13 @@ def test_ranking(mock_load, mock_fit, mock_rank, mock_vis, tmp_path):
     return_value=fit.ScanResults("par", 1.0, 0.1, np.asarray([1.5]), np.asarray([3.5])),
     autospec=True,
 )
-@mock.patch(
-    "cabinetry.workspace.load", return_value={"workspace": "mock"}, autospec=True
-)
-def test_scan(mock_load, mock_scan, mock_vis, tmp_path):
+def test_scan(mock_scan, mock_vis, tmp_path):
     workspace = {"workspace": "mock"}
     workspace_path = str(tmp_path / "workspace.json")
 
     # need to save workspace to file since click looks for it
     with open(workspace_path, "w") as f:
-        f.write("{'workspace': 'mock'}")
+        f.write('{"workspace": "mock"}')
 
     par_name = "par"
     scan_results = fit.ScanResults(
@@ -256,7 +245,6 @@ def test_scan(mock_load, mock_scan, mock_vis, tmp_path):
     # default
     result = runner.invoke(cli.scan, [workspace_path, par_name])
     assert result.exit_code == 0
-    assert mock_load.call_args_list == [((workspace_path,), {})]
     assert mock_scan.call_args_list == [
         ((workspace, par_name), {"par_range": None, "n_steps": 11, "asimov": False})
     ]

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -30,12 +30,8 @@ def test_cabinetry():
 
 # using autospec to catch changes in public API
 @mock.patch("cabinetry.template_builder.create_histograms", autospec=True)
-@mock.patch(
-    "cabinetry.configuration.load",
-    return_value={"General": {"Measurement": "test_config"}},
-    autospec=True,
-)
-def test_templates(mock_read, mock_create_histograms, cli_helpers, tmp_path):
+@mock.patch("cabinetry.configuration.validate", autospec=True)
+def test_templates(mock_validate, mock_create_histograms, cli_helpers, tmp_path):
     config = {"General": {"Measurement": "test_config"}}
 
     config_path = str(tmp_path / "config.yml")
@@ -46,7 +42,7 @@ def test_templates(mock_read, mock_create_histograms, cli_helpers, tmp_path):
     # default method
     result = runner.invoke(cli.templates, [config_path])
     assert result.exit_code == 0
-    assert mock_read.call_args_list == [((config_path,), {})]
+    assert mock_validate.call_args_list == [((config,), {})]
     assert mock_create_histograms.call_args_list == [((config,), {"method": "uproot"})]
 
     # different method
@@ -59,12 +55,8 @@ def test_templates(mock_read, mock_create_histograms, cli_helpers, tmp_path):
 
 
 @mock.patch("cabinetry.template_postprocessor.run", autospec=True)
-@mock.patch(
-    "cabinetry.configuration.load",
-    return_value={"General": {"Measurement": "test_config"}},
-    autospec=True,
-)
-def test_postprocess(mock_read, mock_postprocess, cli_helpers, tmp_path):
+@mock.patch("cabinetry.configuration.validate", autospec=True)
+def test_postprocess(mock_validate, mock_postprocess, cli_helpers, tmp_path):
     config = {"General": {"Measurement": "test_config"}}
 
     config_path = str(tmp_path / "config.yml")
@@ -74,7 +66,7 @@ def test_postprocess(mock_read, mock_postprocess, cli_helpers, tmp_path):
 
     result = runner.invoke(cli.postprocess, [config_path])
     assert result.exit_code == 0
-    assert mock_read.call_args_list == [((config_path,), {})]
+    assert mock_validate.call_args_list == [((config,), {})]
     assert mock_postprocess.call_args_list == [((config,), {})]
 
 
@@ -82,12 +74,8 @@ def test_postprocess(mock_read, mock_postprocess, cli_helpers, tmp_path):
 @mock.patch(
     "cabinetry.workspace.build", return_value={"workspace": "mock"}, autospec=True
 )
-@mock.patch(
-    "cabinetry.configuration.load",
-    return_value={"General": {"Measurement": "test_config"}},
-    autospec=True,
-)
-def test_workspace(mock_read, mock_build, mock_save, cli_helpers, tmp_path):
+@mock.patch("cabinetry.configuration.validate", autospec=True)
+def test_workspace(mock_validate, mock_build, mock_save, cli_helpers, tmp_path):
     config = {"General": {"Measurement": "test_config"}}
 
     config_path = str(tmp_path / "config.yml")
@@ -100,7 +88,7 @@ def test_workspace(mock_read, mock_build, mock_save, cli_helpers, tmp_path):
     # default histogram folder
     result = runner.invoke(cli.workspace, [config_path, workspace_path])
     assert result.exit_code == 0
-    assert mock_read.call_args_list == [((config_path,), {})]
+    assert mock_validate.call_args_list == [((config,), {})]
     assert mock_build.call_args_list == [((config,), {})]
     assert mock_save.call_args_list == [(({"workspace": "mock"}, workspace_path), {})]
 


### PR DESCRIPTION
Allows using `-` to refer to stdin/stdout for workspaces and the `cabinetry` configuration. See the [click file argument documentation](https://click.palletsprojects.com/en/7.x/arguments/#file-arguments).

Examples:

```bash
# read config from stdin
cat config_example.yml | cabinetry workspace - workspaces/example_workspace.json
# read workspace from stdin
cat workspaces/example_workspace.json | cabinetry fit -
# write workspace to stdout
cabinetry workspace config_example.yml -
```

resolves #141