### PR TITLE
feat: data/MC plots without configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,23 +50,23 @@ To run the following example, first generate the input files via the script `uti
 ```python
 import cabinetry
 
-cabinetry_config = cabinetry.configuration.load("config_example.yml")
+config = cabinetry.configuration.load("config_example.yml")
 
 # create template histograms
-cabinetry.template_builder.create_histograms(cabinetry_config)
+cabinetry.template_builder.create_histograms(config)
 
 # perform histogram post-processing
-cabinetry.template_postprocessor.run(cabinetry_config)
+cabinetry.template_postprocessor.run(config)
 
 # build a workspace
-ws = cabinetry.workspace.build(cabinetry_config)
+ws = cabinetry.workspace.build(config)
 
 # run a fit
 model, data = cabinetry.model_utils.model_and_data(ws)
 fit_results = cabinetry.fit.fit(model, data)
 
 # visualize the post-fit model prediction and data
-cabinetry.visualize.data_MC(cabinetry_config, ws, fit_results=fit_results)
+cabinetry.visualize.data_MC(model, data, config=config, fit_results=fit_results)
 ```
 
 The above is an abbreviated version of an example included in `example.py`, which shows how to use `cabinetry`.

--- a/example.py
+++ b/example.py
@@ -18,21 +18,21 @@ if __name__ == "__main__":
         raise SystemExit
 
     # import example config file
-    cabinetry_config = cabinetry.configuration.load("config_example.yml")
-    cabinetry.configuration.print_overview(cabinetry_config)
+    config = cabinetry.configuration.load("config_example.yml")
+    cabinetry.configuration.print_overview(config)
 
     # create template histograms
-    cabinetry.template_builder.create_histograms(cabinetry_config, method="uproot")
+    cabinetry.template_builder.create_histograms(config, method="uproot")
 
     # perform histogram post-processing
-    cabinetry.template_postprocessor.run(cabinetry_config)
+    cabinetry.template_postprocessor.run(config)
 
     # visualize systematics templates
-    cabinetry.visualize.templates(cabinetry_config)
+    cabinetry.visualize.templates(config)
 
     # build a workspace and save to file
     workspace_path = "workspaces/example_workspace.json"
-    ws = cabinetry.workspace.build(cabinetry_config)
+    ws = cabinetry.workspace.build(config)
     cabinetry.workspace.save(ws, workspace_path)
 
     # run a fit
@@ -45,5 +45,5 @@ if __name__ == "__main__":
     cabinetry.visualize.correlation_matrix(fit_results)
 
     # visualize pre- and post-fit distributions
-    cabinetry.visualize.data_MC(cabinetry_config, ws)
-    cabinetry.visualize.data_MC(cabinetry_config, ws, fit_results=fit_results)
+    cabinetry.visualize.data_MC(model, data, config=config)
+    cabinetry.visualize.data_MC(model, data, config=config, fit_results=fit_results)

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -587,7 +587,7 @@ def limit(
 ) -> LimitResults:
     """Calculates observed and expected 95% confidence level upper parameter limits.
 
-    Limits are calculated for the parameter of interest (POI) defined in the workspace.
+    Limits are calculated for the parameter of interest (POI) defined in the model.
     Brent's algorithm is used to automatically determine POI values to be tested.
 
     Args:

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -4,6 +4,7 @@ import pathlib
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
+import pyhf
 
 from . import configuration
 from . import fit
@@ -116,8 +117,9 @@ def data_MC_from_histograms(
 
 
 def data_MC(
-    config: Dict[str, Any],
-    spec: Dict[str, Any],
+    model: pyhf.pdf.Model,
+    data: List[float],
+    config: Optional[Dict[str, Any]] = None,
     figure_folder: Union[str, pathlib.Path] = "figures",
     fit_results: Optional[fit.FitResults] = None,
     log_scale: Optional[bool] = None,
@@ -125,11 +127,19 @@ def data_MC(
     include_table: bool = True,
     method: str = "matplotlib",
 ) -> None:
-    """Draws pre- and post-fit data/MC histograms from a ``pyhf`` workspace.
+    """Draws pre- and post-fit data/MC histograms for a ``pyhf`` model and data.
+
+    The ``config`` argument is optional, but required to determine correct axis labels
+    and binning. The information is not stored in the model, and default values are
+    used if no ``config`` is supplied. This allows quickly plotting distributions for
+    models that were not created with ``cabinetry``, and for which no config exists.
 
     Args:
-        config (Dict[str, Any]): cabinetry configuration
-        spec (Dict[str, Any]): ``pyhf`` workspace specification
+        model (pyhf.pdf.Model): model to visualize
+        data (List[float]): data to include in visualization, can either include auxdata
+            (the auxdata is then stripped internally) or only observed yields
+        config (Optional[Dict[str, Any]]): cabinetry configuration needed for binning
+            and axis labels, defaults to None (uses a default binning and labels then)
         figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
             figures in, defaults to "figures"
         fit_results (Optional[fit.FitResults]): parameter configuration to use for plot,
@@ -146,7 +156,12 @@ def data_MC(
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
     """
-    model, data_combined = model_utils.model_and_data(spec, with_aux=False)
+    n_bins_total = sum(model.config.channel_nbins.values())
+    if len(data) != n_bins_total:
+        # strip auxdata, only observed yields are needed
+        data_combined = data[:n_bins_total]
+    else:
+        data_combined = data
 
     if fit_results is not None:
         # fit results specified, draw a post-fit plot with them applied
@@ -172,7 +187,8 @@ def data_MC(
     # and the second index is the sample
     region_split_indices = model_utils._get_channel_boundary_indices(model)
     model_yields = np.split(yields_combined, region_split_indices, axis=1)
-    data = np.split(data_combined, region_split_indices)  # data just indexed by channel
+    # data is only indexed by channel
+    data_per_channel = np.split(data_combined, region_split_indices)
 
     # calculate the total standard deviation of the model prediction, index: channel
     total_stdev_model = model_utils.calculate_stdev(
@@ -185,16 +201,21 @@ def data_MC(
             log.info("generating pre-fit yield table")
         else:
             log.info("generating post-fit yield table")
-        tabulate._yields(model, model_yields, total_stdev_model, data)
+        tabulate._yields(model, model_yields, total_stdev_model, data_per_channel)
 
     # process channel by channel
     for i_chan, channel_name in enumerate(model.config.channels):
         histogram_dict_list = []  # one dict per region/channel
 
-        # get the region dictionary from the config for binning / variable name
-        region_dict = configuration.get_region_dict(config, channel_name)
-        bin_edges = template_builder._get_binning(region_dict)
-        variable = region_dict["Variable"]
+        if config is not None:
+            # get the region dictionary from the config for binning / variable name
+            region_dict = configuration.get_region_dict(config, channel_name)
+            bin_edges = template_builder._get_binning(region_dict)
+            variable = region_dict["Variable"]
+        else:
+            # fall back to defaults
+            bin_edges = np.arange(len(data_per_channel[i_chan]) + 1)
+            variable = "bin"
 
         for i_sam, sample_name in enumerate(model.config.samples):
             histogram_dict_list.append(
@@ -211,7 +232,7 @@ def data_MC(
             {
                 "label": "Data",
                 "isData": True,
-                "yields": data[i_chan],
+                "yields": data_per_channel[i_chan],
                 "variable": variable,
             }
         )

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -138,8 +138,9 @@ def data_MC(
         model (pyhf.pdf.Model): model to visualize
         data (List[float]): data to include in visualization, can either include auxdata
             (the auxdata is then stripped internally) or only observed yields
-        config (Optional[Dict[str, Any]]): cabinetry configuration needed for binning
-            and axis labels, defaults to None (uses a default binning and labels then)
+        config (Optional[Dict[str, Any]], optional): cabinetry configuration needed for
+            binning and axis labels, defaults to None (uses a default binning and labels
+            then)
         figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
             figures in, defaults to "figures"
         fit_results (Optional[fit.FitResults]): parameter configuration to use for plot,


### PR DESCRIPTION
This updates the `visualize.data_MC` API to use `model, data` arguments instead of a workspace specification (like #183 did for the `fit` API). The cabinetry `config` argument is no longer required, but an optional keyword argument. If no config file is supplied, plots can still be created with the defaults: axis label "bin", bin width 1 on the x-axis. Since the `pyhf` model does not store bin edge information or variable names, no further information can be extracted by default.

This new API allows for easy visualization of  models that were produced without `cabinetry` (and for which consequently no `cabinetry` config may exist).

**Breaking changes:**
- refactored `visualize.data_MC`: workspace specification argument removed, now requires `model, data` (`pyhf` model and data with or without auxdata), `config` argument is now an optional keyword argument