### PR TITLE
refactor: string formatting

### DIFF
--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -320,7 +320,7 @@ def _run_minos(
         if unc_up != 0.0 or unc_down != 0.0:
             log.info(
                 f"{labels[i_par]:<{max_label_length}} = "
-                f"{minuit_obj.np_values()[i_par]: .4f} -{unc_down:.4f} +{unc_up:.4f}"
+                f"{minuit_obj.np_values()[i_par]: .4f} {-unc_down:.4f} {unc_up:+.4f}"
             )
 
 

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -106,7 +106,7 @@ def print_results(
     log.info("fit results (with symmetric uncertainties):")
     for i, label in enumerate(fit_results.labels):
         log.info(
-            f"{label.ljust(max_label_length)}: {fit_results.bestfit[i]: .4f} +/- "
+            f"{label:<{max_label_length}} = {fit_results.bestfit[i]: .4f} +/- "
             f"{fit_results.uncertainty[i]:.4f}"
         )
 
@@ -319,8 +319,8 @@ def _run_minos(
         # the uncertainties are 0.0 by default if MINOS has not been run
         if unc_up != 0.0 or unc_down != 0.0:
             log.info(
-                f"{labels[i_par].ljust(max_label_length)} = "
-                f"{minuit_obj.np_values()[i_par]:.4f} -{unc_down:.4f} +{unc_up:.4f}"
+                f"{labels[i_par]:<{max_label_length}} = "
+                f"{minuit_obj.np_values()[i_par]: .4f} -{unc_down:.4f} +{unc_up:.4f}"
             )
 
 

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -359,7 +359,7 @@ def _goodness_of_fit(
     ) - model_utils.unconstrained_parameter_count(model)
     log.debug(f"number of degrees of freedom: {n_dof}")
     p_val = scipy.stats.chi2.sf(2 * delta_nll, n_dof)
-    log.info(f"p-value for goodness-of-fit test: {p_val*100:.2f}%")
+    log.info(f"p-value for goodness-of-fit test: {p_val:.2%}")
     return p_val
 
 

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -86,8 +86,8 @@ def test_print_results(caplog):
     fit_results = fit.FitResults(bestfit, uncertainty, labels, np.empty(0), 0.0)
 
     fit.print_results(fit_results)
-    assert "param_A:  1.0000 +/- 0.1000" in [rec.message for rec in caplog.records]
-    assert "param_B:  2.0000 +/- 0.3000" in [rec.message for rec in caplog.records]
+    assert "param_A =  1.0000 +/- 0.1000" in [rec.message for rec in caplog.records]
+    assert "param_B =  2.0000 +/- 0.3000" in [rec.message for rec in caplog.records]
     caplog.clear()
 
 
@@ -286,7 +286,7 @@ def test__run_minos(caplog):
     m.migrad()
     fit._run_minos(m, ["b"], ["a", "b"])
     assert "running MINOS for b" in [rec.message for rec in caplog.records]
-    assert "b = 1.5909 -0.7262 +0.4738" in [rec.message for rec in caplog.records]
+    assert "b =  1.5909 -0.7262 +0.4738" in [rec.message for rec in caplog.records]
     caplog.clear()
 
     # proper labels not known to iminuit
@@ -298,7 +298,7 @@ def test__run_minos(caplog):
     m.migrad()
     fit._run_minos(m, ["x0"], ["a", "b"])
     assert "running MINOS for a" in [rec.message for rec in caplog.records]
-    assert "a = 1.3827 -0.8713 +0.5715" in [rec.message for rec in caplog.records]
+    assert "a =  1.3827 -0.8713 +0.5715" in [rec.message for rec in caplog.records]
     caplog.clear()
 
     # unknown parameter, MINOS does not run

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -145,7 +145,7 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     assert np.allclose(fit_results.goodness_of_fit, 0.24679341)
 
     # minos result
-    assert "Signal_norm                    = 1.6895 -0.9580 +0.9052" in [
+    assert "Signal_norm                    =  1.6895 -0.9580 +0.9052" in [
         rec.message for rec in caplog.records
     ]
 


### PR DESCRIPTION
Make better use of [Python's built-in string formatting](https://docs.python.org/3/library/string.html#format-specification-mini-language):
- `<` instead of `ljust`
- empty space to align positive and negative numbers (leaving space for minus sign)
- `%` for percentages
- `+` to force sign for positive values as well