### PR TITLE
chore: Add pyupgrade to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,11 @@ repos:
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.7.3
+    hooks:
+    - id: pyupgrade
+      args: ["--py36-plus"]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.3
+    rev: v2.7.4
     hooks:
     - id: pyupgrade
       args: ["--py36-plus"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,8 @@ repos:
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.7.4
     hooks:
-    - id: pyupgrade
-      args: ["--py36-plus"]
+    -   id: pyupgrade
+        args: ["--py36-plus"]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.3.0
     hooks:

--- a/setup.py
+++ b/setup.py
@@ -20,15 +20,13 @@ extras_require["test"] = sorted(
     )
 )
 extras_require["docs"] = sorted(
-    set(
-        [
-            "sphinx",
-            "sphinx-click",
-            "sphinx-copybutton",
-            "sphinx-jsonschema",
-            "sphinx-rtd-theme",
-        ]
-    )
+    {
+        "sphinx",
+        "sphinx-click",
+        "sphinx-copybutton",
+        "sphinx-jsonschema",
+        "sphinx-rtd-theme",
+    }
 )
 
 extras_require["develop"] = sorted(


### PR DESCRIPTION
Add `pyupgrade` to the pre-commit hooks to help move the codebase along as support for older versions of Python are dropped in time to use newer features and to shed older syntax.

For an example of some of the benefits c.f. https://github.com/scikit-hep/pyhf/pull/1164.

```
* Add pyupgrade v2.7.4 to pre-commit hooks
   - Run with --py36-plus option
* Apply pyupgrade to codebase
```