### PR TITLE
fix: finalize uproot/awkward name migration and update to pyhf 0.5.4

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         python -m pytest -r sx
 
-  awkward1:
+  awkward:
 
     runs-on: ${{ matrix.os }}
     strategy:
@@ -55,7 +55,7 @@ jobs:
       run: |
         python -m pytest -r sx
 
-  uproot4:
+  uproot:
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ An incomplete list of interesting tools to interface:
 
 - [ServiceX](https://github.com/ssl-hep/ServiceX) for data delivery,
 - [coffea](https://github.com/CoffeaTeam/coffea) for histogram processing,
-- [uproot](https://github.com/scikit-hep/uproot) for reading [ROOT](https://root.cern.ch/) files,
+- [uproot](https://github.com/scikit-hep/uproot4) for reading [ROOT](https://root.cern.ch/) files,
 - for building likelihood functions (captured in so-called workspaces in [RooFit](https://root.cern.ch/roofit)) and inference:
   - [RooFit](https://root.cern.ch/roofit) to model probability distributions,
   - [RooStats](http://cds.cern.ch/record/1289965) for statistical tools,

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -5,7 +5,7 @@ Accessing vector branches
 -------------------------
 
 The transverse momentum of the first jet in a vector branch ``jet_pT`` is obtained via ``jet_pT[0]`` in ``ROOT``.
-The ``uproot4`` backend for ntuple reading treats expressions (such as what is written in ``Filter`` and ``Weight`` configuration file options) as Python code.
+The ``uproot`` backend for ntuple reading treats expressions (such as what is written in ``Filter`` and ``Weight`` configuration file options) as Python code.
 The correct way to access the same information through ``cabinetry`` is ``jet_pT[:,0]``, where the first index runs over events.
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ python_requires = >=3.6
 install_requires =
     numpy
     pyyaml
-    pyhf>=0.5.3,<0.6  # paramset.suggested_fixed
+    pyhf>=0.5.4,<0.6  # uproot3 namespace
     iminuit>1.5.1,<2.0  # np_merrors(), parameter limit warning
     boost_histogram
     jsonschema

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     boost_histogram
     jsonschema
     click
-    awkward1
+    awkward>=1.0.0  # new API
     scipy
     tabulate
 
@@ -47,7 +47,6 @@ console_scripts =
 [tool:pytest]
 addopts = --cov=cabinetry --cov-report html --cov-report term-missing --cov-branch -rsx --typeguard-packages=cabinetry
 filterwarnings =
-    ignore::DeprecationWarning:uproot:
     ignore:no type annotations present:UserWarning:typeguard:
 
 [flake8]
@@ -85,10 +84,10 @@ ignore_missing_imports = True
 [mypy-numpy]
 ignore_missing_imports = True
 
-[mypy-uproot4]
+[mypy-uproot]
 ignore_missing_imports = True
 
-[mypy-awkward1]
+[mypy-awkward]
 ignore_missing_imports = True
 
 [mypy-pyhf]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-extras_require = {"contrib": ["matplotlib", "uproot3", "uproot4>=0.0.19"]}
+extras_require = {"contrib": ["matplotlib", "uproot3", "uproot>=4.0.0"]}
 extras_require["test"] = sorted(
     set(
         extras_require["contrib"]

--- a/src/cabinetry/contrib/histogram_creation.py
+++ b/src/cabinetry/contrib/histogram_creation.py
@@ -1,10 +1,10 @@
 import pathlib
 from typing import List, Optional, Tuple
 
-import awkward1 as ak
+import awkward as ak
 import boost_histogram as bh
 import numpy as np
-import uproot4 as uproot
+import uproot
 
 
 def from_uproot(

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, List, Tuple, Union
 
-import awkward1 as ak
+import awkward as ak
 import numpy as np
 import pyhf
 

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 
-import awkward1 as ak
+import awkward as ak
 import numpy as np
 import pyhf
 


### PR DESCRIPTION
This completes the name transitions `awkward1` -> `awkward>=1.0.0` and `uproot4` -> `uproot>=4.0.0`. The switch to `pyhf` [0.5.4](https://github.com/scikit-hep/pyhf/releases/tag/v0.5.4) makes this possible, since in that update `pyhf` switches to `uproot3` to access the old `uproot` API (thereby avoiding name space conflicts under the `uproot` package name).

In particular, this allows use of `cabinetry` together with the `pyhf` `xmlio` setup extra again.

related: #157