### PR TITLE
feat: discovery significance

### DIFF
--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -246,7 +246,7 @@ def limit(
     tolerance: float,
     figfolder: str,
 ) -> None:
-    """Calculates upper limits for parameter of interest, visualizes CLs distribution.
+    """Calculates upper limits, visualizes CLs distribution.
 
     WS_SPEC: path to workspace used in fit
     """
@@ -257,6 +257,23 @@ def limit(
     cabinetry_visualize.limit(limit_results, figure_folder=figfolder)
 
 
+@click.command()
+@click.argument("ws_spec", type=click.File("r"))
+@click.option("--asimov", is_flag=True, help="fit Asimov dataset (default: False)")
+def significance(
+    ws_spec: io.TextIOWrapper,
+    asimov: bool,
+) -> None:
+    """Calculates observed and expected discovery significance.
+
+    WS_SPEC: path to workspace used in fit
+    """
+    _set_logging()
+    ws = json.load(ws_spec)
+    model, data = cabinetry_model_utils.model_and_data(ws, asimov=asimov)
+    _ = cabinetry_fit.significance(model, data)
+
+
 cabinetry.add_command(templates)
 cabinetry.add_command(postprocess)
 cabinetry.add_command(workspace)
@@ -264,3 +281,4 @@ cabinetry.add_command(fit)
 cabinetry.add_command(ranking)
 cabinetry.add_command(scan)
 cabinetry.add_command(limit)
+cabinetry.add_command(significance)

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -246,7 +246,7 @@ def limit(
     tolerance: float,
     figfolder: str,
 ) -> None:
-    """Calculates upper limits, visualizes CLs distribution.
+    """Calculates upper limits and visualizes CLs distribution.
 
     WS_SPEC: path to workspace used in fit
     """

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -804,8 +804,7 @@ def limit(
 def significance(model: pyhf.pdf.Model, data: List[float]) -> SignificanceResults:
     """Calculates the discovery significance of a positive signal.
 
-    Observed and expected p-value and significance are identical by construction when
-    fitting the Asimov dataset.
+    Observed and expected p-values and significances are both calculated and reported.
 
     Args:
         model (pyhf.pdf.Model): model to use in fits

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -801,7 +801,7 @@ def limit(
     return limit_results
 
 
-def significance(spec: Dict[str, Any], asimov: bool = False) -> SignificanceResults:
+def significance(model: pyhf.pdf.Model, data: List[float]) -> SignificanceResults:
     """Calculates the discovery significance of a positive signal.
 
     Observed and expected p-value and significance are identical by construction when
@@ -812,8 +812,6 @@ def significance(spec: Dict[str, Any], asimov: bool = False) -> SignificanceResu
         asimov (bool, optional): whether to fit the Asimov dataset, defaults to False
     """
     pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=True))
-
-    model, data = model_utils.model_and_data(spec, asimov=asimov)
 
     log.info("calculating discovery significance")
     obs_p_val, exp_p_val = pyhf.infer.hypotest(

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -154,7 +154,7 @@ def _fit_model_pyhf(
     Returns:
         FitResults: object storing relevant fit results
     """
-    pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=True))
+    pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=1))
 
     result, result_obj = pyhf.infer.mle.fit(
         data,
@@ -215,7 +215,7 @@ def _fit_model_custom(
     Returns:
         FitResults: object storing relevant fit results
     """
-    pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=True))
+    pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=1))
 
     # use init_pars provided in function argument if they exist, else use default
     init_pars = init_pars or model.config.suggested_init()
@@ -632,7 +632,7 @@ def limit(
     Returns:
         LimitResults: observed and expected limits, CLs values, and scanned points
     """
-    pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=False))
+    pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=1))
 
     log.info(f"calculating upper limit for {model.config.poi_name}")
 
@@ -811,7 +811,7 @@ def significance(model: pyhf.pdf.Model, data: List[float]) -> SignificanceResult
         model (pyhf.pdf.Model): model to use in fits
         data (List[float]): data (including auxdata) the model is fit to
     """
-    pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=True))
+    pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=1))
 
     log.info("calculating discovery significance")
     obs_p_val, exp_p_val = pyhf.infer.hypotest(

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -822,10 +822,10 @@ def significance(model: pyhf.pdf.Model, data: List[float]) -> SignificanceResult
     obs_significance = scipy.stats.norm.isf(obs_p_val, 0, 1)
     exp_significance = scipy.stats.norm.isf(exp_p_val, 0, 1)
 
-    log.info(f"observed p-value: {obs_p_val:.6f}")
-    log.info(f"observed significance: {obs_significance:.2f}")
-    log.info(f"expected p-value: {exp_p_val:.6f}")
-    log.info(f"expected significance: {exp_significance:.2f}")
+    log.info(f"observed p-value: {obs_p_val:.8%}")
+    log.info(f"observed significance: {obs_significance:.3f}")
+    log.info(f"expected p-value: {exp_p_val:.8%}")
+    log.info(f"expected significance: {exp_significance:.3f}")
 
     significance_results = SignificanceResults(
         obs_p_val, obs_significance, exp_p_val, exp_significance

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -808,8 +808,8 @@ def significance(model: pyhf.pdf.Model, data: List[float]) -> SignificanceResult
     fitting the Asimov dataset.
 
     Args:
-        spec (Dict[str, Any]): a ``pyhf`` workspace specification
-        asimov (bool, optional): whether to fit the Asimov dataset, defaults to False
+        model (pyhf.pdf.Model): model to use in fits
+        data (List[float]): data (including auxdata) the model is fit to
     """
     pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=True))
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -446,7 +446,7 @@ def test_significance(mock_util, mock_sig, tmp_path):
     assert mock_util.call_args_list == [((workspace,), {"asimov": False})]
     assert mock_sig.call_args_list == [(("model", "data"), {})]
 
-    # Asimov, tolerance, custom folder
+    # Asimov
     result = runner.invoke(cli.significance, ["--asimov", workspace_path])
     assert result.exit_code == 0
     assert mock_util.call_args_list[-1] == ((workspace,), {"asimov": True})

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -422,3 +422,32 @@ def test_limit(mock_util, mock_limit, mock_vis, tmp_path):
     assert mock_util.call_args_list[-1] == ((workspace,), {"asimov": True})
     assert mock_limit.call_args_list[-1] == (("model", "data"), {"tolerance": 0.1})
     assert mock_vis.call_args_list[-1][1] == {"figure_folder": "folder"}
+
+
+@mock.patch("cabinetry.fit.significance", autospec=True)
+@mock.patch(
+    "cabinetry.model_utils.model_and_data",
+    return_value=("model", "data"),
+    autospec=True,
+)
+def test_significance(mock_util, mock_sig, tmp_path):
+    workspace = {"workspace": "mock"}
+    workspace_path = str(tmp_path / "workspace.json")
+
+    # need to save workspace to file since click looks for it
+    with open(workspace_path, "w") as f:
+        f.write('{"workspace": "mock"}')
+
+    runner = CliRunner()
+
+    # default
+    result = runner.invoke(cli.significance, [workspace_path])
+    assert result.exit_code == 0
+    assert mock_util.call_args_list == [((workspace,), {"asimov": False})]
+    assert mock_sig.call_args_list == [(("model", "data"), {})]
+
+    # Asimov, tolerance, custom folder
+    result = runner.invoke(cli.significance, ["--asimov", workspace_path])
+    assert result.exit_code == 0
+    assert mock_util.call_args_list[-1] == ((workspace,), {"asimov": True})
+    assert mock_sig.call_args_list[-1] == (("model", "data"), {})

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -77,6 +77,20 @@ def test_LimitResults():
     assert np.allclose(limit_results.poi_values, poi_values)
 
 
+def test_SignificanceResults():
+    obs_p_val = 0.05
+    obs_significance = 2
+    exp_p_val = 0.32
+    exp_significance = 1
+    significance_results = fit.SignificanceResults(
+        obs_p_val, obs_significance, exp_p_val, exp_significance
+    )
+    assert significance_results.observed_p_value == obs_p_val
+    assert significance_results.observed_significance == obs_significance
+    assert significance_results.expected_p_value == exp_p_val
+    assert significance_results.expected_significance == exp_significance
+
+
 def test_print_results(caplog):
     caplog.set_level(logging.DEBUG)
 
@@ -607,3 +621,18 @@ def test_limit(example_spec_with_background, caplog):
     with pytest.raises(ValueError, match="the two bracket values must not be the same"):
         fit.limit(model, data, bracket=(3.0, 3.0))
     caplog.clear()
+
+
+def test_significance(example_spec_with_background):
+    significance_results = fit.significance(example_spec_with_background)
+    assert np.allclose(significance_results.observed_p_value, 0.23773068)
+    assert np.allclose(significance_results.observed_significance, 0.71362132)
+    assert np.allclose(significance_results.expected_p_value, 0.00049159)
+    assert np.allclose(significance_results.expected_significance, 3.29529432)
+
+    # Asimov dataset, observed = expected
+    significance_results = fit.significance(example_spec_with_background, asimov=True)
+    assert np.allclose(significance_results.observed_p_value, 0.00031984)
+    assert np.allclose(significance_results.observed_significance, 3.41421033)
+    assert np.allclose(significance_results.expected_p_value, 0.00031984)
+    assert np.allclose(significance_results.expected_significance, 3.41421033)

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -624,14 +624,16 @@ def test_limit(example_spec_with_background, caplog):
 
 
 def test_significance(example_spec_with_background):
-    significance_results = fit.significance(example_spec_with_background)
+    model, data = model_utils.model_and_data(example_spec_with_background)
+    significance_results = fit.significance(model, data)
     assert np.allclose(significance_results.observed_p_value, 0.23773068)
     assert np.allclose(significance_results.observed_significance, 0.71362132)
     assert np.allclose(significance_results.expected_p_value, 0.00049159)
     assert np.allclose(significance_results.expected_significance, 3.29529432)
 
     # Asimov dataset, observed = expected
-    significance_results = fit.significance(example_spec_with_background, asimov=True)
+    model, data = model_utils.model_and_data(example_spec_with_background, asimov=True)
+    significance_results = fit.significance(model, data)
     assert np.allclose(significance_results.observed_p_value, 0.00031984)
     assert np.allclose(significance_results.observed_significance, 3.41421033)
     assert np.allclose(significance_results.expected_p_value, 0.00031984)

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -78,9 +78,9 @@ def test_LimitResults():
 
 
 def test_SignificanceResults():
-    obs_p_val = 0.05
+    obs_p_val = 0.02
     obs_significance = 2
-    exp_p_val = 0.32
+    exp_p_val = 0.16
     exp_significance = 1
     significance_results = fit.SignificanceResults(
         obs_p_val, obs_significance, exp_p_val, exp_significance

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -247,3 +247,10 @@ def test_integration(tmp_path, ntuple_creator, caplog):
         [1.0054, 1.3975, 1.9689, 2.7174, 3.5426],
         rtol=1e-2,
     )
+
+    # discovery significance
+    significance_results = cabinetry.fit.significance(model, data)
+    np.allclose(significance_results.observed_p_value, 0.03583662)
+    np.allclose(significance_results.observed_significance, 1.80118813)
+    np.allclose(significance_results.expected_p_value, 0.14775040)
+    np.allclose(significance_results.expected_significance, 1.04613046)


### PR DESCRIPTION
This adds functionality to calculate observed/expected discovery significance for a positive signal via `fit.significance`. The implementation relies on https://github.com/scikit-hep/pyhf/pull/1232. This functionality is also available via the CLI with `cabinetry significance`.

A new class `fit.SignificanceResults` is used as a container storing results of a significance calculation (observed and expected p-value and significance).

Requires `pyhf` 0.6 and #156, which are both now available.

Also updates the Minuit verbosity through pyhf, now using the `iminuit` v2 API style.

closes #100