### PR TITLE
chore: updating version to 0.2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cabinetry
-version = 0.1.8
+version = 0.2.0
 author = Alexander Held
 description = design and steer profile likelihood fits
 long_description = file: README.md

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -10,4 +10,4 @@ from . import visualize  # NOQA
 from . import workspace  # NOQA
 
 
-__version__ = "0.1.8"
+__version__ = "0.2.0"


### PR DESCRIPTION
Updating minor version to `0.2.0`. This new version adopts the `pyhf` 0.6 and `iminuit` v2 APIs, drops support for Python 3.6, introduces changes to the `cabinetry.fit` API, and adds discovery significance calculation among other features.