### PR TITLE
feat: better handling of unknown parameters when running MINOS

### DIFF
--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -165,10 +165,7 @@ def _fit_model_pyhf(
                 # x0, x1, etc.
                 parameters_translated.append(f"x{par_index}")
 
-        if len(parameters_translated) > 0:
-            _run_minos(result_obj.minuit, parameters_translated, labels)
-        else:
-            log.error(f"cannot run MINOS: parameter(s) {minos} not found in model")
+        _run_minos(result_obj.minuit, parameters_translated, labels)
 
     return fit_results
 
@@ -563,6 +560,9 @@ def _run_minos(minuit_obj: iminuit.Minuit, minos: List[str], labels: List[str]) 
         # get index of current parameter in labels (to translate its name if iminuit
         # did not receive the parameter labels)
         par_index = model_utils._get_parameter_index(par_name, minuit_obj.parameters)
+        if par_index == -1:
+            # parameter not found, skip calculation
+            continue
         log.info(f"running MINOS for {labels[par_index]}")
         minuit_obj.minos(var=par_name)
 

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -158,13 +158,17 @@ def _fit_model_pyhf(
 
     if minos is not None:
         parameters_translated = []
-        for i, label in enumerate(labels):
-            if label in minos:
+        for minos_par in minos:
+            par_index = model_utils._get_parameter_index(minos_par, labels)
+            if par_index != -1:
                 # pyhf does not hand over parameter names, all parameters are known as
                 # x0, x1, etc.
-                parameters_translated.append(f"x{i}")
+                parameters_translated.append(f"x{par_index}")
 
-        _run_minos(result_obj.minuit, parameters_translated, labels)
+        if len(parameters_translated) > 0:
+            _run_minos(result_obj.minuit, parameters_translated, labels)
+        else:
+            log.error(f"cannot run MINOS: parameter(s) {minos} not found in model")
 
     return fit_results
 
@@ -504,7 +508,7 @@ def scan(
     fix_pars = model.config.suggested_fixed()
 
     # get index of parameter with name par_name
-    par_index = next((i for i, label in enumerate(labels) if label == par_name), -1)
+    par_index = model_utils._get_parameter_index(par_name, labels)
     if par_index == -1:
         raise ValueError(f"could not find parameter {par_name} in model")
 
@@ -558,9 +562,7 @@ def _run_minos(minuit_obj: iminuit.Minuit, minos: List[str], labels: List[str]) 
     for par_name in minos:
         # get index of current parameter in labels (to translate its name if iminuit
         # did not receive the parameter labels)
-        par_index = next(
-            (i for i, par in enumerate(minuit_obj.parameters) if par == par_name)
-        )
+        par_index = model_utils._get_parameter_index(par_name, minuit_obj.parameters)
         log.info(f"running MINOS for {labels[par_index]}")
         minuit_obj.minos(var=par_name)
 

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -292,8 +292,8 @@ def _get_parameter_index(
     """Returns the position of a parameter with a given name in the list of parameters.
 
     Useful together with ``get_parameter_names`` to find the position of a parameter
-    when the name is known. If the parameter is not found, prints an error and returns
-    a default value of -1.
+    when the name is known. If the parameter is not found, logs an error and returns a
+    default value of -1.
 
     Args:
         par_name (str): name of parameter to find in list

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Union
 
 import awkward1 as ak
 import numpy as np
@@ -284,3 +284,26 @@ def unconstrained_parameter_count(model: pyhf.pdf.Model) -> int:
         ):
             n_pars += model.config.param_set(parname).n_parameters
     return n_pars
+
+
+def _get_parameter_index(
+    par_name: str, labels: Union[List[str], Tuple[str, ...]]
+) -> int:
+    """Returns the position of a parameter with a given name in the list of parameters.
+
+    Useful together with ``get_parameter_names`` to find the position of a parameter
+    when the name is known. If the parameter is not found, prints an error and returns
+    a default value of -1.
+
+    Args:
+        par_name (str): name of parameter to find in list
+        labels (Union[List[str], Tuple[str, ...]]): list or tuple with all parameter
+            names in the model
+
+    Returns:
+        int: index of parameter
+    """
+    par_index = next((i for i, label in enumerate(labels) if label == par_name), -1)
+    if par_index == -1:
+        log.error(f"parameter {par_name} not found in model")
+    return par_index

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -129,9 +129,9 @@ def test__fit_model_pyhf(mock_minos, example_spec, example_spec_multibin):
     assert np.allclose(fit_results.uncertainty, [0.0, 0.0, 0.20694465, 0.11792837])
     assert np.allclose(fit_results.best_twice_nll, 10.4531891)
 
-    # including minos
+    # including minos, one parameter is unknown
     model, data = model_utils.model_and_data(example_spec)
-    fit_results = fit._fit_model_pyhf(model, data, minos=["Signal strength"])
+    fit_results = fit._fit_model_pyhf(model, data, minos=["Signal strength", "abc"])
     assert mock_minos.call_count == 1
     # first argument to minos call is the Minuit instance
     assert mock_minos.call_args[0][1] == ["x1"]

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -472,7 +472,6 @@ def test__run_minos(caplog):
         errordef=1,
     )
     m.migrad()
-
     fit._run_minos(m, ["b"], ["a", "b"])
     assert "running MINOS for b" in [rec.message for rec in caplog.records]
     assert "b = 1.5909 -0.7262 +0.4738" in [rec.message for rec in caplog.records]
@@ -490,9 +489,19 @@ def test__run_minos(caplog):
     assert "a = 1.3827 -0.8713 +0.5715" in [rec.message for rec in caplog.records]
     caplog.clear()
 
-    # unknown parameter
-    with pytest.raises(StopIteration):
-        fit._run_minos(m, ["x2"], ["a", "b"])
+    # unknown parameter, MINOS does not run
+    m = iminuit.Minuit.from_array_func(
+        func_to_minimize,
+        [1.0, 1.0],
+        errordef=1,
+    )
+    m.migrad()
+    fit._run_minos(m, ["x2"], ["a", "b"])
+    assert [rec.message for rec in caplog.records] == [
+        "parameter x2 not found in model",
+        "MINOS results:",
+    ]
+    caplog.clear()
 
 
 def test_limit(example_spec_with_background, caplog):

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 
 import awkward1 as ak
 import numpy as np
@@ -154,3 +155,16 @@ def test_unconstrained_parameter_count(example_spec, example_spec_shapefactor):
     )
     model = pyhf.Workspace(example_spec_shapefactor).model()
     assert model_utils.unconstrained_parameter_count(model) == 2
+
+
+def test__get_parameter_index(caplog):
+    caplog.set_level(logging.DEBUG)
+    labels = ["a", "b", "c"]
+    par_name = "b"
+    assert model_utils._get_parameter_index(par_name, labels) == 1
+    assert model_utils._get_parameter_index(par_name, tuple(labels)) == 1
+    caplog.clear()
+
+    assert model_utils._get_parameter_index("x", labels) == -1
+    assert "parameter x not found in model" in [rec.message for rec in caplog.records]
+    caplog.clear()


### PR DESCRIPTION
When attempting to run MINOS with parameters that are unknown (e.g. due to a typo), show an error and skip the unknown parameter instead of failing silently or crashing. This also adds a convenience function `model_utils._get_parameter_index` to obtain the index of a parameter (known by name) within a model.