### PR TITLE
chore: Simplify install_requires and use compatible release syntax

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,9 +22,9 @@ package_dir = =src
 python_requires = >=3.6
 install_requires =
     pyhf[minuit]~=0.5.4  # uproot3 namespace; minuit: np_merrors(), parameter limit warning
-    boost_histogram
+    boost_histogram~=0.11
     awkward~=1.0  # new API
-    tabulate
+    tabulate~=0.8
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,10 +21,10 @@ packages = find:
 package_dir = =src
 python_requires = >=3.6
 install_requires =
-    pyhf>=0.5.4,<0.6  # uproot3 namespace
-    iminuit>1.5.1,<2.0  # np_merrors(), parameter limit warning
+    pyhf~=0.5.4  # uproot3 namespace
+    iminuit~=1.5  # np_merrors(), parameter limit warning
     boost_histogram
-    awkward>=1.0.0  # new API
+    awkward~=1.0  # new API
     tabulate
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,7 @@ packages = find:
 package_dir = =src
 python_requires = >=3.6
 install_requires =
-    pyhf~=0.5.4  # uproot3 namespace
-    iminuit~=1.5  # np_merrors(), parameter limit warning
+    pyhf[minuit]~=0.5.4  # uproot3 namespace; minuit: np_merrors(), parameter limit warning
     boost_histogram
     awkward~=1.0  # new API
     tabulate

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,15 +21,10 @@ packages = find:
 package_dir = =src
 python_requires = >=3.6
 install_requires =
-    numpy
-    pyyaml
     pyhf>=0.5.4,<0.6  # uproot3 namespace
     iminuit>1.5.1,<2.0  # np_merrors(), parameter limit warning
     boost_histogram
-    jsonschema
-    click
     awkward>=1.0.0  # new API
-    scipy
     tabulate
 
 [options.packages.find]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-extras_require = {"contrib": ["matplotlib", "uproot3", "uproot>=4.0.0"]}
+extras_require = {"contrib": ["matplotlib", "uproot3", "uproot~=4.0"]}
 extras_require["test"] = sorted(
     set(
         extras_require["contrib"]


### PR DESCRIPTION
Instead of listing all hard requirements out explicitly, this PR removes those dependencies from the list that `pyhf` installs through its own `install_requires`. It additionally constrains the ranges of libraries using the [compatible release synatx of PEP 440](https://www.python.org/dev/peps/pep-0440/#compatible-release).

This probably isn't ever going to be an issue, but with `pip` `v20.3` and the addition to the dependency resolver it probably helps to have better constraints on _ranges_ of dependencies. 

```
* Simplify install_requires by requiring pyhf control dependencies it installs
* Use compatible release syntax (~=) to constrain dependencies to release ranges
```