### PR TITLE
fix: goodness-of-fit with no auxiliary data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.11.0
+    rev: v2.12.0
     hooks:
     -   id: pyupgrade
         args: ["--py37-plus"]

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -348,6 +348,9 @@ def _goodness_of_fit(
 ) -> float:
     """Calculates goodness-of-fit p-value with a saturated model.
 
+    Returns NaN if the number of degrees of freedom in the chi2 test is zero (nominal
+    fit should already be perfect) or negative (over-parameterized model).
+
     Args:
         model (pyhf.pdf.Model): model used in the fit for which goodness-of-fit should
             be calculated
@@ -382,6 +385,14 @@ def _goodness_of_fit(
         model.config.channel_nbins.values()
     ) - model_utils.unconstrained_parameter_count(model)
     log.debug(f"number of degrees of freedom: {n_dof}")
+
+    if n_dof <= 0:
+        log.warning(
+            f"cannot calculate p-value: {n_dof} degrees of freedom and Delta NLL = "
+            f"{delta_nll:.6f}"
+        )
+        return np.nan
+
     p_val = scipy.stats.chi2.sf(2 * delta_nll, n_dof)
     log.info(f"p-value for goodness-of-fit test: {p_val:.2%}")
     return p_val

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,10 +240,7 @@ def example_spec_no_aux():
         ],
         "measurements": [
             {
-                "config": {
-                    "parameters": [],
-                    "poi": "Signal strength",
-                },
+                "config": {"parameters": [], "poi": "Signal strength"},
                 "name": "no auxdata",
             }
         ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,3 +215,39 @@ def example_spec_with_background():
         "version": "1.0.0",
     }
     return spec
+
+
+@pytest.fixture
+def example_spec_no_aux():
+    spec = {
+        "channels": [
+            {
+                "name": "Signal Region",
+                "samples": [
+                    {
+                        "data": [60],
+                        "modifiers": [
+                            {
+                                "data": None,
+                                "name": "Signal strength",
+                                "type": "normfactor",
+                            },
+                        ],
+                        "name": "Signal",
+                    }
+                ],
+            }
+        ],
+        "measurements": [
+            {
+                "config": {
+                    "parameters": [],
+                    "poi": "Signal strength",
+                },
+                "name": "no auxdata",
+            }
+        ],
+        "observations": [{"data": [65], "name": "Signal Region"}],
+        "version": "1.0.0",
+    }
+    return spec


### PR DESCRIPTION
Fixes the goodness-of-fit calculation for models without auxiliary data and without constraint terms. Handles the split of data into main and auxiliary data depending on whether auxiliary data is present, and skips the constraint term calculation if no constraint term is present (https://github.com/scikit-hep/pyhf/issues/1390).

Also adds a warning for models for which the GOF cannot be calculated, either since the number of degrees of freedom is zero (nominal model should already result in perfect fit), or the model is over-parameterized (negative number of degrees of freedom).

resolves #206 