### PR TITLE
feat: mypy check for tabulate package

### DIFF
--- a/src/cabinetry/tabulate.py
+++ b/src/cabinetry/tabulate.py
@@ -89,7 +89,7 @@ def _yields_per_bin(
         "yields per bin:\n"
         + tabulate.tabulate(
             table,
-            headers=headers,  # type: ignore
+            headers=headers,
             tablefmt="fancy_grid",
         )
     )


### PR DESCRIPTION
#169 introduced a `# type: ignore` to skip `mypy` checking an argument type in a `tabulate.tabulate` call due to a bug in the `tabulate` type stubs. With `mypy` 0.800 the fix has been propagated and the check does no longer need to be skipped. 