### PR TITLE
feat: yields per region

### DIFF
--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -273,7 +273,7 @@ def calculate_stdev(
                 # factor of two below is there since loop is only over half the matrix
                 total_variance = total_variance + 2 * (corr * sym_unc_i * sym_unc_j)
 
-    # convert to standard deviation per bins and per channels
+    # convert to standard deviations per bin and per channel
     total_stdev_per_bin = np.sqrt(total_variance[:n_channels])
     total_stdev_per_channel = ak.flatten(np.sqrt(total_variance[n_channels:]))
     log.debug(f"total stdev is {total_stdev_per_bin}")

--- a/src/cabinetry/tabulate.py
+++ b/src/cabinetry/tabulate.py
@@ -102,7 +102,7 @@ def _yields_per_channel(
     total_stdev_model: List[float],
     data: List[float],
 ) -> List[Dict[str, Any]]:
-    """Outputs and returns a yield table with predicted and observed - per channel.
+    """Outputs and returns a yield table with predicted and observed yields per channel.
 
     Args:
         model (pyhf.pdf.Model): the model which the table corresponds to

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -197,7 +197,7 @@ def data_MC(
     ]
 
     # calculate the total standard deviation of the model prediction
-    # indices: channel (and bin) for per-bin uncertainties, bin for per-channel
+    # indices: channel (and bin) for per-bin uncertainties, channel for per-channel
     total_stdev_model_bins, total_stdev_model_channels = model_utils.calculate_stdev(
         model, param_values, param_uncertainty, corr_mat
     )

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -192,9 +192,7 @@ def data_MC(
         m.tolist() for m in np.split(yields_combined, region_split_indices, axis=1)
     ]
     # data is only indexed by channel (and bin)
-    data_per_channel = [
-        d.tolist() for d in np.split(data_combined, region_split_indices)
-    ]
+    data_yields = [d.tolist() for d in np.split(data_combined, region_split_indices)]
 
     # calculate the total standard deviation of the model prediction
     # indices: channel (and bin) for per-bin uncertainties, channel for per-channel
@@ -209,17 +207,17 @@ def data_MC(
         else:
             log.info("generating post-fit yield table")
         tabulate._yields_per_bin(
-            model, model_yields, total_stdev_model_bins, data_per_channel
+            model, model_yields, total_stdev_model_bins, data_yields
         )
 
         # yields per channel
         model_yields_per_channel = np.sum(ak.from_iter(model_yields), axis=-1).tolist()
-        data_per_channel_summed = [sum(d) for d in data_per_channel]
+        data_per_channel = [sum(d) for d in data_yields]
         tabulate._yields_per_channel(
             model,
             model_yields_per_channel,
             total_stdev_model_channels,
-            data_per_channel_summed,
+            data_per_channel,
         )
 
     # process channel by channel
@@ -233,7 +231,7 @@ def data_MC(
             variable = region_dict["Variable"]
         else:
             # fall back to defaults
-            bin_edges = np.arange(len(data_per_channel[i_chan]) + 1)
+            bin_edges = np.arange(len(data_yields[i_chan]) + 1)
             variable = "bin"
 
         for i_sam, sample_name in enumerate(model.config.samples):
@@ -251,7 +249,7 @@ def data_MC(
             {
                 "label": "Data",
                 "isData": True,
-                "yields": data_per_channel[i_chan],
+                "yields": data_yields[i_chan],
                 "variable": variable,
             }
         )

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -3,6 +3,7 @@ import logging
 import pathlib
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+import awkward as ak
 import numpy as np
 import pyhf
 
@@ -187,13 +188,13 @@ def data_MC(
     # slice the yields into list of lists (of lists) where first index is channel,
     # second index is sample (and third index is bin)
     region_split_indices = model_utils._get_channel_boundary_indices(model)
-    model_yields = np.asarray(
-        np.split(yields_combined, region_split_indices, axis=1)
-    ).tolist()
+    model_yields = [
+        m.tolist() for m in np.split(yields_combined, region_split_indices, axis=1)
+    ]
     # data is only indexed by channel (and bin)
-    data_per_channel = np.asarray(
-        np.split(data_combined, region_split_indices)
-    ).tolist()
+    data_per_channel = [
+        d.tolist() for d in np.split(data_combined, region_split_indices)
+    ]
 
     # calculate the total standard deviation of the model prediction
     # indices: channel (and bin) for per-bin uncertainties, bin for per-channel
@@ -212,7 +213,7 @@ def data_MC(
         )
 
         # yields per channel
-        model_yields_per_channel = np.sum(model_yields, axis=-1).tolist()
+        model_yields_per_channel = np.sum(ak.from_iter(model_yields), axis=-1).tolist()
         data_per_channel_summed = [sum(d) for d in data_per_channel]
         tabulate._yields_per_channel(
             model,

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -1,7 +1,6 @@
 import copy
 import logging
 
-import awkward as ak
 import numpy as np
 import pyhf
 
@@ -110,19 +109,21 @@ def test_calculate_stdev(example_spec, example_spec_multibin):
     uncertainty = np.asarray([0.1, 0.1])
     corr_mat = np.asarray([[1.0, 0.2], [0.2, 1.0]])
 
-    total_stdev = model_utils.calculate_stdev(model, parameters, uncertainty, corr_mat)
-    expected_stdev = [[8.03767016]]
-    assert np.allclose(ak.to_list(total_stdev), expected_stdev)
+    total_stdev_bin, total_stdev_chan = model_utils.calculate_stdev(
+        model, parameters, uncertainty, corr_mat
+    )
+    assert np.allclose(total_stdev_bin, [[8.03767016]])
+    assert np.allclose(total_stdev_chan, [8.03767016])
 
     # pre-fit
     parameters = np.asarray([1.0, 1.0])
     uncertainty = np.asarray([0.0495665682, 0.0])
     diag_corr_mat = np.diag([1.0, 1.0])
-    total_stdev = model_utils.calculate_stdev(
+    total_stdev_bin, total_stdev_chan = model_utils.calculate_stdev(
         model, parameters, uncertainty, diag_corr_mat
     )
-    expected_stdev = [[2.56951880]]  # the staterror
-    assert np.allclose(ak.to_list(total_stdev), expected_stdev)
+    assert np.allclose(total_stdev_bin, [[2.56951880]])  # the staterror
+    assert np.allclose(total_stdev_chan, [2.56951880])
 
     # multiple channels, bins, staterrors
     model = pyhf.Workspace(example_spec_multibin).model()
@@ -136,10 +137,14 @@ def test_calculate_stdev(example_spec, example_spec_multibin):
             [0.1, 0.3, 0.3, 1.0],
         ]
     )
-    total_stdev = model_utils.calculate_stdev(model, parameters, uncertainty, corr_mat)
-    expected_stdev = [[8.056054, 1.670629], [2.775377]]
+    total_stdev_bin, total_stdev_chan = model_utils.calculate_stdev(
+        model, parameters, uncertainty, corr_mat
+    )
+    expected_stdev_bin = [[8.056054, 1.670629], [2.775377]]
+    expected_stdev_chan = [9.585327, 2.775377]
     for i_reg in range(2):
-        assert np.allclose(total_stdev[i_reg], expected_stdev[i_reg])
+        assert np.allclose(total_stdev_bin[i_reg], expected_stdev_bin[i_reg])
+        assert np.allclose(total_stdev_chan[i_reg], expected_stdev_chan[i_reg])
 
 
 def test_unconstrained_parameter_count(example_spec, example_spec_shapefactor):

--- a/tests/test_tabulate.py
+++ b/tests/test_tabulate.py
@@ -58,3 +58,44 @@ def test__yields_per_bin(example_spec_multibin, example_spec_with_background):
         {"sample": "total", "Signal Region\nbin 1": "200.00 \u00B1 8.60"},
         {"sample": "data", "Signal Region\nbin 1": "160.00"},
     ]
+
+
+def test__yields_per_channel(example_spec_multibin, example_spec_with_background):
+    # multiple channels
+    model = pyhf.Workspace(example_spec_multibin).model()
+    yields = [[30], [8.0]]
+    total_stdev = [5.39, 1.0]
+    data = [43, 10]
+
+    yield_table = tabulate._yields_per_channel(model, yields, total_stdev, data)
+    assert yield_table == [
+        {
+            "sample": "Signal",
+            "region_1": "30.00",
+            "region_2": "8.00",
+        },
+        {
+            "sample": "total",
+            "region_1": "30.00 \u00B1 5.39",
+            "region_2": "8.00 \u00B1 1.00",
+        },
+        {
+            "sample": "data",
+            "region_1": "43.00",
+            "region_2": "10.00",
+        },
+    ]
+
+    # multiple samples
+    model = pyhf.Workspace(example_spec_with_background).model()
+    yields = [[150.0, 50]]
+    total_stdev = [8.60]
+    data = [160]
+
+    yield_table = tabulate._yields_per_channel(model, yields, total_stdev, data)
+    assert yield_table == [
+        {"sample": "Background", "Signal Region": "150.00"},
+        {"sample": "Signal", "Signal Region": "50.00"},
+        {"sample": "total", "Signal Region": "200.00 \u00B1 8.60"},
+        {"sample": "data", "Signal Region": "160.00"},
+    ]

--- a/tests/test_tabulate.py
+++ b/tests/test_tabulate.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pyhf
 import pytest
 
@@ -17,14 +16,14 @@ def test__header_name(test_input, expected):
     assert tabulate._header_name("abc", 2, unique=False) == "\nbin 3"
 
 
-def test__yields(example_spec_multibin, example_spec_with_background):
+def test__yields_per_bin(example_spec_multibin, example_spec_with_background):
     # multiple channels
     model = pyhf.Workspace(example_spec_multibin).model()
-    yields = [np.asarray([[25.0, 5.0]]), np.asarray([[8.0]])]
+    yields = [[[25.0, 5.0]], [[8.0]]]
     total_stdev = [[5.0, 2.0], [1.0]]
-    data = [np.asarray([35, 8]), np.asarray([10])]
+    data = [[35, 8], [10]]
 
-    yield_table = tabulate._yields(model, yields, total_stdev, data)
+    yield_table = tabulate._yields_per_bin(model, yields, total_stdev, data)
     assert yield_table == [
         {
             "sample": "Signal",
@@ -48,11 +47,11 @@ def test__yields(example_spec_multibin, example_spec_with_background):
 
     # multiple samples
     model = pyhf.Workspace(example_spec_with_background).model()
-    yields = [np.asarray([[150.0], [50.0]])]
+    yields = [[[150.0], [50.0]]]
     total_stdev = [[8.60]]
-    data = [np.asarray([160])]
+    data = [[160]]
 
-    yield_table = tabulate._yields(model, yields, total_stdev, data)
+    yield_table = tabulate._yields_per_bin(model, yields, total_stdev, data)
     assert yield_table == [
         {"sample": "Background", "Signal Region\nbin 1": "150.00"},
         {"sample": "Signal", "Signal Region\nbin 1": "50.00"},


### PR DESCRIPTION
Added `tabulate._yields_per_channel` to build yield tables with yields per channel. These tables are shown when `visualize.data_MC` is called with `include_table=True` (the default). `model_utils.calculate_stdev` is expanded to include calculation of uncertainties for the sum of yields per channel.

resolves #158 

**breaking changes:**
- `model_utils.calculate_stdev` now returns a tuple: uncertainties for all bins per channel, and uncertainties for total yield in channel
- `tabulate. _yields` renamed to `tabulate._yields_per_bin`