### PR TITLE
test: check yield uncertainties in integration test

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -151,6 +151,24 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     assert "Signal_norm                    =  1.6895 -0.9580 +0.9052" in [
         rec.message for rec in caplog.records
     ]
+    caplog.clear()
+
+    # pre- and post-fit yield uncertainties
+    cabinetry.visualize.data_MC(model, data)
+    assert "total stdev is [[69, 58.3, 38.2, 45.3]]" in [
+        rec.message for rec in caplog.records
+    ]
+    assert "total stdev per channel is [137]" in [rec.message for rec in caplog.records]
+    caplog.clear()
+
+    cabinetry.visualize.data_MC(model, data, fit_results=fit_results)
+    assert "total stdev is [[11.9, 7.28, 7.41, 7.69]]" in [
+        rec.message for rec in caplog.records
+    ]
+    assert "total stdev per channel is [20.3]" in [
+        rec.message for rec in caplog.records
+    ]
+    caplog.clear()
 
     # nuisance parameter ranking
     ranking_results = cabinetry.fit.ranking(


### PR DESCRIPTION
Adding pre- and post-fit data/MC plots to integration test to include a check of yield uncertainties in this test.