### PR TITLE
fix: yield tables for multiple multi-bin regions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     pyhf[minuit]~=0.5.4  # uproot3 namespace; minuit: np_merrors(), parameter limit warning
     boost_histogram~=0.11
     awkward~=1.0  # new API
-    tabulate~=0.8
+    tabulate~=0.8.1
 
 [options.packages.find]
 where = src

--- a/src/cabinetry/tabulate.py
+++ b/src/cabinetry/tabulate.py
@@ -87,7 +87,11 @@ def _yields(
 
     log.info(
         "yield table:\n"
-        + tabulate.tabulate(table, headers=headers, tablefmt="fancy_grid")
+        + tabulate.tabulate(
+            table,
+            headers=headers,  # type: ignore
+            tablefmt="fancy_grid",
+        )
     )
 
     return table

--- a/tests/test_tabulate.py
+++ b/tests/test_tabulate.py
@@ -9,11 +9,12 @@ from cabinetry import tabulate
     "test_input, expected",
     [
         (("abc", 0), "abc\nbin 1"),
-        (("abc", 2), "\nbin 3"),
+        (("abc", 2), "abc\nbin 3"),
     ],
 )
 def test__header_name(test_input, expected):
     assert tabulate._header_name(*test_input) == expected
+    assert tabulate._header_name("abc", 2, unique=False) == "\nbin 3"
 
 
 def test__yields(example_spec_multibin, example_spec_with_background):
@@ -28,19 +29,19 @@ def test__yields(example_spec_multibin, example_spec_with_background):
         {
             "sample": "Signal",
             "region_1\nbin 1": "25.00",
-            "\nbin 2": "5.00",
+            "region_1\nbin 2": "5.00",
             "region_2\nbin 1": "8.00",
         },
         {
             "sample": "total",
             "region_1\nbin 1": "25.00 \u00B1 5.00",
-            "\nbin 2": "5.00 \u00B1 2.00",
+            "region_1\nbin 2": "5.00 \u00B1 2.00",
             "region_2\nbin 1": "8.00 \u00B1 1.00",
         },
         {
             "sample": "data",
             "region_1\nbin 1": "35.00",
-            "\nbin 2": "8.00",
+            "region_1\nbin 2": "8.00",
             "region_2\nbin 1": "10.00",
         },
     ]


### PR DESCRIPTION
Yield table entries for bins after the first bin of a region were accidentally overwritten when multiple multi-bin regions were used. This was caused by the table header (used as dict key) not being unique. This changes the header to make it unique, by including the region name in each header (previously omitted since it seemed superfluous).

resolves #167

Previously failed `mypy` since stubs for `tabulate` were missing the `Dict[str, str]` type for headers, fixed with https://github.com/python/typeshed/pull/4835.