### PR TITLE
fix: numpy array smoothing and typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.800
     hooks:
     -   id: mypy
         files: src/cabinetry
@@ -14,7 +14,7 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.4
+    rev: v2.9.0
     hooks:
     -   id: pyupgrade
         args: ["--py36-plus"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,8 +76,9 @@ no_implicit_optional = True
 [mypy-boost_histogram]
 ignore_missing_imports = True
 
+# needed for python 3.6 CI
 [mypy-numpy]
-ignore_missing_imports = True  # needed for python 3.6 CI
+ignore_missing_imports = True
 
 [mypy-uproot]
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,9 @@ no_implicit_optional = True
 [mypy-boost_histogram]
 ignore_missing_imports = True
 
+[mypy-numpy]
+ignore_missing_imports = True  # needed for python 3.6 CI
+
 [mypy-uproot]
 ignore_missing_imports = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,9 +76,6 @@ no_implicit_optional = True
 [mypy-boost_histogram]
 ignore_missing_imports = True
 
-[mypy-numpy]
-ignore_missing_imports = True
-
 [mypy-uproot]
 ignore_missing_imports = True
 

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -735,7 +735,7 @@ def limit(
             # expected CLs values for next limit type that have been calculated already
             exp_CLs_next = np.asarray([exp[i_limit] for _, exp in cache_CLs.values()])
             # associated POI values
-            poi_list = list(cache_CLs.keys())
+            poi_arr = np.fromiter(cache_CLs.keys(), dtype=float)
 
             # left: CLs has to be > 0.05, mask out values where CLs <= 0.05
             masked_CLs_left = np.where(exp_CLs_next <= 0.05, 1, exp_CLs_next)
@@ -744,7 +744,7 @@ def limit(
                 bracket_left = bracket_left_default
             else:
                 # find closest to CLs = 0.05 from above
-                bracket_left = poi_list[np.argmin(masked_CLs_left)]
+                bracket_left = poi_arr[np.argmin(masked_CLs_left)]
 
             # right: CLs has to be < 0.05, mask out values where CLs >= 0.05
             masked_CLs_right = np.where(exp_CLs_next >= 0.05, -1, exp_CLs_next)
@@ -753,7 +753,7 @@ def limit(
                 bracket_right = bracket_right_default
             else:
                 # find closest to CLs=0.05 from below
-                bracket_right = poi_list[np.argmax(masked_CLs_right)]
+                bracket_right = poi_arr[np.argmax(masked_CLs_right)]
 
             bracket = (bracket_left, bracket_right)
 
@@ -766,17 +766,17 @@ def limit(
         log.info(f"{limit_label.ljust(17)}: {all_limits[i_limit]:.4f}")
 
     # sort all CLs values and scanned POI points by increasing POI value
-    poi_list = list(cache_CLs.keys())
-    sorted_indices = np.argsort(poi_list)
+    poi_arr = np.fromiter(cache_CLs.keys(), dtype=float)
+    sorted_indices = np.argsort(poi_arr)
     observed_CLs_np = np.asarray([obs for obs, _ in cache_CLs.values()])[sorted_indices]
     expected_CLs_np = np.asarray([exp for _, exp in cache_CLs.values()])[sorted_indices]
-    poi_list_np = np.asarray(poi_list)[sorted_indices]
+    poi_arr = poi_arr[sorted_indices]
 
     limit_results = LimitResults(
         all_limits[0],
         np.asarray(all_limits[1:]),
         observed_CLs_np,
         expected_CLs_np,
-        poi_list_np,
+        poi_arr,
     )
     return limit_results

--- a/src/cabinetry/smooth.py
+++ b/src/cabinetry/smooth.py
@@ -60,7 +60,7 @@ def smooth_353QH_twice(hist: T) -> T:
         log.warning("at least three points needed for smoothing, no smoothing applied")
         return hist
 
-    zz = hist.copy()
+    zz = np.asarray(hist.copy())
 
     for i_353QH in range(2):  # run 353QH twice
         # do running median with window sizes 3, 5, 3
@@ -92,7 +92,7 @@ def smooth_353QH_twice(hist: T) -> T:
             # algorithm has been run once
             rr = zz.copy()  # save computed values
             # calculate residuals: (original) - (after 353QH)
-            zz = [hist[ii] - zz[ii] for ii in range(0, nbins)]
+            zz = np.asarray([hist[ii] - zz[ii] for ii in range(0, nbins)])
             # zz is now "rough", while rr is "smooth"
 
         # "twicing": run 353QH again on "rough" zz and add to "smooth" rr

--- a/src/cabinetry/smooth.py
+++ b/src/cabinetry/smooth.py
@@ -60,7 +60,11 @@ def smooth_353QH_twice(hist: T) -> T:
         log.warning("at least three points needed for smoothing, no smoothing applied")
         return hist
 
-    zz = np.asarray(hist.copy())
+    if isinstance(hist, np.ndarray):
+        # ensure dtype is not int to avoid rounding in smooth histogram
+        hist = hist.astype("float")
+
+    zz = np.array(hist, dtype=float, copy=True)
 
     for i_353QH in range(2):  # run 353QH twice
         # do running median with window sizes 3, 5, 3

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -45,7 +45,7 @@ def _total_yield_uncertainty(stdev_list: List[np.ndarray]) -> np.ndarray:
     Returns:
         np.array: absolute stat. uncertainty of stack of samples
     """
-    tot_unc = np.sqrt(np.sum(np.power(stdev_list, 2), axis=0))
+    tot_unc = np.sqrt(np.sum(np.power(np.asarray(stdev_list), 2), axis=0))
     return tot_unc
 
 

--- a/tests/test_smooth.py
+++ b/tests/test_smooth.py
@@ -20,11 +20,19 @@ def test__medians_353(orig, mod):
 
 def test_smooth_353QH_twice(caplog):
     caplog.set_level(logging.DEBUG)
-    assert np.allclose(smooth.smooth_353QH_twice([1, 3, 2, 5]), [1, 2, 3.25, 5])
+    hist_smooth = smooth.smooth_353QH_twice([1, 3, 2, 5])
+    assert isinstance(hist_smooth, list)
+    assert np.allclose(hist_smooth, [1, 2, 3.25, 5])
     assert np.allclose(
         smooth.smooth_353QH_twice([1, 3, 2, 5, 11, 3, 8]),
         [1.0, 2.125, 3.66666675, 5.08333349, 6.16666651, 7.375, 8.0],
     )
+
+    # with np.ndarray
+    hist_smooth = smooth.smooth_353QH_twice(np.asarray([1, 3, 2, 5]))
+    assert isinstance(hist_smooth, np.ndarray)
+    assert hist_smooth.dtype == float
+    assert np.allclose(hist_smooth, [1, 2, 3.25, 5])
     caplog.clear()
 
     assert np.allclose(smooth.smooth_353QH_twice([1, 3]), [1, 3])


### PR DESCRIPTION
With `numpy` release 1.20, [it is now typed](https://numpy.org/doc/1.20/release/1.20.0-notes.html#numpy-is-now-typed). This results in some new things flagged by `mypy` that are fixed here.

Also fixes edge case where `smooth.smooth_353QH_twice` applied to `np.ndarray` with `int` `dtype` returns the wrong result due to rounding.