### PR TITLE
ci: run mypy again with Python 3.7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,16 +28,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install .[test]
-    - name: Static code analysis with flake8
+    - name: Static code analysis with flake8 and mypy
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 src/cabinetry --select=E9,F63,F7,F82 --show-source
         # check for additional issues flagged by flake8
         flake8
-    - name: Type checking with mypy
-      if: matrix.python-version != 3.7
-      run: |
-        mypy  # 3.7 not supported due to boost-histogram
+        # run mypy for type checking
+        mypy
     - name: Format with Black
       run: |
         black --check --diff --verbose .


### PR DESCRIPTION
#204 removed `mypy` in the CI for Python 3.7 due to incompatibility with `boost-histogram`. [Version 1.0.2](https://github.com/scikit-hep/boost-histogram/releases/tag/v1.0.2) of `boost-histogram` allows the use of `mypy` again with Python 3.7, so it can be added back.