### PR TITLE
build: drop support for Python 3.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.9.0
+    rev: v2.10.0
     hooks:
     -   id: pyupgrade
         args: ["--py37-plus"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: v2.9.0
     hooks:
     -   id: pyupgrade
-        args: ["--py36-plus"]
+        args: ["--py37-plus"]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py37', 'py38']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ license = BSD 3-Clause
 url = https://github.com/alexander-held/cabinetry
 classifiers =
     Development Status :: 3 - Alpha
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     License :: OSI Approved :: BSD License
@@ -19,7 +18,7 @@ classifiers =
 [options]
 packages = find:
 package_dir = =src
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     pyhf[minuit]~=0.5.4  # uproot3 namespace; minuit: np_merrors(), parameter limit warning
     boost_histogram~=0.11
@@ -74,10 +73,6 @@ strict_equality = True
 no_implicit_optional = True
 
 [mypy-boost_histogram]
-ignore_missing_imports = True
-
-# needed for python 3.6 CI
-[mypy-numpy]
 ignore_missing_imports = True
 
 [mypy-uproot]


### PR DESCRIPTION
Following `pyhf` dropping support for Python 3.6 (https://github.com/scikit-hep/pyhf/pull/1272) in the upcoming 0.6 release, `cabinetry` will also drop 3.6 support in line with the [NEP schedule](https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule).

The minimum Python version is raised to 3.7, and the last `cabinetry` version to support Python 3.6 will likely be 0.1.8. Upcoming releases require at least version Python 3.7. Testing for Python 3.6 is also dropped.

Support for Python 3.9 will be added officially once `pyhf` supports it (it already seems useable on the `fix/pyhf-0.6-compatibility` branch).

resolves #192