### PR TITLE
feat: make Samples property of modifiers optional

### DIFF
--- a/config_example.yml
+++ b/config_example.yml
@@ -32,7 +32,6 @@ Systematics:
       Normalization: 0.05
     Down:
       Normalization: -0.05
-    Samples: ["Signal", "Background"]
     Type: "Normalization"
 
   - Name: "Modeling"

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -102,11 +102,11 @@ def _x_contains_y(x: Dict[str, Any], y: Dict[str, Any], y_key: str) -> bool:
 
     If ``y_key`` is not specified, ``x`` is assumed to contain ``y`` by default. Used
     to check if regions contain samples/modifiers and if samples contain modifiers.
-    ``x`` is identified by its ``Name`` property, which must exist.
+    ``x`` is identified by its "Name" property, which must exist.
 
     Args:
         x (Dict[str, Any]): containing all relevant information: region or sample, must
-            have a ``Name`` property
+            have a "Name" property
         y (Dict[str, Any]): containing all relevant information: sample or modifier
         y_key (str): property of ``y`` to check
 
@@ -124,7 +124,7 @@ def _x_contains_y(x: Dict[str, Any], y: Dict[str, Any], y_key: str) -> bool:
 def region_contains_sample(region: Dict[str, Any], sample: Dict[str, Any]) -> bool:
     """Checks if a region contains a given sample.
 
-    A sample enters all regions by default, and its ``Regions`` property can be used to
+    A sample enters all regions by default, and its "Regions" property can be used to
     specify a single region or list of regions that contain the sample.
 
     Args:
@@ -140,8 +140,8 @@ def region_contains_sample(region: Dict[str, Any], sample: Dict[str, Any]) -> bo
 def sample_contains_modifier(sample: Dict[str, Any], modifier: Dict[str, Any]) -> bool:
     """Checks if a sample is affected by a given modifier (Systematic, NormFactor).
 
-    A modifier affects all samples by default, and its ``Samples`` property can be used
-    to specify a single sample or list of samples on which the modifier acts.
+    A modifier affects all samples by default, and its "Samples" property can be used to
+    specify a single sample or list of samples on which the modifier acts.
 
     Args:
         sample (Dict[str, Any]): containing all sample information

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -124,8 +124,8 @@ def _x_contains_y(x: Dict[str, Any], y: Dict[str, Any], y_key: str) -> bool:
 def region_contains_sample(region: Dict[str, Any], sample: Dict[str, Any]) -> bool:
     """Checks if a region contains a given sample.
 
-    A sample enters all regions by default, and the "Regions" property of a sample can
-    be used to specify a single region or list of regions that contain the sample.
+    A sample enters all regions by default, and its ``Regions`` property can be used to
+    specify a single region or list of regions that contain the sample.
 
     Args:
         region (Dict[str, Any]): containing all region information
@@ -139,6 +139,9 @@ def region_contains_sample(region: Dict[str, Any], sample: Dict[str, Any]) -> bo
 
 def sample_contains_modifier(sample: Dict[str, Any], modifier: Dict[str, Any]) -> bool:
     """Checks if a sample is affected by a given modifier (Systematic, NormFactor).
+
+    A modifier affects all samples by default, and its ``Samples`` property can be used
+    to specify a single sample or list of samples on which the modifier acts.
 
     Args:
         sample (Dict[str, Any]): containing all sample information

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -175,14 +175,14 @@
             "$$target": "#/definitions/normfactor",
             "description": "a normalization factor affecting one or more samples",
             "type": "object",
-            "required": ["Name", "Samples"],
+            "required": ["Name"],
             "properties": {
                 "Name": {
                     "description": "name of the normalization factor",
                     "type": "string"
                 },
                 "Samples": {
-                    "description": "affected sample(s)",
+                    "description": "affected sample(s), defaults to all samples",
                     "$ref": "#/definitions/samples_setting"
                 },
                 "Nominal": {
@@ -208,15 +208,11 @@
             "$$target": "#/definitions/systematic",
             "description": "a systematic uncertainty",
             "type": "object",
-            "required": ["Name", "Samples", "Type", "Up", "Down"],
+            "required": ["Name", "Type", "Up", "Down"],
             "properties": {
                 "Name": {
                     "description": "name of the systematic uncertainty",
                     "type": "string"
-                },
-                "Samples": {
-                    "description": "affected sample(s)",
-                    "$ref": "#/definitions/samples_setting"
                 },
                 "Type": {
                     "description": "type of systematic uncertainty",
@@ -230,6 +226,10 @@
                 "Down": {
                     "description": "template for \"down\" variation",
                     "$ref": "#/definitions/template_setting"
+                },
+                "Samples": {
+                    "description": "affected sample(s), defaults to all samples",
+                    "$ref": "#/definitions/samples_setting"
                 },
                 "Smoothing": {
                     "description": "smoothing to apply",
@@ -347,7 +347,7 @@
                     "$ref": "#/definitions/regions_setting"
                 },
                 "Samples": {
-                    "description": "samples to apply smoothing to",
+                    "description": "sample(s) to apply smoothing to, defaults to all samples",
                     "$ref": "#/definitions/samples_setting"
                 }
             },

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -70,14 +70,14 @@ def _get_smoothing_algorithm(
     if smoothing is None:
         return None
 
-    # check for limited regions and samples for which to apply smoothing, apply to all
+    # check for region and sample restrictions specified for smoothing, apply to all
     # regions and samples by default if no further specification is made
     if not configuration._x_contains_y(region, smoothing, "Regions"):
-        # limited regions are specified and current region does not match, do not smooth
+        # regions are specified and current region does not match, do not smooth
         return None
 
     if not configuration._x_contains_y(sample, smoothing, "Samples"):
-        # limited samples are specified and current sample does not match, do not smooth
+        # samples are specified and current sample does not match, do not smooth
         return None
 
     # smoothing algorithm needs to be applied

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -70,19 +70,15 @@ def _get_smoothing_algorithm(
     if smoothing is None:
         return None
 
-    smoothing_regions = smoothing.get("Regions", False)
-    if smoothing_regions:
-        # if regions are specified, only smooth those regions
-        smoothing_regions = configuration._convert_setting_to_list(smoothing_regions)
-        if region["Name"] not in smoothing_regions:
-            return None
+    # check for limited regions and samples for which to apply smoothing, apply to all
+    # regions and samples by default if no further specification is made
+    if not configuration._x_contains_y(region, smoothing, "Regions"):
+        # limited regions are specified and current region does not match, do not smooth
+        return None
 
-    smoothing_samples = smoothing.get("Samples", False)
-    if smoothing_samples:
-        # if samples are specified, only smooth those samples
-        smoothing_samples = configuration._convert_setting_to_list(smoothing_samples)
-        if sample["Name"] not in smoothing_samples:
-            return None
+    if not configuration._x_contains_y(sample, smoothing, "Samples"):
+        # limited samples are specified and current sample does not match, do not smooth
+        return None
 
     # smoothing algorithm needs to be applied
     smoothing_algorithm = smoothing["Algorithm"]

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -125,7 +125,7 @@ class WorkspaceBuilder:
         """
         modifiers = []
         for NormFactor in self.config["NormFactors"]:
-            if configuration.sample_affected_by_modifier(sample, NormFactor):
+            if configuration.sample_contains_modifier(sample, NormFactor):
                 log.debug(
                     f"adding NormFactor {NormFactor['Name']} to sample {sample['Name']}"
                 )
@@ -268,7 +268,7 @@ class WorkspaceBuilder:
         """
         modifiers = []
         for systematic in self.config.get("Systematics", []):
-            if configuration.sample_affected_by_modifier(sample, systematic):
+            if configuration.sample_contains_modifier(sample, systematic):
                 if systematic["Type"] == "Normalization":
                     # OverallSys (norm uncertainty with Gaussian constraint)
                     log.debug(

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -102,8 +102,8 @@ def test__convert_setting_to_list(samples, converted):
         (({"Name": "Signal"}, {"Samples": "Background"}), False),
     ],
 )
-def test_sample_affected_by_modifier(sample_and_modifier, affected):
-    assert configuration.sample_affected_by_modifier(*sample_and_modifier) is affected
+def test_sample_contains_modifier(sample_and_modifier, affected):
+    assert configuration.sample_contains_modifier(*sample_and_modifier) is affected
 
 
 @pytest.mark.parametrize(
@@ -180,7 +180,7 @@ def test_region_contains_sample(region_and_sample, contained):
     ],
 )
 def test_histogram_is_needed(reg_sam_sys_tem, is_needed):
-    # could also mock sample_affected_by_modifier and region_contains_sample here
+    # could also mock sample_contains_modifier and region_contains_sample here
     reg, sam, sys, tem = reg_sam_sys_tem
     assert configuration.histogram_is_needed(*reg_sam_sys_tem) is is_needed
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -124,6 +124,7 @@ def test_region_contains_sample(region_and_sample, contained):
 @pytest.mark.parametrize(
     "sample_and_modifier, contained",
     [
+        (({"Name": "Signal"}, {}), True),
         (({"Name": "Signal"}, {"Samples": ["Signal", "Background"]}), True),
         (({"Name": "Signal"}, {"Samples": "Background"}), False),
     ],
@@ -141,12 +142,14 @@ def test_sample_contains_modifier(sample_and_modifier, contained):
         (({}, {"Data": True}, {"Name": "var"}, ""), False),
         # overall normalization variation
         (({}, {}, {"Type": "Normalization"}, ""), False),
-        # normalization + shape variation on affected sample
+        # normalization + shape variation
+        (({}, {"Name": "Signal"}, {"Type": "NormPlusShape"}, "Up"), True),
+        # normalization + shape variation on specified and affected sample
         (
             (
                 {},
                 {"Name": "Signal"},
-                {"Type": "NormPlusShape", "Samples": "Signal"},
+                {"Type": "NormPlusShape", "Samples": ["Signal", "Background"]},
                 "Up",
             ),
             True,
@@ -161,7 +164,7 @@ def test_sample_contains_modifier(sample_and_modifier, contained):
             ),
             False,
         ),
-        # non-needed template of systematic due to symmetrization
+        # template not needed due to symmetrization
         (
             (
                 {},

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -24,7 +24,7 @@ def test_validate():
         },
         "Regions": [{"Name": "", "Filter": "", "Variable": "", "Binning": [0, 1]}],
         "Samples": [{"Name": "", "Tree": "", "Data": True}],
-        "NormFactors": [{"Name": "", "Samples": ""}],
+        "NormFactors": [{"Name": ""}],
     }
     assert configuration.validate(config_valid)
 
@@ -38,7 +38,7 @@ def test_validate():
         },
         "Regions": [{"Name": "", "Filter": "", "Variable": "", "Binning": [0, 1]}],
         "Samples": [{"Name": "", "Tree": ""}],
-        "NormFactors": [{"Name": "", "Samples": ""}],
+        "NormFactors": [{"Name": ""}],
     }
     with pytest.raises(
         NotImplementedError, match="can only handle cases with exactly one data sample"
@@ -168,7 +168,6 @@ def test_sample_contains_modifier(sample_and_modifier, contained):
                 {"Name": "Signal"},
                 {
                     "Type": "NormPlusShape",
-                    "Samples": "Signal",
                     "Up": {"Symmetrize": True},
                 },
                 "Up",

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -96,14 +96,17 @@ def test__convert_setting_to_list(samples, converted):
 
 
 @pytest.mark.parametrize(
-    "sample_and_modifier, affected",
+    "x_y_key, contained",
     [
-        (({"Name": "Signal"}, {"Samples": ["Signal", "Background"]}), True),
-        (({"Name": "Signal"}, {"Samples": "Background"}), False),
+        (({"Name": "abc"}, {}, "key"), True),
+        (({"Name": "abc"}, {"key": ["abc", "def"]}, "key"), True),
+        (({"Name": "abc"}, {"key": ["def"]}, "key"), False),
+        (({"Name": "abc"}, {"key": "abc"}, "key"), True),
+        (({"Name": "abc"}, {"key": "def"}, "key"), False),
     ],
 )
-def test_sample_contains_modifier(sample_and_modifier, affected):
-    assert configuration.sample_contains_modifier(*sample_and_modifier) is affected
+def test__x_contains_y(x_y_key, contained):
+    assert configuration._x_contains_y(*x_y_key) is contained
 
 
 @pytest.mark.parametrize(
@@ -116,6 +119,17 @@ def test_sample_contains_modifier(sample_and_modifier, affected):
 )
 def test_region_contains_sample(region_and_sample, contained):
     assert configuration.region_contains_sample(*region_and_sample) is contained
+
+
+@pytest.mark.parametrize(
+    "sample_and_modifier, contained",
+    [
+        (({"Name": "Signal"}, {"Samples": ["Signal", "Background"]}), True),
+        (({"Name": "Signal"}, {"Samples": "Background"}), False),
+    ],
+)
+def test_sample_contains_modifier(sample_and_modifier, contained):
+    assert configuration.sample_contains_modifier(*sample_and_modifier) is contained
 
 
 @pytest.mark.parametrize(

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -218,7 +218,7 @@ def test_apply_to_all_templates():
         "Samples": [{"Name": "sample"}],
         "Systematics": [
             {"Name": "norm", "Type": "Normalization"},
-            {"Name": "var", "Type": "NormPlusShape", "Samples": "sample"},
+            {"Name": "var", "Type": "NormPlusShape"},
         ],
     }
 
@@ -235,7 +235,7 @@ def test_apply_to_all_templates():
         (
             {"Name": "test_region"},
             {"Name": "sample"},
-            {"Name": "var", "Type": "NormPlusShape", "Samples": "sample"},
+            {"Name": "var", "Type": "NormPlusShape"},
             "Up",
         ),
         {},
@@ -244,7 +244,7 @@ def test_apply_to_all_templates():
         (
             {"Name": "test_region"},
             {"Name": "sample"},
-            {"Name": "var", "Type": "NormPlusShape", "Samples": "sample"},
+            {"Name": "var", "Type": "NormPlusShape"},
             "Down",
         ),
         {},
@@ -262,12 +262,12 @@ def test_apply_to_all_templates():
     assert override_call_args[1] == (
         {"Name": "test_region"},
         {"Name": "sample"},
-        {"Name": "var", "Type": "NormPlusShape", "Samples": "sample"},
+        {"Name": "var", "Type": "NormPlusShape"},
         "Up",
     )
     assert override_call_args[2] == (
         {"Name": "test_region"},
         {"Name": "sample"},
-        {"Name": "var", "Type": "NormPlusShape", "Samples": "sample"},
+        {"Name": "var", "Type": "NormPlusShape"},
         "Down",
     )

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -152,10 +152,7 @@ def test_WorkspaceBuilder_get_NF_modifiers():
     # multiple NFs affect sample
     example_config = {
         "General": {"HistogramFolder": "path"},
-        "NormFactors": [
-            {"Name": "mu", "Samples": ["ABC", "DEF"]},
-            {"Name": "k", "Samples": ["DEF", "GHI"]},
-        ],
+        "NormFactors": [{"Name": "mu"}, {"Name": "k"}],
     }
     sample = {"Name": "DEF"}
     expected_modifier = [
@@ -192,7 +189,6 @@ def test_WorkspaceBuilder_get_sys_modifiers():
             {
                 "Name": "sys",
                 "Type": "Normalization",
-                "Samples": "Signal",
                 "Up": {"Normalization": 0.1},
                 "Down": {"Normalization": -0.05},
             }
@@ -211,9 +207,7 @@ def test_WorkspaceBuilder_get_sys_modifiers():
     # unsupported systematics type
     example_config_unsupported = {
         "General": {"HistogramFolder": "path"},
-        "Systematics": [
-            {"Name": "Normalization", "Type": "unknown", "Samples": "Signal"}
-        ],
+        "Systematics": [{"Name": "Normalization", "Type": "unknown"}],
     }
     ws_builder = workspace.WorkspaceBuilder(example_config_unsupported)
     with pytest.raises(


### PR DESCRIPTION
`Systematics` and `NormFactors` previously had a required `Samples` property to specify on which samples the modifier acts. This makes the property optional, and when not specified the modifier will act on all samples. Also unifies the functionality in the `configuration` module to avoid duplications due to the features required by #214, including harmonizing the `Samples` handling for smoothing.

partially addresses #214

**breaking changes**:
- `configuration.sample_affected_by_modifier` renamed to `configuration.sample_contains_modifier` to harmonize naming with `configuration.region_contains_sample` and the upcoming `configuration.region_contains_sample`