### PR TITLE
fix: restrict typeguard version for NamedTuple compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extras_require["test"] = sorted(
             "flake8-import-order",
             "flake8-print",
             "mypy",
-            "typeguard",
+            "typeguard<=2.10.0",
             "black==20.8b1",
         ]
     )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extras_require["test"] = sorted(
             "flake8-import-order",
             "flake8-print",
             "mypy",
-            "typeguard<=2.10.0",
+            "typeguard<2.11",  # NamedTuple compatibility in Python 3.7
             "black==20.8b1",
         ]
     )


### PR DESCRIPTION
The recent `typeguard` releases `2.11.0` and `2.11.1` cause errors in tests when type checking classes inheriting from `typing.NamedTuple` in Python 3.7 (and 3.6), as reported in https://github.com/agronholm/typeguard/issues/175. This restricts the version to `2.10.0` and below as a temporary fix.