### PR TITLE
ci: install ghostscript for pdf conversion

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,6 @@ jobs:
         python example.py
     - name: Test with pytest and generate coverage report
       run: |
-        sudo apt-get install ghostscript  # for pdf comparison
         pytest --cov-report=xml
     - name: Upload coverage to codecov
       if: matrix.python-version == 3.7

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,6 +44,7 @@ jobs:
         python example.py
     - name: Test with pytest and generate coverage report
       run: |
+        sudo apt-get install ghostscript  # for pdf comparison
         pytest --cov-report=xml
     - name: Upload coverage to codecov
       if: matrix.python-version == 3.7


### PR DESCRIPTION
Recent commits occasionally skip `matplotlib` visualization tests in the CI with:

> SKIPPED [7] ../../../../../opt/hostedtoolcache/Python/3.7.9/x64/lib/python3.7/site-packages/matplotlib/testing/compare.py:279: Don't know how to convert .pdf files to png

See for example f9d8a999004df01d13b77f7d36b8b041198f7396 where the tests worked, and the following a8f3942b7ba6d171906663ab731433d47888edce where they were skipped. This leads to fluctuating coverage.

This Installation of `ghostscript` is now done in the CI to resolve the problem.