### PR TITLE
feat: more flexibility in parameter exclusion from pull plots

### DIFF
--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -116,7 +116,7 @@ def _fit_model_pyhf(
     data: List[float],
     init_pars: Optional[List[float]] = None,
     fix_pars: Optional[List[bool]] = None,
-    minos: Optional[List[str]] = None,
+    minos: Optional[Union[List[str], Tuple[str, ...]]] = None,
 ) -> FitResults:
     """Uses the ``pyhf.infer`` API to perform a maximum likelihood fit.
 
@@ -131,8 +131,9 @@ def _fit_model_pyhf(
             defaults to None (use ``pyhf`` suggested inits)
         fix_pars (Optional[List[bool]], optional): list of booleans specifying which
             parameters are held constant, defaults to None (use ``pyhf`` suggestion)
-        minos (Optional[List[str]], optional): runs the MINOS algorithm for all
-            parameters specified in the list, defaults to None (does not run MINOS)
+        minos (Optional[Union[List[str], Tuple[str, ...]]], optional): runs the MINOS
+            algorithm for all parameters specified, defaults to None (does not run
+            MINOS)
 
     Returns:
         FitResults: object storing relevant fit results
@@ -175,7 +176,7 @@ def _fit_model_custom(
     data: List[float],
     init_pars: Optional[List[float]] = None,
     fix_pars: Optional[List[bool]] = None,
-    minos: Optional[List[str]] = None,
+    minos: Optional[Union[List[str], Tuple[str, ...]]] = None,
 ) -> FitResults:
     """Uses ``iminuit`` directly to perform a maximum likelihood fit.
 
@@ -190,8 +191,9 @@ def _fit_model_custom(
             defaults to None (use ``pyhf`` suggested inits)
         fix_pars (Optional[List[bool]], optional): list of booleans specifying which
             parameters are held constant, defaults to None (use ``pyhf`` suggestion)
-        minos (Optional[List[str]], optional): runs the MINOS algorithm for all
-            parameters specified in the list, defaults to None (does not run MINOS)
+        minos (Optional[Union[List[str], Tuple[str, ...]]], optional): runs the MINOS
+            algorithm for all parameters specified, defaults to None (does not run
+            MINOS)
 
     Returns:
         FitResults: object storing relevant fit results
@@ -247,7 +249,7 @@ def _fit_model(
     data: List[float],
     init_pars: Optional[List[float]] = None,
     fix_pars: Optional[List[bool]] = None,
-    minos: Optional[List[str]] = None,
+    minos: Optional[Union[List[str], Tuple[str, ...]]] = None,
     custom_fit: bool = False,
 ) -> FitResults:
     """Interface for maximum likelihood fits through ``pyhf.infer`` API or ``iminuit``.
@@ -263,8 +265,9 @@ def _fit_model(
             defaults to None (use ``pyhf`` suggested inits)
         fix_pars (Optional[List[bool]], optional): list of booleans specifying which
             parameters are held constant, defaults to None (use ``pyhf`` suggestion)
-        minos (Optional[List[str]], optional): runs the MINOS algorithm for all
-            parameters specified in the list, defaults to None (does not run MINOS)
+        minos (Optional[Union[List[str], Tuple[str, ...]]], optional): runs the MINOS
+            algorithm for all parameters specified, defaults to None (does not run
+            MINOS)
         custom_fit (bool, optional): whether to use the ``pyhf.infer`` API or
             ``iminuit``, defaults to False (using ``pyhf.infer``)
 
@@ -285,12 +288,16 @@ def _fit_model(
     return fit_results
 
 
-def _run_minos(minuit_obj: iminuit.Minuit, minos: List[str], labels: List[str]) -> None:
+def _run_minos(
+    minuit_obj: iminuit.Minuit,
+    minos: Union[List[str], Tuple[str, ...]],
+    labels: List[str],
+) -> None:
     """Determines parameter uncertainties for a list of parameters with MINOS.
 
     Args:
         minuit_obj (iminuit.Minuit): Minuit instance to use
-        minos (List[str]): parameters for which MINOS is run
+        minos (Union[List[str], Tuple[str, ...]]): parameters for which MINOS is run
         labels (List[str]]): names of all parameters known to ``iminuit``, these names
             are used in output (may be the same as the names under which ``iminiuit``
             knows parameters)
@@ -359,7 +366,7 @@ def _goodness_of_fit(
 def fit(
     spec: Dict[str, Any],
     asimov: bool = False,
-    minos: Optional[Union[str, List[str]]] = None,
+    minos: Optional[Union[str, List[str], Tuple[str, ...]]] = None,
     goodness_of_fit: bool = False,
     custom_fit: bool = False,
 ) -> FitResults:
@@ -372,8 +379,9 @@ def fit(
     Args:
         spec (Dict[str, Any]): a ``pyhf`` workspace specification
         asimov (bool, optional): whether to fit the Asimov dataset, defaults to False
-        minos (Optional[Union[str, List[str]]], optional): runs the MINOS algorithm for
-            all parameters specified in the list, defaults to None (does not run MINOS)
+        minos (Optional[Union[str, List[str], Tuple[str, ...]]], optional): runs the
+            MINOS algorithm for all parameters specified, defaults to None (does not run
+            MINOS)
         goodness_of_fit (bool, optional): calculate goodness of fit with a saturated
             model (perfectly fits data with shapefactors in all bins), defaults to False
         custom_fit (bool, optional): whether to use the ``pyhf.infer`` API or
@@ -386,8 +394,8 @@ def fit(
 
     model, data = model_utils.model_and_data(spec, asimov=asimov)
 
-    # convert minos parameter to list, if a parameter is specified and is not a list
-    if minos is not None and not isinstance(minos, list):
+    # convert minos parameter to list if a single parameter is specified as string
+    if minos is not None and isinstance(minos, str):
         minos = [minos]
 
     # perform fit

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -294,8 +294,8 @@ def pulls(
             parameter labels
         figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
             figures in, defaults to "figures"
-        exclude (Optional[Union[str, List[str]]], optional): parameter or list/tuple of
-            parameters to exclude from plot, defaults to None (nothing excluded)
+        exclude (Optional[Union[str, List[str], Tuple[str, ...]]], optional): parameter
+            or parameters to exclude from plot, defaults to None (nothing excluded)
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
 
     Raises:

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -1,7 +1,7 @@
 import glob
 import logging
 import pathlib
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -284,7 +284,7 @@ def correlation_matrix(
 def pulls(
     fit_results: fit.FitResults,
     figure_folder: Union[str, pathlib.Path] = "figures",
-    exclude_list: Optional[List[str]] = None,
+    exclude: Optional[Union[str, List[str], Tuple[str, ...]]] = None,
     method: str = "matplotlib",
 ) -> None:
     """Draws a pull plot of parameter results and uncertainties.
@@ -294,8 +294,8 @@ def pulls(
             parameter labels
         figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
             figures in, defaults to "figures"
-        exclude_list (Optional[List[str]], optional): list of parameters to exclude from
-            plot, defaults to None (nothing excluded)
+        exclude (Optional[Union[str, List[str]]], optional): parameter or list/tuple of
+            parameters to exclude from plot, defaults to None (nothing excluded)
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
 
     Raises:
@@ -304,21 +304,27 @@ def pulls(
     figure_path = pathlib.Path(figure_folder) / "pulls.pdf"
     labels_np = np.asarray(fit_results.labels)
 
-    if exclude_list is None:
-        exclude_list = []
+    if exclude is None:
+        exclude_set = set()
+    elif isinstance(exclude, str):
+        exclude_set = {exclude}
+    else:
+        exclude_set = set(exclude)
 
     # exclude fixed parameters from pull plot
-    exclude_list += [
-        label
-        for i_np, label in enumerate(labels_np)
-        if fit_results.uncertainty[i_np] == 0.0
-    ]
+    exclude_set.update(
+        [
+            label
+            for i_np, label in enumerate(labels_np)
+            if fit_results.uncertainty[i_np] == 0.0
+        ]
+    )
 
     # exclude staterror parameters from pull plot (they are centered at 1)
-    exclude_list += [label for label in labels_np if label[0:10] == "staterror_"]
+    exclude_set.update([label for label in labels_np if label[0:10] == "staterror_"])
 
-    # filter out parameters
-    mask = [True if label not in exclude_list else False for label in labels_np]
+    # filter out user-specified parameters
+    mask = [True if label not in exclude_set else False for label in labels_np]
     bestfit = fit_results.bestfit[mask]
     uncertainty = fit_results.uncertainty[mask]
     labels_np = labels_np[mask]

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -295,7 +295,7 @@ def test_pulls(mock_draw):
     bestfit = np.asarray([0.8, 1.0, 1.05, 1.1])
     uncertainty = np.asarray([0.9, 1.0, 0.03, 0.7])
     labels = ["a", "b", "staterror_region[bin_0]", "c"]
-    exclude_list = ["a"]
+    exclude = ["a"]
     folder_path = "tmp"
     fit_results = fit.FitResults(bestfit, uncertainty, labels, np.empty(0), 1.0)
 
@@ -308,7 +308,7 @@ def test_pulls(mock_draw):
     visualize.pulls(
         fit_results,
         figure_folder=folder_path,
-        exclude_list=exclude_list,
+        exclude=exclude,
         method="matplotlib",
     )
 
@@ -349,7 +349,7 @@ def test_pulls(mock_draw):
         visualize.pulls(
             fit_results,
             figure_folder=folder_path,
-            exclude_list=exclude_list,
+            exclude=exclude,
             method="unknown",
         )
 

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -324,6 +324,22 @@ def test_pulls(mock_draw):
     assert mock_draw.call_args[0][3] == figure_path
     assert mock_draw.call_args[1] == {}
 
+    # filtering single parameter instead of list
+    visualize.pulls(
+        fit_results,
+        figure_folder=folder_path,
+        exclude=exclude[0],
+        method="matplotlib",
+    )
+    assert np.allclose(mock_draw.call_args[0][0], filtered_bestfit)
+    assert np.allclose(mock_draw.call_args[0][1], filtered_uncertainty)
+    assert np.any(
+        [
+            mock_draw.call_args[0][2][i] == filtered_labels[i]
+            for i in range(len(filtered_labels))
+        ]
+    )
+
     # without filtering via list, but with staterror removal
     # and fixed parameter removal
     fit_results.uncertainty[0] = 0.0


### PR DESCRIPTION
The `exclude_list` keyword argument in `cabinetry.visualize.pulls` used to require a list. This adds support for strings (single parameter) and tuples. The old name does not make sense anymore with the support of these types, so the argument is renamed and now called `exclude`.

Also updating typing for `minos` parameter that contains the parameters to run MINOS on. With this, `cabinetry.fit.fit` now properly supports tuples for this parameter. They already worked fine before, but not with runtime type checks.

**Breaking change:**
- `cabinetry.visualize.pulls` keyword argument `exclude_list` renamed to `exclude`