### PR TITLE
chore: updating version to 0.1.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cabinetry
-version = 0.1.6
+version = 0.1.7
 author = Alexander Held
 description = design and steer profile likelihood fits
 long_description = file: README.md

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -9,4 +9,4 @@ from . import visualize  # NOQA
 from . import workspace  # NOQA
 
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"


### PR DESCRIPTION
Updating to 0.1.7 to avoid namespace collisions with the `uproot` package when using `pyhf` with `xmlio` setup extra (see #164).