### PR TITLE
feat: region-dependent samples

### DIFF
--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -187,7 +187,7 @@ def histogram_is_needed(
                 if systematic.get(template, {}).get("Symmetrize", False):
                     histo_needed = False
             else:
-                raise NotImplementedError("other systematics not yet implemented")
+                raise ValueError(f"unknown systematics type: {systematic['Type']}")
 
     return histo_needed
 

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -115,6 +115,27 @@ def sample_affected_by_modifier(
     return affected
 
 
+def region_contains_sample(region: Dict[str, Any], sample: Dict[str, Any]) -> bool:
+    """Checks if a region contains a given sample.
+
+    A sample enters all regions by default, and the "Regions" property of a sample can
+    be used to specify a single region or list of regions that contain the sample.
+
+    Args:
+        region (Dict[str, Any]): containing all region information
+        sample (Dict[str, Any]): containing all sample information
+
+    Returns:
+        bool: True if region contains sample, False otherwise
+    """
+    # "Regions" setting of samples is optional, default to empty list
+    regions_list_for_sample = _convert_setting_to_list(sample.get("Regions", []))
+    if regions_list_for_sample != [] and region["Name"] not in regions_list_for_sample:
+        # sample only exists for some regions, and current region not in list
+        return False
+    return True
+
+
 def histogram_is_needed(
     region: Dict[str, Any],
     sample: Dict[str, Any],
@@ -139,6 +160,10 @@ def histogram_is_needed(
     Returns:
         bool: whether a histogram is needed
     """
+    if not region_contains_sample(region, sample):
+        # region does not contain sample
+        return False
+
     if systematic.get("Name", None) == "Nominal":
         # for nominal, histograms are generally needed
         histo_needed = True

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -130,7 +130,7 @@ def region_contains_sample(region: Dict[str, Any], sample: Dict[str, Any]) -> bo
     """
     # "Regions" setting of samples is optional, default to empty list
     regions_list_for_sample = _convert_setting_to_list(sample.get("Regions", []))
-    if regions_list_for_sample != [] and region["Name"] not in regions_list_for_sample:
+    if regions_list_for_sample and region["Name"] not in regions_list_for_sample:
         # sample only exists for some regions, and current region not in list
         return False
     return True

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -261,9 +261,9 @@ def apply_to_all_templates(
 
         for sample in config["Samples"]:
             log.debug(f"    reading sample {sample['Name']}")
+            # region dependence of sample is checked below via histogram_is_needed
 
             for systematic in [{"Name": "Nominal"}] + config["Systematics"]:
-
                 # determine how many templates need to be considered
                 if systematic["Name"] == "Nominal":
                     # only nominal template is needed
@@ -273,7 +273,6 @@ def apply_to_all_templates(
                     templates = ["Up", "Down"]
 
                 for template in templates:
-
                     # determine whether a histogram is needed for this
                     # specific combination of sample-region-systematic-template
                     histo_needed = configuration.histogram_is_needed(

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -162,6 +162,10 @@
                 "Data": {
                     "description": "if it is a data sample",
                     "type": "boolean"
+                },
+                "Regions": {
+                    "description": "region(s) that contain the sample, defaults to all regions",
+                    "$ref": "#/definitions/regions_setting"
                 }
             },
             "additionalProperties": false

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional
 
 import numpy as np
 
+from . import configuration
 from . import histo
 from . import route
 from . import smooth
@@ -72,16 +73,14 @@ def _get_smoothing_algorithm(
     smoothing_regions = smoothing.get("Regions", False)
     if smoothing_regions:
         # if regions are specified, only smooth those regions
-        if not isinstance(smoothing_regions, list):
-            smoothing_regions = [smoothing_regions]
+        smoothing_regions = configuration._convert_setting_to_list(smoothing_regions)
         if region["Name"] not in smoothing_regions:
             return None
 
     smoothing_samples = smoothing.get("Samples", False)
     if smoothing_samples:
         # if samples are specified, only smooth those samples
-        if not isinstance(smoothing_samples, list):
-            smoothing_samples = [smoothing_samples]
+        smoothing_samples = configuration._convert_setting_to_list(smoothing_samples)
         if sample["Name"] not in smoothing_samples:
             return None
 

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -308,6 +308,10 @@ class WorkspaceBuilder:
                     # skip the data sample, it goes into the observations instead
                     continue
 
+                if not configuration.region_contains_sample(region, sample):
+                    # region does not contain this sample
+                    continue
+
                 # yield of the samples
                 histo_yield = self.get_yield_for_sample(region, sample)
                 current_sample = {}

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -309,7 +309,7 @@ class WorkspaceBuilder:
                     continue
 
                 if not configuration.region_contains_sample(region, sample):
-                    # region does not contain this sample
+                    # current region does not contain this sample, so skip it
                     continue
 
                 # yield of the samples

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -107,6 +107,18 @@ def test_sample_affected_by_modifier(sample_and_modifier, affected):
 
 
 @pytest.mark.parametrize(
+    "region_and_sample, contained",
+    [
+        (({"Name": "CR"}, {}), True),
+        (({"Name": "SR"}, {"Regions": ["SR", "CR"]}), True),
+        (({"Name": "CR"}, {"Regions": "SR"}), False),
+    ],
+)
+def test_region_contains_sample(region_and_sample, contained):
+    assert configuration.region_contains_sample(*region_and_sample) is contained
+
+
+@pytest.mark.parametrize(
     "reg_sam_sys_tem, is_needed",
     [
         # nominal
@@ -163,18 +175,19 @@ def test_sample_affected_by_modifier(sample_and_modifier, affected):
             ),
             True,
         ),
+        # region does not contain sample
+        (({"Name": "CR"}, {"Name": "Signal", "Regions": "SR"}, {}, "Nominal"), False),
     ],
 )
 def test_histogram_is_needed(reg_sam_sys_tem, is_needed):
+    # could also mock sample_affected_by_modifier and region_contains_sample here
     reg, sam, sys, tem = reg_sam_sys_tem
     assert configuration.histogram_is_needed(*reg_sam_sys_tem) is is_needed
 
 
 def test_histogram_is_needed_unknown():
     # non-supported systematic
-    with pytest.raises(
-        NotImplementedError, match="other systematics not yet implemented"
-    ):
+    with pytest.raises(ValueError, match="unknown systematics type: unknown"):
         configuration.histogram_is_needed({}, {}, {"Type": "unknown"}, "")
 
 

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -201,6 +201,7 @@ def test_Router__find_template_builder_match(processor_examples):
 
 
 def test_apply_to_all_templates():
+    # could mock configuration.histogram_is_needed here
     # define a custom override function that logs its arguments when called
     override_call_args = []
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -276,6 +276,7 @@ def test_WorkspaceBuilder_get_channels(mock_contains, mock_get_yield, mock_get_u
     channels = ws_builder.get_channels()
     expected_channels = [{"name": "region_1", "samples": []}]
     assert channels == expected_channels
+    assert mock_contains.call_count == 2
     assert mock_contains.call_args_list[-1] == (
         (example_config["Regions"][0], example_config["Samples"][0]),
         {},

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -232,7 +232,8 @@ def test_WorkspaceBuilder_get_sys_modifiers():
     "cabinetry.workspace.WorkspaceBuilder.get_yield_for_sample",
     return_value=[1.0, 2.0],
 )
-def test_WorkspaceBuilder_get_channels(mock_get_yield, mock_get_unc):
+@mock.patch("cabinetry.configuration.region_contains_sample", side_effect=[True, False])
+def test_WorkspaceBuilder_get_channels(mock_contains, mock_get_yield, mock_get_unc):
     example_config = {
         "General": {"HistogramFolder": "path"},
         "Regions": [{"Name": "region_1"}],
@@ -261,12 +262,23 @@ def test_WorkspaceBuilder_get_channels(mock_get_yield, mock_get_unc):
         }
     ]
     assert channels == expected_channels
+    assert mock_contains.call_args_list == [
+        ((example_config["Regions"][0], example_config["Samples"][0]), {})
+    ]
     assert mock_get_yield.call_args_list == [
         ((example_config["Regions"][0], example_config["Samples"][0]), {})
     ]
     assert mock_get_unc.call_args_list == [
         ((example_config["Regions"][0], example_config["Samples"][0]), {})
     ]
+
+    # run again, this time region will not contain sample due to side_effect
+    channels = ws_builder.get_channels()
+    expected_channels = [{"name": "region_1", "samples": []}]
+    assert channels == expected_channels
+    # no calls to read histogram content
+    assert mock_get_yield.call_count == 1
+    assert mock_get_unc.call_count == 1
 
 
 def test_WorkspaceBuilder_get_measurement():

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -276,6 +276,10 @@ def test_WorkspaceBuilder_get_channels(mock_contains, mock_get_yield, mock_get_u
     channels = ws_builder.get_channels()
     expected_channels = [{"name": "region_1", "samples": []}]
     assert channels == expected_channels
+    assert mock_contains.call_args_list[-1] == (
+        (example_config["Regions"][0], example_config["Samples"][0]),
+        {},
+    )
     # no calls to read histogram content
     assert mock_get_yield.call_count == 1
     assert mock_get_unc.call_count == 1


### PR DESCRIPTION
Addresses #214 in part. This adds a `Regions` property to samples, which allows specifying the regions that contain a given sample.

Also improves the error in `configuration.histogram_is_needed` when encountering an unknown systematic: switching to a `ValueError` and reporting the name of the unknown systematic.