### PR TITLE
fix: typing for registering custom template builders

### DIFF
--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -61,7 +61,7 @@ class Router:
         systematic_name: Optional[str],
         template: Optional[str],
     ) -> Callable[[UserTemplateFunc], UserTemplateFunc]:
-        """Decorator for registering a processor function.
+        """Decorator for registering a custom processor function.
 
         The function is added to the list provided as function argument. Currently this
         function is used only for template builder functions, but could be used for

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -116,7 +116,7 @@ class Router:
         sample_name: Optional[str] = None,
         systematic_name: Optional[str] = None,
         template: Optional[str] = None,
-    ) -> Callable[[Callable], UserTemplateFunc]:
+    ) -> Callable[[UserTemplateFunc], UserTemplateFunc]:
         """Decorator for registering a template builder function.
 
         The function is added to the list stored in the ``template_builders`` member
@@ -133,8 +133,8 @@ class Router:
                 function to, defaults to None (apply to all templates)
 
         Returns:
-            Callable[[Callable], UserTemplateFunc]: the generic function to register a
-            processor
+            Callable[[UserTemplateFunc], UserTemplateFunc]: the function to register a
+            a processor
         """
         return self._register_processor(
             self.template_builders, region_name, sample_name, systematic_name, template
@@ -189,7 +189,7 @@ class Router:
     def _find_template_builder_match(
         self, region_name: str, sample_name: str, systematic_name: str, template: str
     ) -> Optional[ProcessorFunc]:
-        """Returns a template builder function matching the provided specification.
+        """Returns wrapped template builder function matching provided specification.
 
         If no matches are found, returns None. Wraps the user-defined function in the
         provided wrapper, if no wrapper is found raises an error.

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -1,6 +1,6 @@
 import fnmatch
 import logging
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional
 
 import boost_histogram as bh
 
@@ -19,10 +19,6 @@ ProcessorFunc = Callable[[Dict[str, Any], Dict[str, Any], Dict[str, Any], str], 
 UserTemplateFunc = Callable[
     [Dict[str, Any], Dict[str, Any], Dict[str, Any], str], bh.Histogram
 ]
-
-# type of a generic function that takes sample-region-systematic-template, and
-# may return None or a boost_histogram.Histogram
-GenericProcessorFunc = Union[ProcessorFunc, UserTemplateFunc]
 
 # type of a function called with names of region-sample-systematic-template,
 # which returns either a ProcessorFunc or None
@@ -64,7 +60,7 @@ class Router:
         sample_name: Optional[str],
         systematic_name: Optional[str],
         template: Optional[str],
-    ) -> Callable[[GenericProcessorFunc], GenericProcessorFunc]:
+    ) -> Callable[[UserTemplateFunc], UserTemplateFunc]:
         """Decorator for registering a custom processor function.
 
         Args:
@@ -78,7 +74,7 @@ class Router:
                 None to apply to all templates
 
         Returns:
-            Callable[[GenericProcessorFunc], GenericProcessorFunc]: the function to
+            Callable[[UserTemplateFunc], UserTemplateFunc]: the function to
             register a processor
         """
         if region_name is None:
@@ -90,13 +86,13 @@ class Router:
         if template is None:
             template = "*"
 
-        def _register(func: GenericProcessorFunc) -> GenericProcessorFunc:
+        def _register(func: UserTemplateFunc) -> UserTemplateFunc:
             """Registers a processor function to be applied when matching a pattern.
 
             The pattern is specified by region-sample-systematic-template.
 
             Args:
-                func (GenericProcessorFunc): the function to register
+                func (UserTemplateFunc): the function to register
             """
             processor_list.append(
                 {
@@ -137,7 +133,7 @@ class Router:
         """
         return self._register_processor(
             self.template_builders, region_name, sample_name, systematic_name, template
-        )  # type: ignore
+        )
 
     @staticmethod
     def _find_match(
@@ -146,7 +142,7 @@ class Router:
         sample_name: str,
         systematic_name: str,
         template: str,
-    ) -> Optional[GenericProcessorFunc]:
+    ) -> Optional[UserTemplateFunc]:
         """Returns a function matching the provided specification.
 
         Args:
@@ -157,7 +153,7 @@ class Router:
             template (str): template name
 
         Returns:
-            Optional[GenericProcessorFunc]: processor function matching the description,
+            Optional[UserTemplateFunc]: processor function matching the description,
             or None if no matches are found
         """
         matches = []
@@ -217,7 +213,7 @@ class Router:
 
         if match is not None:
             # if user-defined function was found, wrap and return it
-            return self.template_builder_wrapper(match)  # type: ignore
+            return self.template_builder_wrapper(match)
         return None
 
 

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -61,9 +61,12 @@ class Router:
         systematic_name: Optional[str],
         template: Optional[str],
     ) -> Callable[[UserTemplateFunc], UserTemplateFunc]:
-        """Decorator for registering a template builder function.
+        """Decorator for registering a processor function.
 
-        The function is added to the list provided as function argument.
+        The function is added to the list provided as function argument. Currently this
+        function is used only for template builder functions, but could be used for
+        additional types of functions as well. This requires extending the return type
+        accordingly.
 
         Args:
             region_name  (Optional[str]): name of the region to apply the function to,
@@ -91,7 +94,9 @@ class Router:
         def _register(func: UserTemplateFunc) -> UserTemplateFunc:
             """Registers a processor function to be applied when matching a pattern.
 
-            The pattern is specified by region-sample-systematic-template.
+            The pattern is specified by region-sample-systematic-template. To support
+            functions other than template builder functions, the argument and return
+            types need to be extended.
 
             Args:
                 func (UserTemplateFunc): the function to register

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -139,7 +139,7 @@ class Router:
 
         Returns:
             Callable[[UserTemplateFunc], UserTemplateFunc]: the function to register a
-            a processor
+            processor
         """
         return self._register_processor(
             self.template_builders, region_name, sample_name, systematic_name, template

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -155,6 +155,9 @@ class Router:
     ) -> Optional[UserTemplateFunc]:
         """Returns a function matching the provided specification.
 
+        This is currently only used for template builder functions, but could be used
+        for other types of functions by extending the return type accordingly.
+
         Args:
             processor_list (List[Dict[str, Any]]): list of processors to search in
             region_name (str): region name

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -61,7 +61,9 @@ class Router:
         systematic_name: Optional[str],
         template: Optional[str],
     ) -> Callable[[UserTemplateFunc], UserTemplateFunc]:
-        """Decorator for registering a custom processor function.
+        """Decorator for registering a template builder function.
+
+        The function is added to the list provided as function argument.
 
         Args:
             region_name  (Optional[str]): name of the region to apply the function to,
@@ -116,6 +118,9 @@ class Router:
         template: Optional[str] = None,
     ) -> Callable[[Callable], UserTemplateFunc]:
         """Decorator for registering a template builder function.
+
+        The function is added to the list stored in the ``template_builders`` member
+        variable.
 
         Args:
             region_name (Optional[str], optional): name of the region to apply the


### PR DESCRIPTION
#204 revealed a typing bug in `cabinetry.route`, since `bh.Histogram` is no longer considered `Any`. This fixes the bug:
- `register_template_builder` should only ever be used to decorate functions returning a histogram (so those functions should have type `UserTemplateFunc`)
- the `register_template_builder` function calls `_register_processor`, which also should handle functions of type `UserTemplateFunc`
- `_register_processor` uses `_register` which should follow the same logic
- since all `_find_match` uses the registered functions which are now all of type `UserTemplateFunc`, `_find_match` itself should also return a function of that type

`_find_match` (which returns a un-wrapped `UserTemplateFunc`) is only used via `_find_template_builder_match`, which returns a user-provided template builder wrapped by a `template_builder_wrapper` (the wrapped result is a `ProcessorFunc`). This wrapper ensures that the resulting function saves the histogram and returns `None` instead of returning the histogram itself. `template_builder_wrapper` is used in `template_builder.create_histograms`.