### PR TITLE
chore: remove black version restriction and update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.5b0
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
@@ -10,12 +10,12 @@ repos:
         files: src/cabinetry
         additional_dependencies: ["numpy>=1.20", "boost-histogram>=1.0.1"]
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.0
+    rev: 3.9.1
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.12.0
+    rev: v2.14.0
     hooks:
     -   id: pyupgrade
         args: ["--py37-plus"]

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extras_require["test"] = sorted(
             "flake8-print",
             "mypy",
             "typeguard!=2.11.*,!=2.12",  # NamedTuple incompatibility in Python 3.7
-            "black==20.8b1",
+            "black",
         ]
     )
 )


### PR DESCRIPTION
Removing pinning of `black` version in `contrib` setup extra, and running `pre-commit autoupdate`.