### PR TITLE
fix: skip typeguard 2.12 for NamedTuple compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extras_require["test"] = sorted(
             "flake8-import-order",
             "flake8-print",
             "mypy",
-            "typeguard!=2.11.*",  # NamedTuple compatibility in Python 3.7
+            "typeguard!=2.11.*,!=2.12",  # NamedTuple incompatibility in Python 3.7
             "black==20.8b1",
         ]
     )


### PR DESCRIPTION
`typeguard` 2.12.0 is affected by the same issue with `NamedTuple` as versions 2.11.*, so this skips 2.12 as dependency. See also #199. 