### PR TITLE
feat: boost-histogram 1.0 compatibility and typing updates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,14 +28,16 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install .[test]
-    - name: Static code analysis with flake8 and mypy
+    - name: Static code analysis with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 src/cabinetry --select=E9,F63,F7,F82 --show-source
         # check for additional issues flagged by flake8
         flake8
-        # run mypy for type checking
-        mypy
+    - name: Type checking with mypy
+      if: matrix.python-version != 3.7
+      run: |
+        mypy  # 3.7 not supported due to boost-histogram
     - name: Format with Black
       run: |
         black --check --diff --verbose .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.10.1
+    rev: v2.11.0
     hooks:
     -   id: pyupgrade
         args: ["--py37-plus"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
     -   id: mypy
         files: src/cabinetry
-        additional_dependencies: ["boost-histogram>=1.0.0"]
+        additional_dependencies: ["numpy>=1.20", "boost-histogram>=1.0.1"]
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
     hooks:
     -   id: mypy
         files: src/cabinetry
+        additional_dependencies: ["boost-histogram>=1.0.0"]
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,12 +9,12 @@ repos:
     -   id: mypy
         files: src/cabinetry
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.0
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.10.0
+    rev: v2.10.1
     hooks:
     -   id: pyupgrade
         args: ["--py37-plus"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ package_dir = =src
 python_requires = >=3.7
 install_requires =
     pyhf[minuit]~=0.6.0  # API updates and iminuit v2 compatibility
-    boost_histogram~=0.11
+    boost_histogram>=0.13.0, !=1.0.0  # .values(), subclassing without family
     awkward>=1.0  # new API
     tabulate>=0.8.1  # multiline text
 
@@ -71,9 +71,6 @@ warn_redundant_casts = True
 warn_unreachable = True
 strict_equality = True
 no_implicit_optional = True
-
-[mypy-boost_histogram]
-ignore_missing_imports = True
 
 [mypy-uproot]
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ package_dir = =src
 python_requires = >=3.7
 install_requires =
     pyhf[minuit]~=0.6.0  # API updates and iminuit v2 compatibility
-    boost_histogram>=0.13.0, !=1.0.0  # .values(), subclassing without family
+    boost_histogram>=1.0.0  # subclassing with family
     awkward>=1.0  # new API
     tabulate>=0.8.1  # multiline text
 

--- a/src/cabinetry/contrib/histogram_creation.py
+++ b/src/cabinetry/contrib/histogram_creation.py
@@ -100,6 +100,6 @@ def _bin_data(
     """
     hist = bh.Histogram(bh.axis.Variable(bins), storage=bh.storage.Weight())
     hist.fill(observables, weight=weights)
-    yields = hist.view().value
-    stdev = np.sqrt(hist.view().variance)
+    yields = hist.values()
+    stdev = np.sqrt(hist.variances())  # type: ignore
     return yields, stdev

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Type, TypeVar, Union
 import boost_histogram as bh
 import numpy as np
 
+import cabinetry
+
 
 log = logging.getLogger(__name__)
 
@@ -13,7 +15,7 @@ log = logging.getLogger(__name__)
 H = TypeVar("H", bound="Histogram")
 
 
-class Histogram(bh.Histogram):
+class Histogram(bh.Histogram, family=cabinetry):
     """Holds histogram information, extends boost_histogram.Histogram."""
 
     @classmethod

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -127,7 +127,7 @@ class Histogram(bh.Histogram):
         Returns:
             numpy.ndarray: yields per bin
         """
-        return self.view().value
+        return self.values()
 
     @yields.setter
     def yields(self, value: np.ndarray) -> None:
@@ -136,7 +136,7 @@ class Histogram(bh.Histogram):
         Args:
             value (np.ndarray): yields to set
         """
-        self.view().value = value
+        self.view().value = value  # type: ignore
 
     @property
     def stdev(self) -> np.ndarray:
@@ -145,7 +145,7 @@ class Histogram(bh.Histogram):
         Returns:
             numpy.ndarray: stat. uncertainty per bin
         """
-        return np.sqrt(self.view().variance)
+        return np.sqrt(self.variances())  # type: ignore
 
     @stdev.setter
     def stdev(self, value: np.ndarray) -> None:
@@ -154,7 +154,7 @@ class Histogram(bh.Histogram):
         Args:
             value (numpy.ndarray): the standard deviation
         """
-        self.view().variance = value ** 2
+        self.view().variance = value ** 2  # type: ignore
 
     @property
     def bins(self) -> np.ndarray:
@@ -229,7 +229,7 @@ class Histogram(bh.Histogram):
         current_integrated_yield = sum(self.yields)
         normalization_ratio = current_integrated_yield / target_integrated_yield
         # update integrated yield to match target
-        self.view().value /= normalization_ratio
+        self.view().value /= normalization_ratio  # type: ignore
         return normalization_ratio
 
 

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -17,7 +17,7 @@ ProcessorFunc = Callable[[Dict[str, Any], Dict[str, Any], Dict[str, Any], str], 
 # type of a user-defined function for template processing, takes sample-region-
 # systematic-template, returns a boost_histogram.Histogram
 UserTemplateFunc = Callable[
-    [Dict[str, Any], Dict[str, Any], Dict[str, Any], str], bh.Histogram
+    [Dict[str, Any], Dict[str, Any], Dict[str, Any], str], Optional[bh.Histogram]
 ]
 
 # type of a generic function that takes sample-region-systematic-template, and

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -17,7 +17,7 @@ ProcessorFunc = Callable[[Dict[str, Any], Dict[str, Any], Dict[str, Any], str], 
 # type of a user-defined function for template processing, takes sample-region-
 # systematic-template, returns a boost_histogram.Histogram
 UserTemplateFunc = Callable[
-    [Dict[str, Any], Dict[str, Any], Dict[str, Any], str], Optional[bh.Histogram]
+    [Dict[str, Any], Dict[str, Any], Dict[str, Any], str], bh.Histogram
 ]
 
 # type of a generic function that takes sample-region-systematic-template, and
@@ -137,7 +137,7 @@ class Router:
         """
         return self._register_processor(
             self.template_builders, region_name, sample_name, systematic_name, template
-        )
+        )  # type: ignore
 
     @staticmethod
     def _find_match(
@@ -217,7 +217,7 @@ class Router:
 
         if match is not None:
             # if user-defined function was found, wrap and return it
-            return self.template_builder_wrapper(match)
+            return self.template_builder_wrapper(match)  # type: ignore
         return None
 
 

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -1,5 +1,6 @@
 import logging
 
+import boost_histogram as bh
 import numpy as np
 import pytest
 
@@ -75,6 +76,23 @@ class HistogramHelpers:
 @pytest.fixture
 def histogram_helpers():
     return HistogramHelpers
+
+
+# test properties
+def test_Histogram(example_histograms):
+    bins, yields, stdev = example_histograms.normal()
+    h_orig = bh.Histogram(bh.axis.Variable(bins), storage=bh.storage.Weight())
+    h_orig[...] = np.stack([np.asarray(yields), np.asarray(stdev) ** 2], axis=-1)
+    h = histo.Histogram(h_orig)
+    np.testing.assert_equal(h.bins, bins)
+    np.testing.assert_equal(h.yields, yields)
+    np.testing.assert_equal(h.stdev, stdev)
+    new_yields = np.asarray([3, 4])
+    new_stdev = np.asarray([0.5, 0.5])
+    h.yields = new_yields
+    h.stdev = new_stdev
+    np.testing.assert_equal(h.yields, new_yields)
+    np.testing.assert_equal(h.stdev, new_stdev)
 
 
 def test_Histogram_from_arrays(example_histograms):

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -174,7 +174,7 @@ def test_Router__find_template_builder_match(processor_examples):
         @functools.wraps(func)
         def wrapper(reg, sam, sys, tem):
             # return the bin yield of the histogram to have something to compare
-            return func(reg, sam, sys, tem).view().value
+            return func(reg, sam, sys, tem).values()
 
         return wrapper
 


### PR DESCRIPTION
This enables support for `boost-histogram>=1.0.0`. Subclassing `Histogram` requires a `family` keyword argument (optional starting with `boost-histogram` 1.0.1), and the `boost-histogram` library is now typed. 

resolves #201

#### Overview of changes
```
* support and require boost-histogram>=1.0.0
* improved type checking via pre-commit
* added test for histogram properties
* skip mypy in CI for Python 3.7
```

#### Typing changes
For reading yields and variances, switch to using `h.values()` and `h.variances()` instead of `h.view().value` and `h.view().variance`. The `view()`-based method is still used for writing yields / variances directly.

Calling `numpy` functions with values/variances requires a `# type: ignore`, as does setting values via `view()`.
See https://github.com/scikit-hep/boost-histogram/issues/527 and https://github.com/scikit-hep/boost-histogram/discussions/525#discussioncomment-475592). Some of these `# type: ignore` may possibly be removed in the future with `boost-histogram` updates.

The typing revealed a small typing bug in `cabinetry.route`, which will be resolved in a separate PR (here only temporarily fixed via `# type: ignore`).

#### CI / pre-commit updates
The CI is updated to skip `mypy` with Python 3.7, since the `boost-histogram` syntax requires at least Python 3.8 (see https://github.com/scikit-hep/boost-histogram/discussions/525#discussioncomment-504339).

For type checking, the requirement is `boost-histogram>=1.0.1` due to https://github.com/scikit-hep/boost-histogram/discussions/525#discussioncomment-474816. The `pre-commit` version requirement is set accordingly. `boost-histogram` 1.0.0 will fail with `mypy` due to two typing bugs (ellipsis/constructor), see also [1.0.1 changelog](https://boost-histogram.readthedocs.io/en/latest/CHANGELOG.html#version-1-0-1).

To get `mypy` working correctly in `pre-commit`, also adding `boost-histogram` to the environment requirements (and adding typed `numpy` at the same time).

#### Other notes

Also adding a test for `Histogram` properties.