### PR TITLE
chore: remove upper version limits for dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,8 @@ python_requires = >=3.7
 install_requires =
     pyhf[minuit]~=0.6.0  # API updates and iminuit v2 compatibility
     boost_histogram~=0.11
-    awkward~=1.0  # new API
-    tabulate~=0.8.1
+    awkward>=1.0  # new API
+    tabulate>=0.8.1
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     pyhf[minuit]~=0.6.0  # API updates and iminuit v2 compatibility
     boost_histogram~=0.11
     awkward>=1.0  # new API
-    tabulate>=0.8.1
+    tabulate>=0.8.1  # multiline text
 
 [options.packages.find]
 where = src

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ extras_require["test"] = sorted(
         extras_require["contrib"]
         + [
             "pytest",
-            "pytest-cov>=2.5.1",
+            "pytest-cov>=2.6.1",  # no_cover support
             "pydocstyle",
             "check-manifest",
             "flake8",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-extras_require = {"contrib": ["matplotlib", "uproot3", "uproot~=4.0"]}
+extras_require = {"contrib": ["matplotlib", "uproot3", "uproot>=4.0"]}
 extras_require["test"] = sorted(
     set(
         extras_require["contrib"]
@@ -14,7 +14,7 @@ extras_require["test"] = sorted(
             "flake8-import-order",
             "flake8-print",
             "mypy",
-            "typeguard<2.11",  # NamedTuple compatibility in Python 3.7
+            "typeguard!=2.11",  # NamedTuple compatibility in Python 3.7
             "black==20.8b1",
         ]
     )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extras_require["test"] = sorted(
             "flake8-import-order",
             "flake8-print",
             "mypy",
-            "typeguard!=2.11",  # NamedTuple compatibility in Python 3.7
+            "typeguard!=2.11.*",  # NamedTuple compatibility in Python 3.7
             "black==20.8b1",
         ]
     )


### PR DESCRIPTION
Motivated by https://hynek.me/articles/semver-will-not-save-you/, this removes upper version limits for dependencies where internals are not heavily used. The two exception that retain the upper limit currently are
- `pyhf`: expect that breaking changes (for `cabinetry`) between minor versions are still likely,
- `boost_histogram`: will be updated after https://github.com/alexander-held/cabinetry/issues/201 is resolved.

Also slightly raises minimum required `pytest-cov` version for use with `no_cover`.