### PR TITLE
feat: update default bracket in limit calculation for stability

### DIFF
--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -600,7 +600,7 @@ def limit(
         bracket (Optional[Union[List[float], Tuple[float, float]]], optional): the two
             POI values used to start the observed limit determination, the limit must
             lie between these values and the values must not be the same, defaults to
-            None (then uses ``0.01`` as default lower value and the upper POI bound
+            None (then uses ``0.1`` as default lower value and the upper POI bound
             specified in the measurement as default upper value)
         tolerance (float, optional): tolerance in POI value for convergence to CLs=0.05,
             defaults to 0.01
@@ -622,8 +622,8 @@ def limit(
     par_bounds[model.config.poi_index] = [0, par_bounds[model.config.poi_index][1]]
     log.debug("setting lower parameter bound for POI to 0")
 
-    # set default bracket to (0.01, upper POI bound in measurement) if needed
-    bracket_left_default = 0.01
+    # set default bracket to (0.1, upper POI bound in measurement) if needed
+    bracket_left_default = 0.1
     bracket_right_default = par_bounds[model.config.poi_index][1]
     if bracket is None:
         bracket = (bracket_left_default, bracket_right_default)

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -541,7 +541,7 @@ def test_limit(example_spec_with_background, caplog):
 
     # expected values for results
     observed_limit = 0.749
-    expected_limit = [0.302, 0.410, 0.581, 0.831, 1.160]
+    expected_limit = [0.303, 0.411, 0.581, 0.833, 1.160]
 
     # modify workspace to include custom POI range
     example_spec_with_background["measurements"][0]["config"]["parameters"][0][
@@ -553,12 +553,12 @@ def test_limit(example_spec_with_background, caplog):
     assert np.allclose(limit_results.observed_limit, observed_limit, rtol=1e-2)
     assert np.allclose(limit_results.expected_limit, expected_limit, rtol=1e-2)
     # compare a few CLs values
-    assert np.allclose(limit_results.observed_CLs[0], 0.972168)
+    assert np.allclose(limit_results.observed_CLs[0], 0.780874)
     assert np.allclose(
         limit_results.expected_CLs[0],
-        [0.917830, 0.946246, 0.971371, 0.989493, 0.997945],
+        [0.402421, 0.548538, 0.719383, 0.878530, 0.971678],
     )
-    assert np.allclose(limit_results.poi_values[0], 0.01)
+    assert np.allclose(limit_results.poi_values[0], 0.1)
     assert np.allclose(limit_results.observed_CLs[-1], 0.0)
     assert np.allclose(limit_results.expected_CLs[-1], [0.0, 0.0, 0.0, 0.0, 0.0])
     assert np.allclose(limit_results.poi_values[-1], 8.0)  # from custom POI range
@@ -588,7 +588,7 @@ def test_limit(example_spec_with_background, caplog):
     ] = [0.0]
     model, data = model_utils.model_and_data(example_spec_with_background, asimov=True)
     limit_results = fit.limit(model, data)
-    assert np.allclose(limit_results.observed_limit, 0.584, rtol=2e-2)
+    assert np.allclose(limit_results.observed_limit, 0.586, rtol=2e-2)
     assert np.allclose(limit_results.expected_limit, expected_limit, rtol=2e-2)
     caplog.clear()
 


### PR DESCRIPTION
The default lower parameter of interest (POI) bound in limit calculations through `fit.limit` used to be `0.01`. This is close to the lower POI bound of `0` that is used with the `qtilde` test statistic (see eq. 16 in https://arxiv.org/abs/1007.1727), and can lead to instabilities and `nan` CLs values (see https://github.com/scikit-hep/pyhf/issues/1278). This affects the simple example provided in this repository.

The lower bracket value is change from `0.01` to `0.1` to help avoid such instabilities with default parameter values. The `bracket` keyword argument is still available to specify custom lower and upper POI bracket values.