### PR TITLE
chore: updating version to 0.2.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cabinetry
-version = 0.2.0
+version = 0.2.1
 author = Alexander Held
 description = design and steer profile likelihood fits
 long_description = file: README.md

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -10,4 +10,4 @@ from . import visualize  # NOQA
 from . import workspace  # NOQA
 
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
Updating to version `0.2.1`. This adds flexibility in model construction (samples and systematics with region dependence), CLI for data/MC plots, compatibility with the `boost-histogram` v1 API and fixes goodness-of-fit for models without auxiliary data.