### PR TITLE
chore: update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,17 +5,17 @@ repos:
     -   id: black
         language_version: python3
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.782
+    rev: v0.790
     hooks:
     -   id: mypy
         files: src/cabinetry
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 3.8.4
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.3.0
     hooks:
     -   id: check-added-large-files
         args: ["--maxkb=100"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
     rev: 20.8b1
     hooks:
     -   id: black
-        language_version: python3
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.790
     hooks:


### PR DESCRIPTION
Running `pre-commit autoupdate` and removing `language_version` for `black` as suggested in https://github.com/scikit-hep/pyhf/pull/1167#issuecomment-724082282.