### PR TITLE
ci: do not cancel jobs early if another job fails

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8]
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,10 +17,6 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     """The purpose of this integration test is to check whether the
     steps run without error and whether the fit result is as expected.
     """
-    import sys
-
-    if sys.version_info[1] == 7:
-        raise SystemExit
     ntuple_creator(str(tmp_path))
 
     cabinetry_config = cabinetry.configuration.load("config_example.yml")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,6 +17,10 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     """The purpose of this integration test is to check whether the
     steps run without error and whether the fit result is as expected.
     """
+    import sys
+
+    if sys.version_info[1] == 7:
+        raise SystemExit
     ntuple_creator(str(tmp_path))
 
     cabinetry_config = cabinetry.configuration.load("config_example.yml")


### PR DESCRIPTION
This disables the [`fail-fast`](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) strategy in the CI. The jobs in the matrix of Python versions will not be stopped early if another job fails, which can be useful to catch potential differences between Python versions.