### PR TITLE
feat: region-dependent modifiers

### DIFF
--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -215,8 +215,9 @@ def histogram_is_needed(
                 histo_needed = False
             elif systematic["Type"] == "NormPlusShape":
                 # for a variation defined via a template, a histogram is needed (if
-                # sample is affected)
-                histo_needed = sample_contains_modifier(sample, systematic)
+                # sample is affected in region)
+                histo_needed = region_contains_modifier(region, systematic)
+                histo_needed &= sample_contains_modifier(sample, systematic)
                 # if symmetrization is specified for the template under consideration,
                 # a histogram is not needed (since it will later on be obtained via
                 # symmetrization)

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -137,6 +137,24 @@ def region_contains_sample(region: Dict[str, Any], sample: Dict[str, Any]) -> bo
     return _x_contains_y(region, sample, "Regions")
 
 
+def region_contains_modifier(region: Dict[str, Any], modifier: Dict[str, Any]) -> bool:
+    """Checks if a region contains a given modifier (Systematic, NormFactor).
+
+    A modifier affects all regions by default, and its "Regions" property can be used to
+    specify a single region or list of regions that contain the modifier. This does not
+    check whether the modifier only acts on samples which the region does not contain.
+
+    Args:
+        region (Dict[str, Any]): containing all region information
+        modifier (Dict[str, Any]): containing all modifier information (a Systematic or
+            a NormFactor)
+
+    Returns:
+        bool: True if region contains modifier, False otherwise
+    """
+    return _x_contains_y(region, modifier, "Regions")
+
+
 def sample_contains_modifier(sample: Dict[str, Any], modifier: Dict[str, Any]) -> bool:
     """Checks if a sample is affected by a given modifier (Systematic, NormFactor).
 

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -181,6 +181,10 @@
                     "description": "name of the normalization factor",
                     "type": "string"
                 },
+                "Regions": {
+                    "description": "region(s) that contain the normfactor, defaults to all regions",
+                    "$ref": "#/definitions/regions_setting"
+                },
                 "Samples": {
                     "description": "affected sample(s), defaults to all samples",
                     "$ref": "#/definitions/samples_setting"
@@ -226,6 +230,10 @@
                 "Down": {
                     "description": "template for \"down\" variation",
                     "$ref": "#/definitions/template_setting"
+                },
+                "Regions": {
+                    "description": "region(s) that contain the systematic, defaults to all regions",
+                    "$ref": "#/definitions/regions_setting"
                 },
                 "Samples": {
                     "description": "affected sample(s), defaults to all samples",

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -120,6 +120,7 @@ class WorkspaceBuilder:
         """Returns the list of NormFactor modifiers acting on a sample in a region.
 
         Args:
+            region (Dict[str, Any]): specific region to get NormFactor modifiers for
             sample (Dict[str, Any]): specific sample to get NormFactor modifiers for
 
         Returns:

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -128,7 +128,7 @@ class WorkspaceBuilder:
         """
         modifiers = []
         for norm_factor in self.config["NormFactors"]:
-            # check that region and sample both do not exclude modifier
+            # check that region and sample are both not excluded by modifier
             if configuration.region_contains_modifier(
                 region, norm_factor
             ) and configuration.sample_contains_modifier(sample, norm_factor):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -122,6 +122,18 @@ def test_region_contains_sample(region_and_sample, contained):
 
 
 @pytest.mark.parametrize(
+    "region_and_modifier, contained",
+    [
+        (({"Name": "CR"}, {}), True),
+        (({"Name": "SR"}, {"Regions": ["SR", "CR"]}), True),
+        (({"Name": "CR"}, {"Regions": "SR"}), False),
+    ],
+)
+def test_region_contains_modifier(region_and_modifier, contained):
+    assert configuration.region_contains_modifier(*region_and_modifier) is contained
+
+
+@pytest.mark.parametrize(
     "sample_and_modifier, contained",
     [
         (({"Name": "Signal"}, {}), True),
@@ -192,11 +204,50 @@ def test_sample_contains_modifier(sample_and_modifier, contained):
             True,
         ),
         # region does not contain sample
-        (({"Name": "CR"}, {"Name": "Signal", "Regions": "SR"}, {}, "Nominal"), False),
+        (
+            (
+                {"Name": "CR"},
+                {"Name": "Signal", "Regions": "SR"},
+                {"Type": "NormPlusShape"},
+                "Nominal",
+            ),
+            False,
+        ),
+        # region does contain sample
+        (
+            (
+                {"Name": "CR"},
+                {"Name": "Signal", "Regions": "CR"},
+                {"Type": "NormPlusShape"},
+                "Nominal",
+            ),
+            True,
+        ),
+        # region does not contain modifier
+        (
+            (
+                {"Name": "CR"},
+                {"Name": "Signal"},
+                {"Type": "NormPlusShape", "Regions": "SR"},
+                "Up",
+            ),
+            False,
+        ),
+        # region does contain modifier
+        (
+            (
+                {"Name": "CR"},
+                {"Name": "Signal"},
+                {"Type": "NormPlusShape", "Regions": "CR"},
+                "Up",
+            ),
+            True,
+        ),
     ],
 )
 def test_histogram_is_needed(reg_sam_sys_tem, is_needed):
-    # could also mock sample_contains_modifier and region_contains_sample here
+    # could also mock region_contains_sample, region_contains_modifier, and
+    # sample_contains_modifier
     reg, sam, sys, tem = reg_sam_sys_tem
     assert configuration.histogram_is_needed(*reg_sam_sys_tem) is is_needed
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -151,6 +151,18 @@ def test_WorkspaceBuilder_get_NF_modifiers():
     sample = {"Name": "GHI"}
     assert ws_builder.get_NF_modifiers(region, sample) == []
 
+    # NF enters in region
+    example_config = {
+        "General": {"HistogramFolder": "path"},
+        "NormFactors": [{"Name": "mu", "Regions": "SR"}],
+    }
+    ws_builder = workspace.WorkspaceBuilder(example_config)
+    assert ws_builder.get_NF_modifiers(region, sample) == expected_modifier
+
+    # no NF due to region
+    region = {"Name": "CR"}
+    assert ws_builder.get_NF_modifiers(region, sample) == []
+
     # multiple NFs affect sample
     example_config = {
         "General": {"HistogramFolder": "path"},
@@ -185,6 +197,7 @@ def test_WorkspaceBuilder_get_NormPlusShape_modifiers():
 
 
 def test_WorkspaceBuilder_get_sys_modifiers():
+    # should mock get_Normalization_modifier and especially get_NormPlusShape_modifiers
     # could mock region_contains_modifier / sample_contains_modifier
     example_config = {
         "General": {"HistogramFolder": "path"},
@@ -206,6 +219,18 @@ def test_WorkspaceBuilder_get_sys_modifiers():
         {"name": "sys", "type": "normsys", "data": {"hi": 1.1, "lo": 0.95}}
     ]
     assert modifiers == expected_modifiers
+
+    # systematic not present in region
+    example_config_region_mismatch = example_config.copy()
+    example_config_region_mismatch["Systematics"][0].update({"Regions": "CR"})
+    ws_builder = workspace.WorkspaceBuilder(example_config_region_mismatch)
+    assert ws_builder.get_sys_modifiers(region, sample) == []
+
+    # systematic not present in sample
+    example_config_sample_mismatch = example_config.copy()
+    example_config_sample_mismatch["Systematics"][0].update({"Samples": "Background"})
+    ws_builder = workspace.WorkspaceBuilder(example_config_sample_mismatch)
+    assert ws_builder.get_sys_modifiers(region, sample) == []
 
     # unsupported systematics type
     example_config_unsupported = {

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -135,19 +135,21 @@ def test_WorkspaceBuilder_get_unc_for_sample(mock_histogram):
 
 
 def test_WorkspaceBuilder_get_NF_modifiers():
+    # could mock region_contains_modifier / sample_contains_modifier
     # one NF affects sample
     example_config = {
         "General": {"HistogramFolder": "path"},
         "NormFactors": [{"Name": "mu", "Samples": ["ABC", "DEF"]}],
     }
+    region = {"Name": "SR"}
     sample = {"Name": "DEF"}
     expected_modifier = [{"data": None, "name": "mu", "type": "normfactor"}]
     ws_builder = workspace.WorkspaceBuilder(example_config)
-    assert ws_builder.get_NF_modifiers(sample) == expected_modifier
+    assert ws_builder.get_NF_modifiers(region, sample) == expected_modifier
 
     # no NF affects sample
     sample = {"Name": "GHI"}
-    assert ws_builder.get_NF_modifiers(sample) == []
+    assert ws_builder.get_NF_modifiers(region, sample) == []
 
     # multiple NFs affect sample
     example_config = {
@@ -160,7 +162,7 @@ def test_WorkspaceBuilder_get_NF_modifiers():
         {"data": None, "name": "k", "type": "normfactor"},
     ]
     ws_builder = workspace.WorkspaceBuilder(example_config)
-    assert ws_builder.get_NF_modifiers(sample) == expected_modifier
+    assert ws_builder.get_NF_modifiers(region, sample) == expected_modifier
 
 
 def test_WorkspaceBuilder_get_Normalization_modifier():
@@ -183,6 +185,7 @@ def test_WorkspaceBuilder_get_NormPlusShape_modifiers():
 
 
 def test_WorkspaceBuilder_get_sys_modifiers():
+    # could mock region_contains_modifier / sample_contains_modifier
     example_config = {
         "General": {"HistogramFolder": "path"},
         "Systematics": [
@@ -194,8 +197,8 @@ def test_WorkspaceBuilder_get_sys_modifiers():
             }
         ],
     }
+    region = {"Name": "SR"}
     sample = {"Name": "Signal"}
-    region = {}
     # needs to be expanded to include histogram loading
     ws_builder = workspace.WorkspaceBuilder(example_config)
     modifiers = ws_builder.get_sys_modifiers(region, sample)


### PR DESCRIPTION
This adds a `Regions` property to systematics and normfactors to specify region dependence. When used, the modifiers only enter in the specified regions. Otherwise they enter all regions by default.

**breaking changes**:
- `workspace.WorkspaceBuilder.get_NF_modifiers` signature changed, now takes a `region` and `sample` argument (only used `sample` previously)

resolves #214