### PR TITLE
ci: Uninstall dependencies before installed HEAD versions

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip uninstall --yes pyhf
         python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/pyhf.git
         python -m pip list
     - name: Test with pytest
@@ -49,6 +50,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip uninstall --yes awkward
         python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/awkward-1.0.git
         python -m pip list
     - name: Test with pytest
@@ -73,6 +75,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip uninstall --yes uproot
         python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/uproot4.git
         python -m pip list
     - name: Test with pytest
@@ -97,6 +100,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip uninstall --yes iminuit
         python -m pip install --upgrade --no-cache-dir cython
         python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/iminuit.git
         python -m pip list
@@ -122,6 +126,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip uninstall --yes boost-histogram
         python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/boost-histogram.git
         python -m pip list
     - name: Test with pytest


### PR DESCRIPTION
This is a port of https://github.com/scikit-hep/pyhf/pull/1227 to make sure that the HEAD of dependencies workflow it operating in the way it is expected to.

```
* pip uninstall the dependency that is being tested before installing from the HEAD of version control
   - Has been shown for iminuit to be required to properly test the HEAD of the default repo branch
```