### PR TITLE
fix: uproot package name migration to uproot3 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,8 +23,8 @@ python_requires = >=3.6
 install_requires =
     numpy
     pyyaml
-    pyhf>=0.5.3  # paramset.suggested_fixed
-    iminuit>1.5.1 # np_merrors(), parameter limit warning
+    pyhf>=0.5.3,<0.6  # paramset.suggested_fixed
+    iminuit>1.5.1,<2.0  # np_merrors(), parameter limit warning
     boost_histogram
     jsonschema
     click

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-extras_require = {"contrib": ["matplotlib", "uproot", "uproot4>=0.0.19"]}
+extras_require = {"contrib": ["matplotlib", "uproot3", "uproot4>=0.0.19"]}
 extras_require["test"] = sorted(
     set(
         extras_require["contrib"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-import uproot
+import uproot3 as uproot
 
 
 class Utils:

--- a/util/create_ntuples.py
+++ b/util/create_ntuples.py
@@ -3,7 +3,7 @@ import os
 
 import matplotlib.pyplot as plt
 import numpy as np
-import uproot
+import uproot3 as uproot
 
 
 def toy_distribution(noncentral, multiplier, offset, num_events):


### PR DESCRIPTION
In preparation for the migration `uproot4` -> `uproot`, the "old" `uproot` migrates to `uproot3`. Since `uproot3` is available now (https://pypi.org/project/uproot3/), this updates `uproot` -> `uproot3`. The migration `uproot4` -> `uproot` will follow later. 

Also adding upper limits for the `pyhf` and `iminuit` versions. Compatibility with `pyhf` 0.6 will require updates to `cabinetry` (#150/#156), and the interface changes in `iminuit` 2.0 will also require an update to `cabinetry`.