### PR TITLE
ci: remove Codecov token

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,6 @@ jobs:
       if: matrix.python-version == 3.7
       uses: codecov/codecov-action@v1
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         name: codecov-umbrella
         fail_ci_if_error: true


### PR DESCRIPTION
Codecov needs no token for public projects (since action version [1.0.6](https://github.com/codecov/codecov-action/releases/tag/v1.0.6)), so this token can be removed.