### PR TITLE
refactor: common entry point for maximum likelihood fits

### DIFF
--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -311,10 +311,8 @@ def fit(
     if minos is not None and not isinstance(minos, list):
         minos = [minos]
 
-    if not custom:
-        fit_results = _fit_model_pyhf(model, data, minos=minos)
-    else:
-        fit_results = _fit_model_custom(model, data, minos=minos)
+    # perform fit
+    fit_results = _fit_model(model, data, minos=minos, custom=custom)
 
     print_results(fit_results)
     log.debug(f"-2 log(L) = {fit_results.best_twice_nll:.6f} at the best-fit point")

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -238,6 +238,45 @@ def _fit_model_custom(
     return fit_results
 
 
+def _fit_model(
+    model: pyhf.pdf.Model,
+    data: List[float],
+    custom: bool,
+    init_pars: Optional[List[float]] = None,
+    fix_pars: Optional[List[bool]] = None,
+    minos: Optional[List[str]] = None,
+) -> FitResults:
+    """Interface for maximum likelihood fits through ``pyhf.infer`` API or ``iminuit``.
+
+    Parameters set to be fixed in the model are held constant. The ``init_pars``
+    argument allows to override the ``pyhf`` default initial parameter settings, and the
+    ``fix_pars`` argument overrides which parameters are held constant.
+
+    Args:
+        model (pyhf.pdf.Model): the model to use in the fit
+        data (List[float]): the data to fit the model to
+        custom (bool): uses the ``pyhf.infer`` API if True, otherwise uses ``iminuit``
+        init_pars (Optional[List[float]], optional): list of initial parameter settings,
+            defaults to None (use ``pyhf`` suggested inits)
+        fix_pars (Optional[List[bool]], optional): list of booleans specifying which
+            parameters are held constant, defaults to None (use ``pyhf`` suggestion)
+        minos (Optional[List[str]], optional): runs the MINOS algorithm for all
+            parameters specified in the list, defaults to None (does not run MINOS)
+
+    Returns:
+        FitResults: object storing relevant fit results
+    """
+    if not custom:
+        fit_results = _fit_model_pyhf(
+            model, data, init_pars=init_pars, fix_pars=fix_pars, minos=minos
+        )
+    else:
+        fit_results = _fit_model_custom(
+            model, data, init_pars=init_pars, fix_pars=fix_pars, minos=minos
+        )
+    return fit_results
+
+
 def fit(
     spec: Dict[str, Any],
     asimov: bool = False,

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -241,10 +241,10 @@ def _fit_model_custom(
 def _fit_model(
     model: pyhf.pdf.Model,
     data: List[float],
-    custom: bool,
     init_pars: Optional[List[float]] = None,
     fix_pars: Optional[List[bool]] = None,
     minos: Optional[List[str]] = None,
+    custom: bool = False,
 ) -> FitResults:
     """Interface for maximum likelihood fits through ``pyhf.infer`` API or ``iminuit``.
 
@@ -255,22 +255,25 @@ def _fit_model(
     Args:
         model (pyhf.pdf.Model): the model to use in the fit
         data (List[float]): the data to fit the model to
-        custom (bool): uses the ``pyhf.infer`` API if True, otherwise uses ``iminuit``
         init_pars (Optional[List[float]], optional): list of initial parameter settings,
             defaults to None (use ``pyhf`` suggested inits)
         fix_pars (Optional[List[bool]], optional): list of booleans specifying which
             parameters are held constant, defaults to None (use ``pyhf`` suggestion)
         minos (Optional[List[str]], optional): runs the MINOS algorithm for all
             parameters specified in the list, defaults to None (does not run MINOS)
+        custom (bool, optional): whether to use the ``pyhf.infer`` API or ``iminuit``,
+            defaults to False (using ``pyhf.infer``)
 
     Returns:
         FitResults: object storing relevant fit results
     """
     if not custom:
+        # use pyhf infer API
         fit_results = _fit_model_pyhf(
             model, data, init_pars=init_pars, fix_pars=fix_pars, minos=minos
         )
     else:
+        # use iminuit directly
         fit_results = _fit_model_custom(
             model, data, init_pars=init_pars, fix_pars=fix_pars, minos=minos
         )

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -272,7 +272,7 @@ def test__fit_model(mock_pyhf, mock_custom, example_spec):
 @mock.patch("cabinetry.model_utils.model_and_data", return_value=("model", "data"))
 def test_fit(mock_load, mock_fit, mock_print, example_spec):
     # fit through pyhf.infer API
-    fit.fit(example_spec)
+    fit_results = fit.fit(example_spec)
     assert mock_load.call_args_list == [[(example_spec,), {"asimov": False}]]
     assert mock_fit.call_args_list == [
         [("model", "data"), {"minos": None, "custom": False}]
@@ -281,26 +281,31 @@ def test_fit(mock_load, mock_fit, mock_print, example_spec):
     assert mock_print.call_args[0][0].bestfit == [1.0]
     assert mock_print.call_args[0][0].uncertainty == [0.1]
     assert mock_print.call_args[0][0].labels == ["par"]
+    assert fit_results.bestfit == [1.0]
 
     # Asimov fit
-    fit.fit(example_spec, asimov=True)
+    fit_results = fit.fit(example_spec, asimov=True)
     assert mock_fit.call_count == 2
     assert mock_load.call_args == [(example_spec,), {"asimov": True}]
+    assert fit_results.bestfit == [1.0]
 
     # custom fit
-    fit.fit(example_spec, custom=True)
+    fit_results = fit.fit(example_spec, custom=True)
     assert mock_fit.call_count == 3
     assert mock_fit.call_args == [("model", "data"), {"minos": None, "custom": True}]
     assert mock_print.call_args[0][0].bestfit == [1.0]
     assert mock_print.call_args[0][0].uncertainty == [0.1]
+    assert fit_results.bestfit == [1.0]
 
     # parameters for MINOS
-    fit.fit(example_spec, minos=["abc"])
+    fit_results = fit.fit(example_spec, minos=["abc"])
     assert mock_fit.call_count == 4
     assert mock_fit.call_args[1] == {"minos": ["abc"], "custom": False}
-    fit.fit(example_spec, custom=True, minos="abc")
+    assert fit_results.bestfit == [1.0]
+    fit_results = fit.fit(example_spec, custom=True, minos="abc")
     assert mock_fit.call_count == 5
     assert mock_fit.call_args[1] == {"minos": ["abc"], "custom": True}
+    assert fit_results.bestfit == [1.0]
 
 
 @mock.patch(


### PR DESCRIPTION
This adds `fit._fit_model` as a common entry point to call either `fit._fit_model_pyhf` (maximum likelihood fit using `pyhf.infer` API) or `fit._fit_model_custom` (maximum likelihood fit using `iminuit` directly), depending on the value of the `custom` keyword argument (defaults to `False`: use `pyhf.infer` API).

Allows for the addition of ranking / scan through the `pyhf.infer` API in the future with this new interface. Currently ranking / scan fits make use of `fit._fit_model_custom` only.