### PR TITLE
feat: command line interface for data-MC plots

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.800
+    rev: v0.812
     hooks:
     -   id: mypy
         files: src/cabinetry

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -274,6 +274,49 @@ def significance(
     _ = cabinetry_fit.significance(model, data)
 
 
+@click.command()
+@click.argument("ws_spec", type=click.File("r"))
+@click.option("--config", type=click.File("r"), help="cabinetry configuration file")
+@click.option(
+    "--postfit", is_flag=True, help="visualize post-fit model (default: pre-fit model)"
+)
+@click.option(
+    "--figfolder",
+    default="figures",
+    help='folder to save figures to (default: "figures")',
+)
+def data_mc(
+    ws_spec: io.TextIOWrapper,
+    config: Optional[io.TextIOWrapper],
+    postfit: bool,
+    figfolder: str,
+) -> None:
+    """Visualizes distributions of fit model and observed data.
+
+    WS_SPEC: path to workspace
+    """
+    _set_logging()
+    ws = json.load(ws_spec)
+    model, data = cabinetry_model_utils.model_and_data(ws)
+
+    if config is not None:
+        cabinetry_config = yaml.safe_load(config)
+        cabinetry_configuration.validate(cabinetry_config)
+    else:
+        cabinetry_config = None
+
+    # optionally perform maximum likelihood fit to obtain post-fit model
+    fit_results = cabinetry_fit.fit(model, data) if postfit else None
+
+    cabinetry_visualize.data_MC(
+        model,
+        data,
+        config=cabinetry_config,
+        figure_folder=figfolder,
+        fit_results=fit_results,
+    )
+
+
 cabinetry.add_command(templates)
 cabinetry.add_command(postprocess)
 cabinetry.add_command(workspace)
@@ -282,3 +325,4 @@ cabinetry.add_command(ranking)
 cabinetry.add_command(scan)
 cabinetry.add_command(limit)
 cabinetry.add_command(significance)
+cabinetry.add_command(data_mc)


### PR DESCRIPTION
Adds `cabinetry data-mc` to the command line interface. This allows accessing functionality from `cabinetry.visualize.data_MC` via the CLI.
- optional cabinetry config (for horizontal axis label / binning) via `--config`
- flag `--postfit` to draw post-fit model instead of pre-fit (performs required fit automatically)
- possibility to override figure folder for output via `--figfolder`

Also updates `pre-commit` via `pre-commit autoupdate`.