### PR TITLE
feat: make reference fit results in ranking optional

### DIFF
--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -159,7 +159,7 @@ def ranking(
     ws = json.load(ws_spec)
     model, data = cabinetry_model_utils.model_and_data(ws, asimov=asimov)
     fit_results = cabinetry_fit.fit(model, data)
-    ranking_results = cabinetry_fit.ranking(model, data, fit_results)
+    ranking_results = cabinetry_fit.ranking(model, data, fit_results=fit_results)
     cabinetry_visualize.ranking(
         ranking_results, figure_folder=figfolder, max_pars=max_pars
     )

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -433,7 +433,7 @@ def ranking(
         RankingResults: fit results for parameters, and pre- and post-fit impacts
     """
     if fit_results is None:
-        fit_results = fit(model, data, custom_fit=custom_fit)
+        fit_results = _fit_model(model, data, custom_fit=custom_fit)
 
     labels = model_utils.get_parameter_names(model)
     prefit_unc = model_utils.get_prefit_uncertainties(model)

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -411,7 +411,7 @@ def fit(
 def ranking(
     model: pyhf.pdf.Model,
     data: List[float],
-    fit_results: FitResults,
+    fit_results: Optional[FitResults] = None,
     custom_fit: bool = False,
 ) -> RankingResults:
     """Calculates the impact of nuisance parameters on the parameter of interest (POI).
@@ -424,13 +424,17 @@ def ranking(
     Args:
         model (pyhf.pdf.Model): model to use in fits
         data (List[float]): data (including auxdata) the model is fit to
-        fit_results (FitResults): fit results to use for ranking
+        fit_results (Optional[FitResults], optional): nominal fit results to use for
+            ranking, if not specified will repeat nominal fit, defaults to None
         custom_fit (bool, optional): whether to use the ``pyhf.infer`` API or
             ``iminuit``, defaults to False (using ``pyhf.infer``)
 
     Returns:
         RankingResults: fit results for parameters, and pre- and post-fit impacts
     """
+    if fit_results is None:
+        fit_results = fit(model, data, custom_fit=custom_fit)
+
     labels = model_utils.get_parameter_names(model)
     prefit_unc = model_utils.get_prefit_uncertainties(model)
     nominal_poi = fit_results.bestfit[model.config.poi_index]

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -243,7 +243,9 @@ def test_ranking(mock_util, mock_fit, mock_rank, mock_vis, tmp_path):
     assert result.exit_code == 0
     assert mock_util.call_args_list == [((workspace,), {"asimov": False})]
     assert mock_fit.call_args_list == [(("model", "data"), {})]
-    assert mock_rank.call_args_list == [(("model", "data", fit_results), {})]
+    assert mock_rank.call_args_list == [
+        (("model", "data"), {"fit_results": fit_results})
+    ]
     assert mock_vis.call_count == 1
     assert np.allclose(mock_vis.call_args[0][0].prefit_up, [[1.2]])
     assert np.allclose(mock_vis.call_args[0][0].prefit_down, [[0.8]])
@@ -259,7 +261,10 @@ def test_ranking(mock_util, mock_fit, mock_rank, mock_vis, tmp_path):
     assert result.exit_code == 0
     assert mock_util.call_args_list[-1] == ((workspace,), {"asimov": True})
     assert mock_fit.call_args_list[-1] == (("model", "data"), {})
-    assert mock_rank.call_args_list[-1] == (("model", "data", fit_results), {})
+    assert mock_rank.call_args_list[-1] == (
+        ("model", "data"),
+        {"fit_results": fit_results},
+    )
     assert mock_vis.call_args_list[-1][1] == {"figure_folder": "folder", "max_pars": 3}
 
 

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -395,12 +395,22 @@ def test_fit(mock_fit, mock_print, mock_gof):
         fit.FitResults(
             np.asarray([0.9, 0.8]), np.asarray([0.1, 0.1]), ["a", "b"], np.empty(0), 0.0
         ),
-        # for second fit with fixed parameter
+        # for second ranking call with fixed parameter
         fit.FitResults(
             np.asarray([0.9, 1.2]), np.asarray([0.1, 0.1]), ["a", "b"], np.empty(0), 0.0
         ),
         fit.FitResults(
             np.asarray([0.9, 0.8]), np.asarray([0.1, 0.1]), ["a", "b"], np.empty(0), 0.0
+        ),
+        # for third ranking call without reference results
+        fit.FitResults(
+            np.asarray([0.9, 1.0]), np.asarray([0.3, 0.3]), ["a", "b"], np.empty(0), 0.0
+        ),
+        fit.FitResults(
+            np.asarray([0.9, 1.3]), np.asarray([0.1, 0.1]), ["a", "b"], np.empty(0), 0.0
+        ),
+        fit.FitResults(
+            np.asarray([0.9, 0.7]), np.asarray([0.1, 0.1]), ["a", "b"], np.empty(0), 0.0
         ),
     ],
 )
@@ -448,6 +458,26 @@ def test_ranking(mock_fit, example_spec):
     assert np.allclose(ranking_results.prefit_down, [0.0])
     assert np.allclose(ranking_results.postfit_up, [0.2])
     assert np.allclose(ranking_results.postfit_down, [-0.2])
+
+    # no reference results
+    ranking_results = fit.ranking(model, data, custom_fit=True)
+    assert mock_fit.call_count == 9
+    # reference fit
+    assert mock_fit.call_args_list[-3] == ((model, data), {"custom_fit": True})
+    # fits for impact
+    assert mock_fit.call_args_list[-2][0] == (model, data)
+    assert np.allclose(mock_fit.call_args_list[-2][1]["init_pars"], [1.2, 1.0])
+    assert mock_fit.call_args_list[-2][1]["fix_pars"] == [True, False]
+    assert mock_fit.call_args_list[-2][1]["custom_fit"] is True
+    assert mock_fit.call_args_list[-1][0] == (model, data)
+    assert np.allclose(mock_fit.call_args_list[-1][1]["init_pars"], [0.6, 1.0])
+    assert mock_fit.call_args_list[-1][1]["fix_pars"] == [True, False]
+    assert mock_fit.call_args_list[-1][1]["custom_fit"] is True
+    # ranking results
+    assert np.allclose(ranking_results.prefit_up, [0.0])
+    assert np.allclose(ranking_results.prefit_down, [0.0])
+    assert np.allclose(ranking_results.postfit_up, [0.3])
+    assert np.allclose(ranking_results.postfit_down, [-0.3])
 
 
 @mock.patch(

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -421,7 +421,7 @@ def test_ranking(mock_fit, example_spec):
     labels = ["staterror", "mu"]
     fit_results = fit.FitResults(bestfit, uncertainty, labels, np.empty(0), 0.0)
     model, data = model_utils.model_and_data(example_spec)
-    ranking_results = fit.ranking(model, data, fit_results)
+    ranking_results = fit.ranking(model, data, fit_results=fit_results)
 
     # correct call to fit
     expected_fix = [True, False]
@@ -449,7 +449,7 @@ def test_ranking(mock_fit, example_spec):
     # fixed parameter in ranking, custom fit
     example_spec["measurements"][0]["config"]["parameters"][0]["fixed"] = True
     model, data = model_utils.model_and_data(example_spec)
-    ranking_results = fit.ranking(model, data, fit_results, custom_fit=True)
+    ranking_results = fit.ranking(model, data, fit_results=fit_results, custom_fit=True)
     # expect two calls in this ranking (and had 4 before, so 6 total): pre-fit
     # uncertainty is 0 since parameter is fixed, mock post-fit uncertainty is not 0
     assert mock_fit.call_count == 6

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -153,7 +153,9 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     ]
 
     # nuisance parameter ranking
-    ranking_results = cabinetry.fit.ranking(model, data, fit_results, custom_fit=True)
+    ranking_results = cabinetry.fit.ranking(
+        model, data, fit_results=fit_results, custom_fit=True
+    )
     assert np.allclose(
         ranking_results.prefit_up,
         [


### PR DESCRIPTION
The `fit_results` argument in `fit.ranking` is used as the reference to determine nuisance parameter variations and the reference POI value for impact calculations. This makes the argument an optional keyword argument instead. If not provided, the nominal fit is performed automatically.

**Breaking change:**
- `fit_results` argument in `fit.ranking` is now a keyword argument (not breaking currently, but may become a breaking change in the future)