### PR TITLE
docs: change logo location for PyPI rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center"><img src="docs/_static/cabinetry_logo_small.png" alt="cabinetry logo"></div>
+<div align="center"><img src="https://raw.githubusercontent.com/alexander-held/cabinetry/master/docs/_static/cabinetry_logo_small.png" alt="cabinetry logo"></div>
 
 [![CI status](https://github.com/alexander-held/cabinetry/workflows/CI/badge.svg)](https://github.com/alexander-held/cabinetry/actions?query=workflow%3ACI)
 [![Documentation Status](https://readthedocs.org/projects/cabinetry/badge/?version=latest)](https://cabinetry.readthedocs.io/en/latest/?badge=latest)


### PR DESCRIPTION
The relative link to the logo in `docs/` breaks the visualization of the logo on [PyPI](https://pypi.org/project/cabinetry/). Switch to using the logo from https://raw.githubusercontent.com, which should allow the logo to also show up on PyPI. The logo shown there will break if the logo is renamed/moved in the future.