### PR TITLE
feat: support pyhf.infer fits for ranking and parameter scans

### DIFF
--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -283,8 +283,8 @@ def _fit_model(
 def fit(
     spec: Dict[str, Any],
     asimov: bool = False,
-    custom_fit: bool = False,
     minos: Optional[Union[str, List[str]]] = None,
+    custom_fit: bool = False,
 ) -> FitResults:
     """Performs a  maximum likelihood fit, reports and returns the results.
 
@@ -295,10 +295,10 @@ def fit(
     Args:
         spec (Dict[str, Any]): a ``pyhf`` workspace specification
         asimov (bool, optional): whether to fit the Asimov dataset, defaults to False
-        custom_fit (bool, optional): whether to use the ``pyhf.infer`` API or
-            ``iminuit``, defaults to False (using ``pyhf.infer``)
         minos (Optional[Union[str, List[str]]], optional): runs the MINOS algorithm for
             all parameters specified in the list, defaults to None (does not run MINOS)
+        custom_fit (bool, optional): whether to use the ``pyhf.infer`` API or
+            ``iminuit``, defaults to False (using ``pyhf.infer``)
 
     Returns:
         FitResults: object storing relevant fit results

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -244,7 +244,7 @@ def _fit_model(
     init_pars: Optional[List[float]] = None,
     fix_pars: Optional[List[bool]] = None,
     minos: Optional[List[str]] = None,
-    custom: bool = False,
+    custom_fit: bool = False,
 ) -> FitResults:
     """Interface for maximum likelihood fits through ``pyhf.infer`` API or ``iminuit``.
 
@@ -261,13 +261,13 @@ def _fit_model(
             parameters are held constant, defaults to None (use ``pyhf`` suggestion)
         minos (Optional[List[str]], optional): runs the MINOS algorithm for all
             parameters specified in the list, defaults to None (does not run MINOS)
-        custom (bool, optional): whether to use the ``pyhf.infer`` API or ``iminuit``,
-            defaults to False (using ``pyhf.infer``)
+        custom_fit (bool, optional): whether to use the ``pyhf.infer`` API or
+            ``iminuit``, defaults to False (using ``pyhf.infer``)
 
     Returns:
         FitResults: object storing relevant fit results
     """
-    if not custom:
+    if not custom_fit:
         # use pyhf infer API
         fit_results = _fit_model_pyhf(
             model, data, init_pars=init_pars, fix_pars=fix_pars, minos=minos
@@ -283,20 +283,20 @@ def _fit_model(
 def fit(
     spec: Dict[str, Any],
     asimov: bool = False,
-    custom: bool = False,
+    custom_fit: bool = False,
     minos: Optional[Union[str, List[str]]] = None,
 ) -> FitResults:
     """Performs a  maximum likelihood fit, reports and returns the results.
 
     The ``asimov`` flag allows to fit the Asimov dataset instead of observed data.
-    Depending on the ``custom`` keyword argument, this uses either the ``pyhf.infer``
-    API or ``iminuit`` directly for more control over the minimization.
+    Depending on the ``custom_fit`` keyword argument, this uses either the
+    ``pyhf.infer`` API or ``iminuit`` directly for more control over the minimization.
 
     Args:
         spec (Dict[str, Any]): a ``pyhf`` workspace specification
         asimov (bool, optional): whether to fit the Asimov dataset, defaults to False
-        custom (bool, optional): whether to use the ``pyhf.infer`` API or ``iminuit``,
-            defaults to False (using ``pyhf.infer``)
+        custom_fit (bool, optional): whether to use the ``pyhf.infer`` API or
+            ``iminuit``, defaults to False (using ``pyhf.infer``)
         minos (Optional[Union[str, List[str]]], optional): runs the MINOS algorithm for
             all parameters specified in the list, defaults to None (does not run MINOS)
 
@@ -312,7 +312,7 @@ def fit(
         minos = [minos]
 
     # perform fit
-    fit_results = _fit_model(model, data, minos=minos, custom=custom)
+    fit_results = _fit_model(model, data, minos=minos, custom_fit=custom_fit)
 
     print_results(fit_results)
     log.debug(f"-2 log(L) = {fit_results.best_twice_nll:.6f} at the best-fit point")

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -321,7 +321,10 @@ def fit(
 
 
 def ranking(
-    spec: Dict[str, Any], fit_results: FitResults, asimov: bool = False
+    spec: Dict[str, Any],
+    fit_results: FitResults,
+    asimov: bool = False,
+    custom_fit: bool = False,
 ) -> RankingResults:
     """Calculates the impact of nuisance parameters on the parameter of interest (POI).
 
@@ -337,6 +340,8 @@ def ranking(
         fit_results (FitResults): fit results to use for ranking
         asimov (bool, optional): whether to fit the Asimov dataset, defaults
             to False
+        custom_fit (bool, optional): whether to use the ``pyhf.infer`` API or
+            ``iminuit``, defaults to False (using ``pyhf.infer``)
 
     Returns:
         RankingResults: fit results for parameters, and pre- and post-fit impacts
@@ -377,8 +382,12 @@ def ranking(
             else:
                 init_pars = init_pars_default.copy()
                 init_pars[i_par] = np_val  # set value of current nuisance parameter
-                fit_results_ranking = _fit_model_custom(
-                    model, data, init_pars=init_pars, fix_pars=fix_pars
+                fit_results_ranking = _fit_model(
+                    model,
+                    data,
+                    init_pars=init_pars,
+                    fix_pars=fix_pars,
+                    custom_fit=custom_fit,
                 )
                 poi_val = fit_results_ranking.bestfit[model.config.poi_index]
                 parameter_impact = poi_val - nominal_poi

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -53,7 +53,7 @@ def get_parameter_names(model: pyhf.pdf.Model) -> List[str]:
     for parname in model.config.par_order:
         for i_par in range(model.config.param_set(parname).n_parameters):
             labels.append(
-                "{}[bin_{}]".format(parname, i_par)
+                f"{parname}[bin_{i_par}]"
                 if model.config.param_set(parname).n_parameters > 1
                 else parname
             )

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -379,7 +379,7 @@ def test_ranking(mock_fit, example_spec):
 
 
 @mock.patch(
-    "cabinetry.fit._fit_model_custom",
+    "cabinetry.fit._fit_model",
     side_effect=[
         fit.FitResults(
             np.asarray([0.9, 1.3]), np.asarray([0.1, 0.1]), [], np.empty(0), 8.0
@@ -411,16 +411,20 @@ def test_scan(mock_fit, example_spec):
 
     assert mock_fit.call_count == 12
     # unconstrained fit
-    assert mock_fit.call_args_list[0][1] == {}
+    assert mock_fit.call_args_list[0][1] == {"custom_fit": False}
     # fits in scan
     for i, scan_val in enumerate(expected_scan_values):
         assert mock_fit.call_args_list[i + 1][1]["init_pars"] == [1.1, scan_val]
         assert mock_fit.call_args_list[i + 1][1]["fix_pars"] == [True, True]
+        assert mock_fit.call_args_list[i + 1][1]["custom_fit"] is False
 
-    # parameter range specified
-    scan_results = fit.scan(example_spec, par_name, par_range=(1.0, 1.5), n_steps=5)
+    # parameter range specified, custom fit
+    scan_results = fit.scan(
+        example_spec, par_name, par_range=(1.0, 1.5), n_steps=5, custom_fit=True
+    )
     expected_custom_scan = np.linspace(1.0, 1.5, 5)
     assert np.allclose(scan_results.parameter_values, expected_custom_scan)
+    assert mock_fit.call_args[1]["custom_fit"] is True
 
     # unknown parameter
     with pytest.raises(ValueError, match="could not find parameter abc in model"):

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -231,7 +231,7 @@ def test__fit_model(mock_pyhf, mock_custom, example_spec):
     assert np.allclose(fit_results.bestfit, [1.1])
 
     # direct iminuit
-    fit_results = fit._fit_model(model, data, custom=True)
+    fit_results = fit._fit_model(model, data, custom_fit=True)
     assert mock_custom.call_count == 1
     assert mock_custom.call_args[0][0].spec == model.spec
     assert mock_custom.call_args[0][1] == data
@@ -249,7 +249,7 @@ def test__fit_model(mock_pyhf, mock_custom, example_spec):
         init_pars=[1.5, 2.0],
         fix_pars=[False, True],
         minos=["Signal strength"],
-        custom=True,
+        custom_fit=True,
     )
     assert mock_custom.call_count == 2
     assert mock_custom.call_args[0][0].spec == model.spec
@@ -275,7 +275,7 @@ def test_fit(mock_load, mock_fit, mock_print, example_spec):
     fit_results = fit.fit(example_spec)
     assert mock_load.call_args_list == [[(example_spec,), {"asimov": False}]]
     assert mock_fit.call_args_list == [
-        [("model", "data"), {"minos": None, "custom": False}]
+        [("model", "data"), {"minos": None, "custom_fit": False}]
     ]
     mock_print.assert_called_once()
     assert mock_print.call_args[0][0].bestfit == [1.0]
@@ -290,9 +290,12 @@ def test_fit(mock_load, mock_fit, mock_print, example_spec):
     assert fit_results.bestfit == [1.0]
 
     # custom fit
-    fit_results = fit.fit(example_spec, custom=True)
+    fit_results = fit.fit(example_spec, custom_fit=True)
     assert mock_fit.call_count == 3
-    assert mock_fit.call_args == [("model", "data"), {"minos": None, "custom": True}]
+    assert mock_fit.call_args == [
+        ("model", "data"),
+        {"minos": None, "custom_fit": True},
+    ]
     assert mock_print.call_args[0][0].bestfit == [1.0]
     assert mock_print.call_args[0][0].uncertainty == [0.1]
     assert fit_results.bestfit == [1.0]
@@ -300,11 +303,11 @@ def test_fit(mock_load, mock_fit, mock_print, example_spec):
     # parameters for MINOS
     fit_results = fit.fit(example_spec, minos=["abc"])
     assert mock_fit.call_count == 4
-    assert mock_fit.call_args[1] == {"minos": ["abc"], "custom": False}
+    assert mock_fit.call_args[1] == {"minos": ["abc"], "custom_fit": False}
     assert fit_results.bestfit == [1.0]
-    fit_results = fit.fit(example_spec, custom=True, minos="abc")
+    fit_results = fit.fit(example_spec, custom_fit=True, minos="abc")
     assert mock_fit.call_count == 5
-    assert mock_fit.call_args[1] == {"minos": ["abc"], "custom": True}
+    assert mock_fit.call_args[1] == {"minos": ["abc"], "custom_fit": True}
     assert fit_results.bestfit == [1.0]
 
 

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -305,7 +305,7 @@ def test_fit(mock_load, mock_fit, mock_print, example_spec):
     assert mock_fit.call_count == 4
     assert mock_fit.call_args[1] == {"minos": ["abc"], "custom_fit": False}
     assert fit_results.bestfit == [1.0]
-    fit_results = fit.fit(example_spec, custom_fit=True, minos="abc")
+    fit_results = fit.fit(example_spec, minos="abc", custom_fit=True)
     assert mock_fit.call_count == 5
     assert mock_fit.call_args[1] == {"minos": ["abc"], "custom_fit": True}
     assert fit_results.bestfit == [1.0]

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -352,7 +352,7 @@ def test_ranking(mock_fit, example_spec):
             mock_fit.call_args_list[i][1]["init_pars"], expected_inits[i]
         )
         assert np.allclose(mock_fit.call_args_list[i][1]["fix_pars"], expected_fix)
-    assert mock_fit.call_args[1]["custom_fit"] is False
+        assert mock_fit.call_args_list[i][1]["custom_fit"] is False
 
     # POI removed from fit results
     assert np.allclose(ranking_results.bestfit, [0.9])

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -312,7 +312,7 @@ def test_fit(mock_load, mock_fit, mock_print, example_spec):
 
 
 @mock.patch(
-    "cabinetry.fit._fit_model_custom",
+    "cabinetry.fit._fit_model",
     side_effect=[
         fit.FitResults(
             np.asarray([0.9, 1.3]), np.asarray([0.1, 0.1]), ["a", "b"], np.empty(0), 0.0
@@ -352,6 +352,7 @@ def test_ranking(mock_fit, example_spec):
             mock_fit.call_args_list[i][1]["init_pars"], expected_inits[i]
         )
         assert np.allclose(mock_fit.call_args_list[i][1]["fix_pars"], expected_fix)
+    assert mock_fit.call_args[1]["custom_fit"] is False
 
     # POI removed from fit results
     assert np.allclose(ranking_results.bestfit, [0.9])
@@ -364,12 +365,13 @@ def test_ranking(mock_fit, example_spec):
     assert np.allclose(ranking_results.postfit_up, [0.2])
     assert np.allclose(ranking_results.postfit_down, [-0.2])
 
-    # fixed parameter in ranking
+    # fixed parameter in ranking, custom fit
     example_spec["measurements"][0]["config"]["parameters"][0]["fixed"] = True
-    ranking_results = fit.ranking(example_spec, fit_results)
+    ranking_results = fit.ranking(example_spec, fit_results, custom_fit=True)
     # expect two calls in this ranking (and had 4 before, so 6 total): pre-fit
     # uncertainty is 0 since parameter is fixed, mock post-fit uncertainty is not 0
     assert mock_fit.call_count == 6
+    assert mock_fit.call_args[1]["custom_fit"] is True
     assert np.allclose(ranking_results.prefit_up, [0.0])
     assert np.allclose(ranking_results.prefit_down, [0.0])
     assert np.allclose(ranking_results.postfit_up, [0.2])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -149,7 +149,7 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     ]
 
     # nuisance parameter ranking
-    ranking_results = cabinetry.fit.ranking(ws, fit_results)
+    ranking_results = cabinetry.fit.ranking(ws, fit_results, custom_fit=True)
     assert np.allclose(
         ranking_results.prefit_up,
         [

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -201,7 +201,11 @@ def test_integration(tmp_path, ntuple_creator, caplog):
 
     # parameter scan
     scan_results = cabinetry.fit.scan(
-        ws, "Signal_norm", par_range=(1.18967971, 2.18967971), n_steps=3
+        ws,
+        "Signal_norm",
+        par_range=(1.18967971, 2.18967971),
+        n_steps=3,
+        custom_fit=True,
     )
     # lower edge of scan is beyond normalization factor bounds specified in workspace
     assert np.allclose(


### PR DESCRIPTION
Make use of the new maximum likelihood entry point added in #146 to support using the `pyhf.infer` API for fits needed in nuisance parameter ranking and parameter scans.

**breaking change:** rename `custom` keyword argument (switches between `pyhf.infer` and `iminuit`) to `custom_fit`

also included: unrelated minor update for consistent f-string usage