### PR TITLE
fix: likelihood scan visualization layout for small NLL variations

### DIFF
--- a/src/cabinetry/contrib/matplotlib_visualize.py
+++ b/src/cabinetry/contrib/matplotlib_visualize.py
@@ -595,28 +595,33 @@ def scan(
     mpl.style.use("seaborn-colorblind")
     fig, ax = plt.subplots()
 
-    # line through y=1 and y=4 to show confidence intervals
+    y_lim = max(par_nlls) * 1.2  # upper y-axis limit, 20% headroom
+
+    # lines through y=1 and y=4 to show confidence intervals
     ax.plot([par_vals[0], par_vals[-1]], [1, 1], ":", color="gray")
     ax.plot([par_vals[0], par_vals[-1]], [4, 4], ":", color="gray")
 
     # position for text - right edge of the figure, with slight padding
     text_x_pos = par_vals[-1] - 0.01 * (par_vals[-1] - par_vals[0])
-    ax.text(
-        text_x_pos,
-        1.0,
-        "68% CL",
-        horizontalalignment="right",
-        verticalalignment="bottom",
-        color="gray",
-    )
-    ax.text(
-        text_x_pos,
-        4.0,
-        "95% CL",
-        horizontalalignment="right",
-        verticalalignment="bottom",
-        color="gray",
-    )
+    # only draw text if it fits in the figure
+    if y_lim >= 1:
+        ax.text(
+            text_x_pos,
+            1.0,
+            "68% CL",
+            horizontalalignment="right",
+            verticalalignment="bottom",
+            color="gray",
+        )
+    if y_lim >= 4:
+        ax.text(
+            text_x_pos,
+            4.0,
+            "95% CL",
+            horizontalalignment="right",
+            verticalalignment="bottom",
+            color="gray",
+        )
 
     # Gaussian at best-fit parameter value for reference
     val_grid = np.linspace(par_vals[0], par_vals[-1], 100)
@@ -640,7 +645,7 @@ def scan(
     ax.set_xlabel(par_name)
     ax.set_xlim(par_vals[0], par_vals[-1])
     ax.set_ylabel(r"$-2 \Delta \log(L)$")
-    ax.set_ylim(0, max(par_nlls) * 1.2)
+    ax.set_ylim(0, y_lim)
     ax.tick_params(axis="both", which="major", pad=8)
     ax.tick_params(direction="in", top=True, right=True, which="both")
 

--- a/tests/contrib/test_matplotlib_visualize.py
+++ b/tests/contrib/test_matplotlib_visualize.py
@@ -181,6 +181,10 @@ def test_scan(tmp_path):
     matplotlib_visualize.scan(par_name, par_mle, par_unc, par_vals, par_nlls, fname)
     assert compare_images("tests/contrib/reference/scan.pdf", str(fname), 0) is None
 
+    # no 68% CL / 95% CL text
+    par_nlls = np.asarray([0.1, 0.04, 0.0, 0.04, 0.1])
+    matplotlib_visualize.scan(par_name, par_mle, par_unc, par_vals, par_nlls, fname)
+
 
 def test_limit(tmp_path):
     fname = tmp_path / "fig.pdf"


### PR DESCRIPTION
The "68% CL" / "95% CL" text in the likelihood scan visualization was previously always drawn and independent of the y-axis range. For narrow scans around the minimum, the log likelihood offset may not reach 1 or 4. This suppresses the display of the corresponding CL annotations in this case to fix the figure layout.