### PR TITLE
feat: root finding for faster limit convergence

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,7 @@
 .. image:: _static/cabinetry_logo_small.png
   :width: 480
   :alt: cabinetry logo
+  :align: center
 
 cabinetry
 ==============================

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ filterwarnings =
     ignore:no type annotations present:UserWarning:typeguard:
 
 [flake8]
-max-complexity = 12
+max-complexity = 15
 max-line-length = 88
 exclude = docs/conf.py
 count = True

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -591,6 +591,7 @@ def limit(
     bracket: Optional[Union[List[float], Tuple[float, float]]] = None,
     asimov: bool = False,
     tolerance: float = 0.01,
+    maxiter: int = 100,
 ) -> LimitResults:
     """Calculates observed and expected 95% confidence level upper parameter limits.
 
@@ -606,6 +607,8 @@ def limit(
         asimov (bool, optional): whether to fit the Asimov dataset, defaults to False
         tolerance (float, optional): tolerance in POI value for convergence to CLs=0.05,
             defaults to 0.01
+        maxiter (int, optional): maximum number of steps for limit finding, defaults to
+            100
 
     Raises:
         ValueError: if lower and upper bracket value are the same
@@ -664,8 +667,7 @@ def limit(
         if poi <= 0:
             # no fit needed for negative POI value, return a default value
             log.debug(
-                f"optimizer used {model.config.poi_name} = {poi:.4f}, skipping fit and "
-                f"setting CLs = 1"
+                f"skipping fit for {model.config.poi_name} = {poi:.4f}, setting CLs = 1"
             )
             return 0.95  # corresponds to distance of CLs = 1 to target CLs = 0.05
         cache = cache_CLs.get(poi)
@@ -717,7 +719,7 @@ def limit(
                 bracket=bracket,
                 args=(data, model, i_limit, limit_label),
                 method="brentq",
-                options={"xtol": tolerance, "maxiter": 100},
+                options={"xtol": tolerance, "maxiter": maxiter},
             )
         except ValueError:
             # invalid starting bracket is most common issue

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -604,8 +604,8 @@ def limit(
             lie between these values and the values must not be the same, defaults to
             None (then uses ``(0.01, 10.0)`` as default)
         asimov (bool, optional): whether to fit the Asimov dataset, defaults to False
-        tolerance (float, optional): tolerance for convergence to CLs=0.05, defaults to
-            0.01
+        tolerance (float, optional): tolerance in POI value for convergence to CLs=0.05,
+            defaults to 0.01
 
     Raises:
         ValueError: if lower and upper bracket value are the same

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -588,7 +588,7 @@ def scan(
 
 def limit(
     spec: Dict[str, Any],
-    bracket: Optional[List[float]] = None,
+    bracket: Optional[Union[List[float], Tuple[float, float]]] = None,
     asimov: bool = False,
     tolerance: float = 0.01,
 ) -> LimitResults:
@@ -599,10 +599,10 @@ def limit(
 
     Args:
         spec (Dict[str, Any]): a ``pyhf`` workspace specification
-        bracket (Optional[List[float]], optional): the two POI values used to start the
-            observed limit determination, example: ``[1.0, 2.0]`` (final POI values may
-            lie outside this bracket), the two values must not be the same, defaults to
-            None (then uses ``[0.5, 1.5]`` as default)
+        bracket (Optional[Union[List[float], Tuple[float, float]]], optional): the two
+            POI values used to start the observed limit determination, the limit must
+            lie between these values and the values must not be the same, defaults to
+            None (then uses ``(0.01, 10.0)`` as default)
         asimov (bool, optional): whether to fit the Asimov dataset, defaults to False
         tolerance (float, optional): tolerance for convergence to CLs=0.05, defaults to
             0.01
@@ -613,8 +613,10 @@ def limit(
     Returns:
         LimitResults: observed and expected limits, CLs values, and scanned points
     """
+    bracket_left_default = 0.01
+    bracket_right_default = 10.0
     if bracket is None:
-        bracket = [0.5, 1.5]
+        bracket = (bracket_left_default, bracket_right_default)
     elif bracket[0] == bracket[1]:
         raise ValueError(f"the two bracket values must not be the same: " f"{bracket}")
 
@@ -631,19 +633,21 @@ def limit(
     poi_list = []  # scanned POI values
     observed_CLs_list = []  # observed CLs values, one entry per scan point
     expected_CLs_list = []  # expected CLs values, 5 per point (with 1 and 2 sigma band)
+    cache_CLs: Dict[float, tuple] = {}  # cache to avoid re-fitting
 
-    def _CLs_distance_to_crossing(
+    def _CLs_minus_threshold(
         poi: float,
         data: List[float],
         model: pyhf.pdf.Model,
         which_limit: int,
         limit_label: str,
     ) -> float:
-        """Objective function to minimize in order to find CLs=0.05 crossing.
+        """The root of this function is the POI value at the CLs=0.05 crossing.
 
         Each observed and expected CLs result is also appended to lists, useful for
         visualization and to optimize the starting bracket for subsequent calculations.
-        For POI values below 0, returns the maximum possible distance of 0.95.
+        Returns 0.95 for POI values below 0. Makes use of an external cache to avoid
+        re-fitting with known POI values.
 
         Args:
             poi (float): value for parameter of interest
@@ -657,30 +661,36 @@ def limit(
         Returns:
             float: absolute value of difference to CLs=0.05
         """
-        if poi < 0:
+        if poi <= 0:
             # no fit needed for negative POI value, return a default value
             log.debug(
                 f"optimizer used {model.config.poi_name} = {poi:.4f}, skipping fit and "
                 f"setting CLs = 1"
             )
             return 0.95  # corresponds to distance of CLs = 1 to target CLs = 0.05
-        results = pyhf.infer.hypotest(
-            poi,
-            data,
-            model,
-            qtilde=True,
-            return_expected_set=True,
-            par_bounds=par_bounds,
-        )
-        observed = float(results[0])
-        expected = np.asarray(results[1])
-        poi_list.append(poi)
-        observed_CLs_list.append(observed)
-        expected_CLs_list.append(expected)
+        cache = cache_CLs.get(poi)
+        if cache:
+            observed, expected = cache  # use result from cache
+        else:
+            # calculate CLs
+            results = pyhf.infer.hypotest(
+                poi,
+                data,
+                model,
+                qtilde=True,
+                return_expected_set=True,
+                par_bounds=par_bounds,
+            )
+            observed = float(results[0])
+            expected = np.asarray(results[1])
+            poi_list.append(poi)
+            observed_CLs_list.append(observed)
+            expected_CLs_list.append(expected)
+            cache_CLs.update({poi: (observed, expected)})
         current_CLs = np.hstack((observed, expected))[which_limit]
         log.debug(
             f"{model.config.poi_name} = {poi:.4f}, {limit_label} CLs = "
-            f"{current_CLs:.4f}"
+            f"{current_CLs:.4f}{' (cached)' if cache else ''}"
         )
         return current_CLs - 0.05
 
@@ -700,14 +710,23 @@ def limit(
     for i_limit, limit_label in enumerate(limit_labels):
         log.info(f"determining {limit_label} upper limit")
 
-        # find the 95% CL upper limit
-        res = scipy.optimize.root_scalar(
-            _CLs_distance_to_crossing,
-            bracket=bracket,
-            args=(data, model, i_limit, limit_label),
-            method="brentq",
-            options={"xtol": tolerance, "maxiter": 100},
-        )
+        try:
+            # find the 95% CL upper limit
+            res = scipy.optimize.root_scalar(
+                _CLs_minus_threshold,
+                bracket=bracket,
+                args=(data, model, i_limit, limit_label),
+                method="brentq",
+                options={"xtol": tolerance, "maxiter": 100},
+            )
+        except ValueError:
+            # invalid starting bracket is most common issue
+            log.error(
+                f"CLs values at {bracket[0]:.4f} and {bracket[1]:.4f} do not bracket "
+                f"CLs=0.05, try a different starting bracket"
+            )
+            raise
+
         if not res.converged:
             log.error(
                 f"failed to converge after {res.function_calls} steps: {res.flag}"
@@ -722,23 +741,28 @@ def limit(
 
         # determine the starting bracket for the next limit calculation
         if i_limit < 5:
-            # get sorted list of POI values and associated expected CLs
-            sorted_indices = np.argsort(poi_list)
-            expected_CLs_np = np.asarray(expected_CLs_list)[sorted_indices]
-            poi_list_np = np.asarray(poi_list)[sorted_indices]
+            # list of POI values and associated expected CLs
+            exp_CLs_next = np.asarray(expected_CLs_list)[:, i_limit]
 
-            # interpolate to get expected CLs=0.06 and CLs=0.04 positions, inverted as
-            # np.interp expects function to increase
-            # for i_limit = 0, the next limit will be expected -2 sigma, corresponding
-            # to expected_CLs_np[:, 0] etc.
-            next_bracket: List[float] = np.interp(
-                [0.07, 0.03], expected_CLs_np[:, i_limit][::-1], poi_list_np[::-1]
-            ).tolist()
-            # if the interpolation fails and the lower/upper bound are the same, then
-            # offset both values to avoid getting stuck
-            if next_bracket[0] == next_bracket[1]:
-                next_bracket = [next_bracket[0] - 1, next_bracket[1] + 1]
-            bracket = next_bracket
+            # left: CLs has to be > 0.05, mask out values where CLs <= 0.05
+            masked_CLs_left = np.where(exp_CLs_next <= 0.05, 1, exp_CLs_next)
+            if sum(masked_CLs_left != 1) == 0:
+                # all values are below 0.05, pick default lower bound
+                bracket_left = bracket_left_default
+            else:
+                # find closest to CLs = 0.05 from above
+                bracket_left = poi_list[np.argmin(masked_CLs_left)]
+
+            # right: CLs has to be < 0.05, mask out values where CLs >= 0.05
+            masked_CLs_right = np.where(exp_CLs_next >= 0.05, -1, exp_CLs_next)
+            if sum(masked_CLs_right != -1) == 0:
+                # all values are above 0.05, pick default upper bound
+                bracket_right = bracket_right_default
+            else:
+                # find closest to CLs=0.05 from below
+                bracket_right = poi_list[np.argmax(masked_CLs_right)]
+
+            bracket = (bracket_left, bracket_right)
 
     # report all results
     log.info(f"total of {steps_total} steps to calculate all limits")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -214,10 +214,10 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     )
 
     # upper limit, this calculation is slow
-    limit_results = cabinetry.fit.limit(ws, bracket=[0.5, 3.5], tolerance=0.05)
-    assert np.allclose(limit_results.observed_limit, 3.2295, rtol=1e-2)
+    limit_results = cabinetry.fit.limit(ws, bracket=(0.5, 3.5), tolerance=0.05)
+    assert np.allclose(limit_results.observed_limit, 3.1502, rtol=1e-2)
     assert np.allclose(
         limit_results.expected_limit,
-        [1.0464, 1.4309, 1.8968, 2.6627, 3.4603],
+        [1.0054, 1.3975, 1.9689, 2.7174, 3.5426],
         rtol=1e-2,
     )


### PR DESCRIPTION
The previous implementation to find CLs=0.05 crossings minimized `|CLs-0.05|`. This was not very efficient. A more efficient approach is using Brent's method to find roots `CLs-0.05 = 0`. This requires a suitable starting bracket `[a, b]` where `f(a)` and `f(b)` have different signs. In this case, two POI values are needed, where one is below the limit and one above.

For further performance improvements, caching is added to skip the hypothesis test for POI values that have been tested before. Typically that skips two tests per limit (10 total for observed, expected and expected +/- 1,2 sigma).

The full test suite is around 25% faster with this change.

The new method is more precise in the examples tested.

A new keyword argument `maxiter` allows to set the maximum amount of iterations before aborting the root finding for each CLs crossing.