### PR TITLE
feat: command line interface for parameter limits

### DIFF
--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -103,7 +103,7 @@ def workspace(config: io.TextIOWrapper, ws_spec: io.TextIOWrapper) -> None:
 )
 @click.option(
     "--figfolder",
-    default="figures/",
+    default="figures",
     help='folder to save figures to (default: "figures")',
 )
 def fit(
@@ -130,9 +130,9 @@ def fit(
         ws, asimov=asimov, minos=minos_converted, goodness_of_fit=goodness_of_fit
     )
     if pulls:
-        cabinetry_visualize.pulls(fit_results, figfolder)
+        cabinetry_visualize.pulls(fit_results, figure_folder=figfolder)
     if corrmat:
-        cabinetry_visualize.correlation_matrix(fit_results, figfolder)
+        cabinetry_visualize.correlation_matrix(fit_results, figure_folder=figfolder)
 
 
 @click.command()
@@ -143,8 +143,8 @@ def fit(
 )
 @click.option(
     "--figfolder",
-    default="figures/",
-    help="folder to save figures to (default: figures/)",
+    default="figures",
+    help='folder to save figures to (default: "figures")',
 )
 def ranking(
     ws_spec: io.TextIOWrapper, asimov: bool, max_pars: int, figfolder: str
@@ -157,7 +157,9 @@ def ranking(
     ws = json.load(ws_spec)
     fit_results = cabinetry_fit.fit(ws, asimov=asimov)
     ranking_results = cabinetry_fit.ranking(ws, fit_results, asimov=asimov)
-    cabinetry_visualize.ranking(ranking_results, figfolder, max_pars=max_pars)
+    cabinetry_visualize.ranking(
+        ranking_results, figure_folder=figfolder, max_pars=max_pars
+    )
 
 
 @click.command()
@@ -179,8 +181,8 @@ def ranking(
 @click.option("--asimov", is_flag=True, help="fit Asimov dataset (default: False)")
 @click.option(
     "--figfolder",
-    default="figures/",
-    help="folder to save figures to (default: figures/)",
+    default="figures",
+    help='folder to save figures to (default: "figures")',
 )
 def scan(
     ws_spec: io.TextIOWrapper,
@@ -218,7 +220,7 @@ def scan(
     scan_results = cabinetry_fit.scan(
         ws, par_name, par_range=par_range, n_steps=n_steps, asimov=asimov
     )
-    cabinetry_visualize.scan(scan_results, figfolder)
+    cabinetry_visualize.scan(scan_results, figure_folder=figfolder)
 
 
 @click.command()

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -221,9 +221,39 @@ def scan(
     cabinetry_visualize.scan(scan_results, figfolder)
 
 
+@click.command()
+@click.argument("ws_spec", type=click.File("r"))
+@click.option("--asimov", is_flag=True, help="fit Asimov dataset (default: False)")
+@click.option(
+    "--tolerance",
+    default=0.01,
+    help="tolerance for convergence to CLs=0.05 (default: 0.01)",
+)
+@click.option(
+    "--figfolder",
+    default="figures",
+    help='folder to save figures to (default: "figures")',
+)
+def limit(
+    ws_spec: io.TextIOWrapper,
+    asimov: bool,
+    tolerance: float,
+    figfolder: str,
+) -> None:
+    """Calculates upper limits for parameter of interest, visualizes CLs distribution.
+
+    WS_SPEC: path to workspace used in fit
+    """
+    _set_logging()
+    ws = json.load(ws_spec)
+    limit_results = cabinetry_fit.limit(ws, asimov=asimov, tolerance=tolerance)
+    cabinetry_visualize.limit(limit_results, figure_folder=figfolder)
+
+
 cabinetry.add_command(templates)
 cabinetry.add_command(postprocess)
 cabinetry.add_command(workspace)
 cabinetry.add_command(fit)
 cabinetry.add_command(ranking)
 cabinetry.add_command(scan)
+cabinetry.add_command(limit)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -326,3 +326,68 @@ def test_scan(mock_scan, mock_vis, tmp_path):
         {"par_range": (0.0, 2.0), "n_steps": 21, "asimov": True},
     )
     assert mock_vis.call_args[1] == {"figure_folder": "folder"}
+
+
+@mock.patch("cabinetry.visualize.limit", autospec=True)
+@mock.patch(
+    "cabinetry.fit.limit",
+    return_value=fit.LimitResults(
+        3.0,
+        np.asarray([1.0, 2.0, 3.0, 4.0, 5.0]),
+        np.asarray([0.05]),
+        np.asarray([0.01, 0.02, 0.05, 0.07, 0.10]),
+        np.asarray([3.0]),
+    ),
+    autospec=True,
+)
+def test_limit(mock_limit, mock_vis, tmp_path):
+    workspace = {"workspace": "mock"}
+    workspace_path = str(tmp_path / "workspace.json")
+
+    # need to save workspace to file since click looks for it
+    with open(workspace_path, "w") as f:
+        f.write('{"workspace": "mock"}')
+
+    limit_results = fit.LimitResults(
+        3.0,
+        np.asarray([1.0, 2.0, 3.0, 4.0, 5.0]),
+        np.asarray([0.05]),
+        np.asarray([0.01, 0.02, 0.05, 0.07, 0.10]),
+        np.asarray([3.0]),
+    )
+
+    runner = CliRunner()
+
+    # default
+    result = runner.invoke(cli.limit, [workspace_path])
+    assert result.exit_code == 0
+    assert mock_limit.call_args_list == [
+        ((workspace,), {"asimov": False, "tolerance": 0.01})
+    ]
+    assert mock_vis.call_count == 1
+    assert np.allclose(
+        mock_vis.call_args[0][0].observed_limit, limit_results.observed_limit
+    )
+    assert np.allclose(
+        mock_vis.call_args[0][0].expected_limit, limit_results.expected_limit
+    )
+    assert np.allclose(
+        mock_vis.call_args[0][0].observed_CLs, limit_results.observed_CLs
+    )
+    assert np.allclose(
+        mock_vis.call_args[0][0].expected_CLs, limit_results.expected_CLs
+    )
+    assert np.allclose(mock_vis.call_args[0][0].poi_values, limit_results.poi_values)
+    assert mock_vis.call_args[1] == {"figure_folder": "figures"}
+
+    # Asimov, tolerance, custom folder
+    result = runner.invoke(
+        cli.limit,
+        ["--asimov", "--tolerance", "0.1", "--figfolder", "folder", workspace_path],
+    )
+    assert result.exit_code == 0
+    assert mock_limit.call_args_list[-1] == (
+        (workspace,),
+        {"asimov": True, "tolerance": 0.1},
+    )
+    assert mock_vis.call_args_list[-1][1] == {"figure_folder": "folder"}

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -162,20 +162,28 @@ def test_fit(mock_fit, mock_pulls, mock_corrmat, tmp_path):
     # pull plot
     result = runner.invoke(cli.fit, ["--pulls", workspace_path])
     assert result.exit_code == 0
-    assert mock_pulls.call_args_list == [((fit_results, "figures/"), {})]
+    assert mock_pulls.call_args_list == [((fit_results,), {"figure_folder": "figures"})]
 
     # correlation matrix plot
     result = runner.invoke(cli.fit, ["--corrmat", workspace_path])
     assert result.exit_code == 0
-    assert mock_corrmat.call_args_list == [((fit_results, "figures/"), {})]
+    assert mock_corrmat.call_args_list == [
+        ((fit_results,), {"figure_folder": "figures"})
+    ]
 
     # both plots, different folder
     result = runner.invoke(
-        cli.fit, ["--figfolder", "folder/", "--pulls", "--corrmat", workspace_path]
+        cli.fit, ["--figfolder", "folder", "--pulls", "--corrmat", workspace_path]
     )
     assert result.exit_code == 0
-    assert mock_corrmat.call_args_list[-1] == ((fit_results, "folder/"), {})
-    assert mock_pulls.call_args_list[-1] == ((fit_results, "folder/"), {})
+    assert mock_corrmat.call_args_list[-1] == (
+        (fit_results,),
+        {"figure_folder": "folder"},
+    )
+    assert mock_pulls.call_args_list[-1] == (
+        (fit_results,),
+        {"figure_folder": "folder"},
+    )
 
 
 @mock.patch("cabinetry.visualize.ranking", autospec=True)
@@ -225,19 +233,17 @@ def test_ranking(mock_fit, mock_rank, mock_vis, tmp_path):
     assert np.allclose(mock_vis.call_args[0][0].prefit_down, [[0.8]])
     assert np.allclose(mock_vis.call_args[0][0].postfit_up, [[1.1]])
     assert np.allclose(mock_vis.call_args[0][0].postfit_down, [[0.9]])
-    assert mock_vis.call_args[0][1] == "figures/"
-    assert mock_vis.call_args[1] == {"max_pars": 10}
+    assert mock_vis.call_args[1] == {"figure_folder": "figures", "max_pars": 10}
 
     # Asimov, maximum amount of parameters, custom folder
     result = runner.invoke(
         cli.ranking,
-        ["--asimov", "--max_pars", 3, "--figfolder", "folder/", workspace_path],
+        ["--asimov", "--max_pars", 3, "--figfolder", "folder", workspace_path],
     )
     assert result.exit_code == 0
     assert mock_fit.call_args_list[-1] == ((workspace,), {"asimov": True})
     assert mock_rank.call_args_list[-1] == ((workspace, fit_results), {"asimov": True})
-    assert mock_vis.call_args_list[-1][1] == {"max_pars": 3}
-    assert mock_vis.call_args_list[-1][0][1] == "folder/"
+    assert mock_vis.call_args_list[-1][1] == {"figure_folder": "folder", "max_pars": 3}
 
 
 @mock.patch("cabinetry.visualize.scan", autospec=True)
@@ -275,7 +281,7 @@ def test_scan(mock_scan, mock_vis, tmp_path):
         mock_vis.call_args[0][0].parameter_values, scan_results.parameter_values
     )
     assert np.allclose(mock_vis.call_args[0][0].delta_nlls, scan_results.delta_nlls)
-    assert mock_vis.call_args[0][1] == "figures/"
+    assert mock_vis.call_args[1] == {"figure_folder": "figures"}
 
     # only one bound
     with pytest.raises(
@@ -309,7 +315,7 @@ def test_scan(mock_scan, mock_vis, tmp_path):
             21,
             "--asimov",
             "--figfolder",
-            "folder/",
+            "folder",
             workspace_path,
             par_name,
         ],
@@ -319,4 +325,4 @@ def test_scan(mock_scan, mock_vis, tmp_path):
         (workspace, par_name),
         {"par_range": (0.0, 2.0), "n_steps": 21, "asimov": True},
     )
-    assert mock_vis.call_args[0][1] == "folder/"
+    assert mock_vis.call_args[1] == {"figure_folder": "folder"}


### PR DESCRIPTION
Adding command line interface for upper parameter limits. See `cabinetry limit --help` for details.