### PR TITLE
feat: default output folder for visualizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ cabinetry.template_builder.create_histograms(cabinetry_config)
 # perform histogram post-processing
 cabinetry.template_postprocessor.run(cabinetry_config)
 
-# visualize templates and data
-cabinetry.visualize.data_MC_from_histograms(cabinetry_config, "figures/")
-
 # build a workspace
 ws = cabinetry.workspace.build(cabinetry_config)
 
 # run a fit
-cabinetry.fit.fit(ws)
+fit_results = cabinetry.fit.fit(ws)
+
+# visualize the post-fit model prediction and data
+cabinetry.visualize.data_MC(cabinetry_config, ws, fit_results=fit_results)
 ```
 
 The above is an abbreviated version of an example included in `example.py`, which shows how to use `cabinetry`.

--- a/example.py
+++ b/example.py
@@ -28,8 +28,7 @@ if __name__ == "__main__":
     cabinetry.template_postprocessor.run(cabinetry_config)
 
     # visualize systematics templates
-    figure_folder = "figures/"
-    cabinetry.visualize.templates(cabinetry_config, figure_folder)
+    cabinetry.visualize.templates(cabinetry_config)
 
     # build a workspace and save to file
     workspace_path = "workspaces/example_workspace.json"
@@ -41,9 +40,9 @@ if __name__ == "__main__":
     fit_results = cabinetry.fit.fit(ws)
 
     # visualize pulls and correlation matrix
-    cabinetry.visualize.pulls(fit_results, figure_folder)
-    cabinetry.visualize.correlation_matrix(fit_results, figure_folder)
+    cabinetry.visualize.pulls(fit_results)
+    cabinetry.visualize.correlation_matrix(fit_results)
 
     # visualize pre- and post-fit distributions
-    cabinetry.visualize.data_MC(cabinetry_config, figure_folder, ws)
-    cabinetry.visualize.data_MC(cabinetry_config, figure_folder, ws, fit_results)
+    cabinetry.visualize.data_MC(cabinetry_config, ws)
+    cabinetry.visualize.data_MC(cabinetry_config, ws, fit_results=fit_results)

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -123,8 +123,8 @@ def data_MC(
     Args:
         config (Dict[str, Any]): cabinetry configuration
         spec (Dict[str, Any]): ``pyhf`` workspace specification
-        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in,
-            defaults to "figures"
+        figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
+            figures in, defaults to "figures"
         fit_results (Optional[fit.FitResults]): parameter configuration to use for plot,
             includes best-fit settings and uncertainties, as well as correlation matrix,
             defaults to None (then the pre-fit configuration is drawn)
@@ -231,8 +231,8 @@ def correlation_matrix(
     Args:
         fit_results (fit.FitResults): fit results, including correlation matrix and
             parameter labels
-        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in,
-            defaults to "figures"
+        figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
+            figures in, defaults to "figures"
         pruning_threshold (float, optional): minimum correlation for a parameter to
             have with any other parameters to not get pruned, defaults to 0.0
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
@@ -281,8 +281,8 @@ def pulls(
     Args:
         fit_results (fit.FitResults): fit results, including correlation matrix and
             parameter labels
-        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in,
-            defaults to "figures"
+        figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
+            figures in, defaults to "figures"
         exclude_list (Optional[List[str]], optional): list of parameters to exclude from
             plot, defaults to None (nothing excluded)
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
@@ -330,8 +330,8 @@ def ranking(
 
     Args:
         ranking_results (fit.RankingResults): fit results, and pre- and post-fit impacts
-        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in,
-            defaults to "figures"
+        figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
+            figures in, defaults to "figures"
         max_pars (Optional[int], optional): number of parameters to include, defaults to
             None (which means all parameters are included)
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
@@ -392,8 +392,8 @@ def templates(
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in,
-            defaults to "figures"
+        figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
+            figures in, defaults to "figures"
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
 
     Raises:
@@ -486,8 +486,8 @@ def scan(
 
     Args:
         scan_results (fit.ScanResults): results of a likelihood scan
-        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in,
-            defaults to "figures"
+        figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
+            figures in, defaults to "figures"
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
 
     Raises:
@@ -523,8 +523,8 @@ def limit(
 
     Args:
         limit_results (fit.LimitResults): results of upper limit determination
-        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in,
-            defaults to "figures"
+        figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
+            figures in, defaults to "figures"
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
 
     Raises:

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -49,7 +49,7 @@ def _total_yield_uncertainty(stdev_list: List[np.ndarray]) -> np.ndarray:
 
 def data_MC_from_histograms(
     config: Dict[str, Any],
-    figure_folder: Union[str, pathlib.Path],
+    figure_folder: Union[str, pathlib.Path] = "figures",
     log_scale: Optional[bool] = None,
     method: str = "matplotlib",
 ) -> None:
@@ -59,7 +59,8 @@ def data_MC_from_histograms(
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
+        figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
+            figures in, defaults to "figures"
         log_scale (Optional[bool], optional): whether to use logarithmic vertical axis,
             defaults to None (automatically determine whether to use linear/log scale)
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
@@ -111,8 +112,8 @@ def data_MC_from_histograms(
 
 def data_MC(
     config: Dict[str, Any],
-    figure_folder: Union[str, pathlib.Path],
     spec: Dict[str, Any],
+    figure_folder: Union[str, pathlib.Path] = "figures",
     fit_results: Optional[fit.FitResults] = None,
     log_scale: Optional[bool] = None,
     method: str = "matplotlib",
@@ -121,8 +122,9 @@ def data_MC(
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
         spec (Dict[str, Any]): ``pyhf`` workspace specification
+        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in,
+            defaults to "figures"
         fit_results (Optional[fit.FitResults]): parameter configuration to use for plot,
             includes best-fit settings and uncertainties, as well as correlation matrix,
             defaults to None (then the pre-fit configuration is drawn)
@@ -220,7 +222,7 @@ def data_MC(
 
 def correlation_matrix(
     fit_results: fit.FitResults,
-    figure_folder: Union[str, pathlib.Path],
+    figure_folder: Union[str, pathlib.Path] = "figures",
     pruning_threshold: float = 0.0,
     method: str = "matplotlib",
 ) -> None:
@@ -229,7 +231,8 @@ def correlation_matrix(
     Args:
         fit_results (fit.FitResults): fit results, including correlation matrix and
             parameter labels
-        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
+        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in,
+            defaults to "figures"
         pruning_threshold (float, optional): minimum correlation for a parameter to
             have with any other parameters to not get pruned, defaults to 0.0
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
@@ -269,7 +272,7 @@ def correlation_matrix(
 
 def pulls(
     fit_results: fit.FitResults,
-    figure_folder: Union[str, pathlib.Path],
+    figure_folder: Union[str, pathlib.Path] = "figures",
     exclude_list: Optional[List[str]] = None,
     method: str = "matplotlib",
 ) -> None:
@@ -278,7 +281,8 @@ def pulls(
     Args:
         fit_results (fit.FitResults): fit results, including correlation matrix and
             parameter labels
-        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
+        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in,
+            defaults to "figures"
         exclude_list (Optional[List[str]], optional): list of parameters to exclude from
             plot, defaults to None (nothing excluded)
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
@@ -318,7 +322,7 @@ def pulls(
 
 def ranking(
     ranking_results: fit.RankingResults,
-    figure_folder: Union[str, pathlib.Path],
+    figure_folder: Union[str, pathlib.Path] = "figures",
     max_pars: Optional[int] = None,
     method: str = "matplotlib",
 ) -> None:
@@ -326,7 +330,8 @@ def ranking(
 
     Args:
         ranking_results (fit.RankingResults): fit results, and pre- and post-fit impacts
-        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
+        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in,
+            defaults to "figures"
         max_pars (Optional[int], optional): number of parameters to include, defaults to
             None (which means all parameters are included)
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
@@ -380,14 +385,15 @@ def ranking(
 
 def templates(
     config: Dict[str, Any],
-    figure_folder: Union[str, pathlib.Path],
+    figure_folder: Union[str, pathlib.Path] = "figures",
     method: str = "matplotlib",
 ) -> None:
     """Visualizes template histograms for systematic variations.
 
     Args:
         config (Dict[str, Any]): cabinetry configuration
-        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
+        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in,
+            defaults to "figures"
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
 
     Raises:
@@ -473,14 +479,15 @@ def templates(
 
 def scan(
     scan_results: fit.ScanResults,
-    figure_folder: Union[str, pathlib.Path],
+    figure_folder: Union[str, pathlib.Path] = "figures",
     method: str = "matplotlib",
 ) -> None:
     """Visualizes the results of a likelihood scan.
 
     Args:
         scan_results (fit.ScanResults): results of a likelihood scan
-        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
+        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in,
+            defaults to "figures"
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
 
     Raises:
@@ -509,14 +516,15 @@ def scan(
 
 def limit(
     limit_results: fit.LimitResults,
-    figure_folder: Union[str, pathlib.Path],
+    figure_folder: Union[str, pathlib.Path] = "figures",
     method: str = "matplotlib",
 ) -> None:
     """Visualizes observed and expected CLs values as a function of the POI.
 
     Args:
         limit_results (fit.LimitResults): results of upper limit determination
-        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in
+        figure_folder (Union[str, pathlib.Path]): path to the folder to save figures in,
+            defaults to "figures"
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
 
     Raises:

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -131,7 +131,7 @@ def test_data_MC(
     model_spec = pyhf.Workspace(example_spec).model().spec
 
     # pre-fit plot
-    visualize.data_MC(config, figure_folder, example_spec)
+    visualize.data_MC(config, example_spec, figure_folder)
 
     # Asimov parameter calculation and pre-fit uncertainties
     assert mock_stdev.call_count == 1
@@ -184,7 +184,7 @@ def test_data_MC(
         0.0,
     )
     visualize.data_MC(
-        config, figure_folder, example_spec, fit_results=fit_results, log_scale=False
+        config, example_spec, figure_folder, fit_results=fit_results, log_scale=False
     )
 
     assert mock_asimov.call_count == 1  # no new call
@@ -211,7 +211,7 @@ def test_data_MC(
 
     # unknown plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
-        visualize.data_MC(config, figure_folder, example_spec, method="unknown")
+        visualize.data_MC(config, example_spec, figure_folder, method="unknown")
 
 
 @mock.patch("cabinetry.contrib.matplotlib_visualize.correlation_matrix")

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -40,7 +40,7 @@ def test__total_yield_uncertainty():
     "cabinetry.histo.Histogram.from_config",
     return_value=MockHistogram([0.0, 1.0], [1.0], [0.1]),
 )
-def test_data_MC_from_histograms(mock_load, mock_draw, mock_stdev, tmp_path):
+def test_data_MC_from_histograms(mock_load, mock_draw, mock_stdev):
     """contrib.matplotlib_visualize is only imported depending on the keyword argument,
     so cannot patch via cabinetry.visualize.matplotlib_visualize
     Generally it seems like following the path to the module is preferred, but that
@@ -48,13 +48,15 @@ def test_data_MC_from_histograms(mock_load, mock_draw, mock_stdev, tmp_path):
     https://docs.python.org/3/library/unittest.mock.html#where-to-patch
     """
     config = {
-        "General": {"HistogramFolder": tmp_path},
+        "General": {"HistogramFolder": "tmp_hist"},
         "Regions": [{"Name": "reg_1", "Variable": "x"}],
         "Samples": [{"Name": "sample_1"}, {"Name": "data", "Data": True}],
     }
+    figure_folder = pathlib.Path("tmp")
+    histogram_folder = pathlib.Path("tmp_hist")
 
     visualize.data_MC_from_histograms(
-        config, figure_folder=tmp_path, method="matplotlib"
+        config, figure_folder=figure_folder, method="matplotlib"
     )
 
     # the call_args_list contains calls (outer round brackets), first filled with
@@ -62,7 +64,7 @@ def test_data_MC_from_histograms(mock_load, mock_draw, mock_stdev, tmp_path):
     assert mock_load.call_args_list == [
         (
             (
-                tmp_path,
+                histogram_folder,
                 {"Name": "reg_1", "Variable": "x"},
                 {"Name": "data", "Data": True},
                 {"Name": "Nominal"},
@@ -71,7 +73,7 @@ def test_data_MC_from_histograms(mock_load, mock_draw, mock_stdev, tmp_path):
         ),
         (
             (
-                tmp_path,
+                histogram_folder,
                 {"Name": "reg_1", "Variable": "x"},
                 {"Name": "sample_1"},
                 {"Name": "Nominal"},
@@ -99,7 +101,7 @@ def test_data_MC_from_histograms(mock_load, mock_draw, mock_stdev, tmp_path):
                 ],
                 [0.2],
                 [0.0, 1.0],
-                tmp_path / "reg_1_prefit.pdf",
+                figure_folder / "reg_1_prefit.pdf",
             ),
             {"log_scale": None},
         )
@@ -108,7 +110,7 @@ def test_data_MC_from_histograms(mock_load, mock_draw, mock_stdev, tmp_path):
     # other plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
         visualize.data_MC_from_histograms(
-            config, figure_folder=tmp_path, method="unknown"
+            config, figure_folder=figure_folder, method="unknown"
         )
 
 

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -53,7 +53,9 @@ def test_data_MC_from_histograms(mock_load, mock_draw, mock_stdev, tmp_path):
         "Samples": [{"Name": "sample_1"}, {"Name": "data", "Data": True}],
     }
 
-    visualize.data_MC_from_histograms(config, tmp_path, method="matplotlib")
+    visualize.data_MC_from_histograms(
+        config, figure_folder=tmp_path, method="matplotlib"
+    )
 
     # the call_args_list contains calls (outer round brackets), first filled with
     # arguments (inner round brackets) and then keyword arguments
@@ -105,7 +107,9 @@ def test_data_MC_from_histograms(mock_load, mock_draw, mock_stdev, tmp_path):
 
     # other plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
-        visualize.data_MC_from_histograms(config, tmp_path, method="unknown")
+        visualize.data_MC_from_histograms(
+            config, figure_folder=tmp_path, method="unknown"
+        )
 
 
 @mock.patch("cabinetry.contrib.matplotlib_visualize.data_MC")
@@ -131,7 +135,7 @@ def test_data_MC(
     model_spec = pyhf.Workspace(example_spec).model().spec
 
     # pre-fit plot
-    visualize.data_MC(config, example_spec, figure_folder)
+    visualize.data_MC(config, example_spec, figure_folder=figure_folder)
 
     # Asimov parameter calculation and pre-fit uncertainties
     assert mock_stdev.call_count == 1
@@ -184,7 +188,11 @@ def test_data_MC(
         0.0,
     )
     visualize.data_MC(
-        config, example_spec, figure_folder, fit_results=fit_results, log_scale=False
+        config,
+        example_spec,
+        figure_folder=figure_folder,
+        fit_results=fit_results,
+        log_scale=False,
     )
 
     assert mock_asimov.call_count == 1  # no new call
@@ -211,7 +219,9 @@ def test_data_MC(
 
     # unknown plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
-        visualize.data_MC(config, example_spec, figure_folder, method="unknown")
+        visualize.data_MC(
+            config, example_spec, figure_folder=figure_folder, method="unknown"
+        )
 
 
 @mock.patch("cabinetry.contrib.matplotlib_visualize.correlation_matrix")
@@ -225,7 +235,9 @@ def test_correlation_matrix(mock_draw):
     fit_results = fit.FitResults(np.empty(0), np.empty(0), labels, corr_mat, 1.0)
 
     # pruning with threshold
-    visualize.correlation_matrix(fit_results, folder_path, pruning_threshold=0.15)
+    visualize.correlation_matrix(
+        fit_results, figure_folder=folder_path, pruning_threshold=0.15
+    )
 
     mock_draw.assert_called_once()
     assert np.allclose(mock_draw.call_args[0][0], corr_mat_pruned)
@@ -240,7 +252,7 @@ def test_correlation_matrix(mock_draw):
     fit_results_fixed = fit.FitResults(
         np.empty(0), np.empty(0), labels, corr_mat_fixed, 1.0
     )
-    visualize.correlation_matrix(fit_results_fixed, folder_path)
+    visualize.correlation_matrix(fit_results_fixed, figure_folder=folder_path)
     assert np.allclose(mock_draw.call_args_list[1][0][0], corr_mat_pruned)
     assert np.any(
         [
@@ -251,7 +263,9 @@ def test_correlation_matrix(mock_draw):
 
     # unknown plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
-        visualize.correlation_matrix(fit_results, folder_path, method="unknown")
+        visualize.correlation_matrix(
+            fit_results, figure_folder=folder_path, method="unknown"
+        )
 
 
 @mock.patch("cabinetry.contrib.matplotlib_visualize.pulls")
@@ -270,7 +284,10 @@ def test_pulls(mock_draw):
 
     # with filtering
     visualize.pulls(
-        fit_results, folder_path, exclude_list=exclude_list, method="matplotlib"
+        fit_results,
+        figure_folder=folder_path,
+        exclude_list=exclude_list,
+        method="matplotlib",
     )
 
     mock_draw.assert_called_once()
@@ -292,7 +309,7 @@ def test_pulls(mock_draw):
     bestfit_expected = np.asarray([1.0, 1.1])
     uncertainty_expected = np.asarray([1.0, 0.7])
     labels_expected = ["b", "c"]
-    visualize.pulls(fit_results, folder_path, method="matplotlib")
+    visualize.pulls(fit_results, figure_folder=folder_path, method="matplotlib")
 
     assert np.allclose(mock_draw.call_args[0][0], bestfit_expected)
     assert np.allclose(mock_draw.call_args[0][1], uncertainty_expected)
@@ -308,7 +325,10 @@ def test_pulls(mock_draw):
     # unknown plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
         visualize.pulls(
-            fit_results, folder_path, exclude_list=exclude_list, method="unknown"
+            fit_results,
+            figure_folder=folder_path,
+            exclude_list=exclude_list,
+            method="unknown",
         )
 
 
@@ -337,7 +357,7 @@ def test_ranking(mock_draw):
     uncertainty_expected = np.asarray([0.8, 0.2])
     labels_expected = ["modeling", "staterror_a"]
 
-    visualize.ranking(ranking_results, folder_path)
+    visualize.ranking(ranking_results, figure_folder=folder_path)
     assert mock_draw.call_count == 1
     assert np.allclose(mock_draw.call_args[0][0], bestfit_expected)
     assert np.allclose(mock_draw.call_args[0][1], uncertainty_expected)
@@ -351,7 +371,7 @@ def test_ranking(mock_draw):
     assert mock_draw.call_args[1] == {}
 
     # maximum parameter amount specified
-    visualize.ranking(ranking_results, folder_path, max_pars=1)
+    visualize.ranking(ranking_results, figure_folder=folder_path, max_pars=1)
     assert mock_draw.call_count == 2
     assert np.allclose(mock_draw.call_args[0][0], bestfit_expected[0])
     assert np.allclose(mock_draw.call_args[0][1], uncertainty_expected[0])
@@ -365,7 +385,7 @@ def test_ranking(mock_draw):
 
     # unknown plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
-        visualize.ranking(ranking_results, folder_path, method="unknown")
+        visualize.ranking(ranking_results, figure_folder=folder_path, method="unknown")
 
 
 @mock.patch(
@@ -407,7 +427,7 @@ def test_templates(mock_draw, mock_histo_config, mock_histo_path, tmp_path):
     # also add a file that matches pattern but is not needed
     (tmp_path / "region_sample_sys_unknown_modified.npz").touch()
 
-    visualize.templates(config, folder_path)
+    visualize.templates(config, figure_folder=folder_path)
 
     assert mock_histo_config.call_args_list == [
         [(tmp_path, region, sample, {"Name": "Nominal"}), {}]
@@ -424,13 +444,13 @@ def test_templates(mock_draw, mock_histo_config, mock_histo_path, tmp_path):
 
     # unknown plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
-        visualize.templates(config, folder_path, method="unknown")
+        visualize.templates(config, figure_folder=folder_path, method="unknown")
 
     # remove files for variation histograms
     up_path.unlink()
     down_path.unlink()
 
-    visualize.templates(config, folder_path)
+    visualize.templates(config, figure_folder=folder_path)
     assert mock_draw.call_count == 1  # no new call, since no variations found
 
 
@@ -446,7 +466,7 @@ def test_scan(mock_draw):
     par_nlls = np.asarray([0.9, 0.0, 1.1])
     scan_results = fit.ScanResults(par_name, par_mle, par_unc, par_vals, par_nlls)
 
-    visualize.scan(scan_results, folder_path)
+    visualize.scan(scan_results, figure_folder=folder_path)
 
     assert mock_draw.call_count == 1
     assert mock_draw.call_args[0][0] == par_name
@@ -459,7 +479,7 @@ def test_scan(mock_draw):
 
     # unknown plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
-        visualize.scan(scan_results, folder_path, method="unknown")
+        visualize.scan(scan_results, figure_folder=folder_path, method="unknown")
 
 
 @mock.patch("cabinetry.contrib.matplotlib_visualize.limit")
@@ -474,7 +494,7 @@ def test_limit(mock_draw):
         3.0, np.empty(5), observed_CLs, expected_CLs, poi_values
     )
 
-    visualize.limit(limit_results, folder_path)
+    visualize.limit(limit_results, figure_folder=folder_path)
 
     assert mock_draw.call_count == 1
     assert np.allclose(mock_draw.call_args[0][0], limit_results.observed_CLs)
@@ -485,4 +505,4 @@ def test_limit(mock_draw):
 
     # unknown plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
-        visualize.limit(limit_results, folder_path, method="unknown")
+        visualize.limit(limit_results, figure_folder=folder_path, method="unknown")


### PR DESCRIPTION
This adds `"figures"` as default value for the output folder of visualizations done through the `visualize` module. Previously the  `figure_folder` was a required argument. The default can be overridden via the `figure_folder` keyword argument.

**breaking change:** The order of arguments for `visualize.data_MC` changed: the workspace specification is now the second required argument, while the figure output folder is the third function argument and optional.