### PR TITLE
feat: support all pyhf backends

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,6 +57,7 @@ jobs:
       if: matrix.python-version != 3.7
       run: |
         sudo apt-get install ghostscript  # for pdf comparison
+        python -m pip install .[test]  # should downgrade numpy again for tensorflow compatibility
         pytest --runslow
     - name: Upload coverage to codecov
       if: matrix.python-version == 3.7

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install .[test]
+        pip install --upgrade numpy  # temporary workaround to avoid downgrade due to tensorflow
     - name: Static code analysis with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -56,7 +57,6 @@ jobs:
       if: matrix.python-version != 3.7
       run: |
         sudo apt-get install ghostscript  # for pdf comparison
-        pip install --upgrade numpy  # temporary workaround to avoid downgrade due to tensorflow
         pytest --runslow
     - name: Upload coverage to codecov
       if: matrix.python-version == 3.7

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,7 +56,7 @@ jobs:
       if: matrix.python-version != 3.7
       run: |
         sudo apt-get install ghostscript  # for pdf comparison
-        pytest
+        pytest --runslow
     - name: Upload coverage to codecov
       if: matrix.python-version == 3.7
       uses: codecov/codecov-action@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,6 +56,7 @@ jobs:
       if: matrix.python-version != 3.7
       run: |
         sudo apt-get install ghostscript  # for pdf comparison
+        pip install --upgrade numpy  # temporary workaround to avoid downgrade due to tensorflow
         pytest --runslow
     - name: Upload coverage to codecov
       if: matrix.python-version == 3.7

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,7 +56,7 @@ jobs:
       if: matrix.python-version != 3.7
       run: |
         sudo apt-get install ghostscript  # for pdf comparison
-        pytest --runslow
+        pytest --runslow  # also test pyhf backends
     - name: Upload coverage to codecov
       if: matrix.python-version == 3.7
       uses: codecov/codecov-action@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,7 +56,6 @@ jobs:
       if: matrix.python-version != 3.7
       run: |
         sudo apt-get install ghostscript  # for pdf comparison
-        python -m pip install pyhf[tensorflow]  # workaround to get tensorflow
         pytest --runslow
     - name: Upload coverage to codecov
       if: matrix.python-version == 3.7

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install .[test]
-        pip install --upgrade numpy  # temporary workaround to avoid downgrade due to tensorflow
     - name: Static code analysis with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -57,7 +56,7 @@ jobs:
       if: matrix.python-version != 3.7
       run: |
         sudo apt-get install ghostscript  # for pdf comparison
-        python -m pip install .[test]  # should downgrade numpy again for tensorflow compatibility
+        python -m pip install pyhf[tensorflow]  # workaround to get tensorflow
         pytest --runslow
     - name: Upload coverage to codecov
       if: matrix.python-version == 3.7

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras_require["test"] = sorted(
             "types-PyYAML",
             "typeguard>=2.12.1",  # click 8.0 compatibility
             "black",
-            "pyhf[jax, torch]",
+            "pyhf[backends]",
         ]
     )
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras_require["test"] = sorted(
             "types-PyYAML",
             "typeguard>=2.12.1",  # click 8.0 compatibility
             "black",
-            "pyhf[backends]",
+            "pyhf[jax, torch]",
         ]
     )
 )

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ extras_require["test"] = sorted(
             "types-PyYAML",
             "typeguard>=2.12.1",  # click 8.0 compatibility
             "black",
+            "pyhf[backends]",
         ]
     )
 )

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -154,7 +154,7 @@ def _fit_model_pyhf(
     Returns:
         FitResults: object storing relevant fit results
     """
-    pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=1))
+    pyhf.set_backend(pyhf.tensorlib, pyhf.optimize.minuit_optimizer(verbose=1))
 
     result, result_obj = pyhf.infer.mle.fit(
         data,
@@ -166,8 +166,8 @@ def _fit_model_pyhf(
     )
     log.info(f"MINUIT status:\n{result_obj.minuit.fmin}")
 
-    bestfit = result[:, 0]
-    uncertainty = result[:, 1]
+    bestfit = pyhf.tensorlib.to_numpy(result[:, 0])
+    uncertainty = pyhf.tensorlib.to_numpy(result[:, 1])
     labels = model_utils.get_parameter_names(model)
     corr_mat = result_obj.hess_inv.correlation()
     best_twice_nll = float(result_obj.fun)  # convert 0-dim np.ndarray to float
@@ -215,7 +215,7 @@ def _fit_model_custom(
     Returns:
         FitResults: object storing relevant fit results
     """
-    pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=1))
+    pyhf.set_backend(pyhf.tensorlib, pyhf.optimize.minuit_optimizer(verbose=1))
 
     # use init_pars provided in function argument if they exist, else use default
     init_pars = init_pars or model.config.suggested_init()
@@ -364,15 +364,19 @@ def _goodness_of_fit(
     if model.config.nauxdata > 0:
         main_data, aux_data = model.fullpdf_tv.split(pyhf.tensorlib.astensor(data))
         # constraint term: log Gaussian(aux_data|parameters) etc.
-        constraint_ll = model.constraint_logpdf(
-            aux_data, pyhf.tensorlib.astensor(model.config.suggested_init())
+        constraint_ll = pyhf.tensorlib.to_numpy(
+            model.constraint_logpdf(
+                aux_data, pyhf.tensorlib.astensor(model.config.suggested_init())
+            )
         )
     else:
         # no auxiliary data, so no constraint terms present
         main_data = pyhf.tensorlib.astensor(data)
         constraint_ll = 0.0
     # Poisson term: log Poisson(data|lambda=data), sum is over log likelihood of bins
-    poisson_ll = sum(pyhf.tensorlib.poisson_dist(main_data).log_prob(main_data))
+    poisson_ll = pyhf.tensorlib.to_numpy(
+        sum(pyhf.tensorlib.poisson_dist(main_data).log_prob(main_data))
+    )
     saturated_nll = -(poisson_ll + constraint_ll)  # saturated likelihood
 
     log.info("calculating goodness-of-fit")
@@ -648,7 +652,7 @@ def limit(
     Returns:
         LimitResults: observed and expected limits, CLs values, and scanned points
     """
-    pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=1))
+    pyhf.set_backend(pyhf.tensorlib, pyhf.optimize.minuit_optimizer(verbose=1))
 
     log.info(f"calculating upper limit for {model.config.poi_name}")
 
@@ -826,7 +830,7 @@ def significance(model: pyhf.pdf.Model, data: List[float]) -> SignificanceResult
         model (pyhf.pdf.Model): model to use in fits
         data (List[float]): data (including auxdata) the model is fit to
     """
-    pyhf.set_backend("numpy", pyhf.optimize.minuit_optimizer(verbose=1))
+    pyhf.set_backend(pyhf.tensorlib, pyhf.optimize.minuit_optimizer(verbose=1))
 
     log.info("calculating discovery significance")
     obs_p_val, exp_p_val = pyhf.infer.hypotest(

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -375,8 +375,10 @@ def _goodness_of_fit(
     if model.config.nauxdata > 0:
         main_data, aux_data = model.fullpdf_tv.split(pyhf.tensorlib.astensor(data))
         # constraint term: log Gaussian(aux_data|parameters) etc.
-        constraint_ll = model.constraint_logpdf(
-            aux_data, pyhf.tensorlib.astensor(model.config.suggested_init())
+        constraint_ll = pyhf.tensorlib.to_numpy(
+            model.constraint_logpdf(
+                aux_data, pyhf.tensorlib.astensor(model.config.suggested_init())
+            )
         )
     else:
         # no auxiliary data, so no constraint terms present

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
 
 import iminuit
 import numpy as np
@@ -229,7 +229,18 @@ def _fit_model_custom(
     # this will cause the associated parameter uncertainties to be 0 post-fit
     step_size = [0.1 if not fix_pars[i_par] else 0.0 for i_par in range(len(init_pars))]
 
-    def twice_nll_func(pars: np.ndarray) -> float:
+    def twice_nll_func(pars: np.ndarray) -> Any:
+        """The objective for minimization: twice the negative log-likelihood.
+
+        The return value is float-like, but not always a float. The actual type depends
+        on the active ``pyhf`` backend.
+
+        Args:
+            pars (np.ndarray): parameter values at which the NLL is evaluated
+
+        Returns:
+            Any: twice the negative log-likelihood
+        """
         twice_nll = -2 * model.logpdf(pars, data)
         return twice_nll[0]
 

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -375,10 +375,8 @@ def _goodness_of_fit(
     if model.config.nauxdata > 0:
         main_data, aux_data = model.fullpdf_tv.split(pyhf.tensorlib.astensor(data))
         # constraint term: log Gaussian(aux_data|parameters) etc.
-        constraint_ll = pyhf.tensorlib.to_numpy(
-            model.constraint_logpdf(
-                aux_data, pyhf.tensorlib.astensor(model.config.suggested_init())
-            )
+        constraint_ll = model.constraint_logpdf(
+            aux_data, pyhf.tensorlib.astensor(model.config.suggested_init())
         )
     else:
         # no auxiliary data, so no constraint terms present

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -75,9 +75,9 @@ def build_Asimov_data(model: pyhf.Model, with_aux: bool = True) -> List[float]:
     Returns:
         List[float]: the Asimov dataset
     """
-    asimov_data = model.expected_data(
-        get_asimov_parameters(model), include_auxdata=with_aux
-    ).tolist()
+    asimov_data = pyhf.tensorlib.tolist(
+        model.expected_data(get_asimov_parameters(model), include_auxdata=with_aux)
+    )
     return asimov_data
 
 
@@ -220,14 +220,18 @@ def calculate_stdev(
         down_pars[i_par] -= uncertainty[i_par]
 
         # total model distribution with this parameter varied up
-        up_combined = model.expected_data(up_pars, include_auxdata=False)
+        up_combined = pyhf.tensorlib.to_numpy(
+            model.expected_data(up_pars, include_auxdata=False)
+        )
         up_yields = np.split(up_combined, region_split_indices)
         # append list of yields summed per channel
         up_yields += [np.asarray([sum(chan_yields)]) for chan_yields in up_yields]
         up_variations.append(up_yields)
 
         # total model distribution with this parameter varied down
-        down_combined = model.expected_data(down_pars, include_auxdata=False)
+        down_combined = pyhf.tensorlib.to_numpy(
+            model.expected_data(down_pars, include_auxdata=False)
+        )
         down_yields = np.split(down_combined, region_split_indices)
         # append list of yields summed per channel
         down_yields += [np.asarray([sum(chan_yields)]) for chan_yields in down_yields]

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -181,8 +181,8 @@ def data_MC(
         corr_mat = np.zeros(shape=(len(param_values), len(param_values)))
         np.fill_diagonal(corr_mat, 1.0)
 
-    yields_combined = model.main_model.expected_data(
-        param_values, return_by_sample=True
+    yields_combined = pyhf.tensorlib.to_numpy(
+        model.main_model.expected_data(param_values, return_by_sample=True)
     )  # all channels concatenated
 
     # slice the yields into list of lists (of lists) where first index is channel,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,3 +248,25 @@ def example_spec_no_aux():
         "version": "1.0.0",
     }
     return spec
+
+
+# code below allows marking tests as slow and adds --runslow to run them
+# implemented following https://docs.pytest.org/en/6.2.x/example/simple.html
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -35,8 +35,8 @@ def test_backend_integration(backend, reset_backend):
     fit_results_2 = cabinetry.fit.fit(
         model, data, minos="mu", goodness_of_fit=True, custom_fit=True
     )
-    assert np.allclose(fit_results_1.bestfit, fit_results_2.bestfit, rtol=0.005)
-    assert np.allclose(fit_results_1.uncertainty, fit_results_2.uncertainty, rtol=0.005)
+    assert np.allclose(fit_results_1.bestfit, fit_results_2.bestfit, rtol=0.01)
+    assert np.allclose(fit_results_1.uncertainty, fit_results_2.uncertainty, rtol=0.01)
     assert np.allclose(fit_results_1.corr_mat, fit_results_2.corr_mat, rtol=0.01)
     assert np.allclose(fit_results_1.best_twice_nll, fit_results_2.best_twice_nll)
     assert np.allclose(fit_results_1.goodness_of_fit, fit_results_2.goodness_of_fit)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,64 @@
+import numpy as np
+import pyhf
+import pytest
+
+import cabinetry
+
+
+@pytest.fixture
+def reset_backend():
+    """This sets the ``pyhf`` backend back to ``numpy`` after a test has run."""
+    # setup before test
+    yield  # test
+    # teardown after test
+    pyhf.set_backend("numpy")
+
+
+@pytest.mark.slow
+@pytest.mark.no_cover
+@pytest.mark.parametrize("backend", ["jax", "pytorch", "tensorflow"])
+def test_backend_integration(backend, reset_backend):
+    """Integration test for the inference pipeline that can be run with all ``pyhf``
+    backends to ensure they work. ``typeguard`` will catch type issues at runtime.
+    """
+    pyhf.set_backend(backend)
+    # construct a simple workspace
+    model = pyhf.simplemodels.hepdata_like(
+        signal_data=[24.0, 22.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0]
+    )
+    ws = pyhf.Workspace.build(model, [74, 74])
+
+    model, data = cabinetry.model_utils.model_and_data(ws)
+
+    # MLE comparison of both implementations
+    fit_results_1 = cabinetry.fit.fit(model, data, minos="mu", goodness_of_fit=True)
+    fit_results_2 = cabinetry.fit.fit(
+        model, data, minos="mu", goodness_of_fit=True, custom_fit=True
+    )
+    assert np.allclose(fit_results_1.bestfit, fit_results_2.bestfit)
+    assert np.allclose(fit_results_1.uncertainty, fit_results_2.uncertainty, rtol=0.001)
+    assert np.allclose(fit_results_1.corr_mat, fit_results_2.corr_mat, rtol=0.001)
+    assert np.allclose(fit_results_1.best_twice_nll, fit_results_2.best_twice_nll)
+    assert np.allclose(fit_results_1.goodness_of_fit, fit_results_2.goodness_of_fit)
+
+    # remaining types of fit results
+    cabinetry.fit.ranking(model, data)
+    cabinetry.fit.scan(model, data, "mu")
+    cabinetry.fit.limit(model, data)
+    cabinetry.fit.significance(model, data)
+
+    # model_utils functions that deal with expected_data
+    cabinetry.model_utils.build_Asimov_data(model)
+    # parameters, uncertainty, correlation for stdev
+    param_values = cabinetry.model_utils.get_asimov_parameters(model)
+    param_uncertainty = cabinetry.model_utils.get_prefit_uncertainties(model)
+    corr_mat = np.zeros(shape=(len(param_values), len(param_values)))
+    np.fill_diagonal(corr_mat, 1.0)
+    cabinetry.model_utils.calculate_stdev(
+        model, param_values, param_uncertainty, corr_mat
+    )
+
+
+def test_backend_reset():
+    # ensure that the pyhf backend is numpy again
+    assert pyhf.tensorlib.name == "numpy"

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -36,8 +36,8 @@ def test_backend_integration(backend, reset_backend):
         model, data, minos="mu", goodness_of_fit=True, custom_fit=True
     )
     assert np.allclose(fit_results_1.bestfit, fit_results_2.bestfit)
-    assert np.allclose(fit_results_1.uncertainty, fit_results_2.uncertainty, rtol=0.001)
-    assert np.allclose(fit_results_1.corr_mat, fit_results_2.corr_mat, rtol=0.001)
+    assert np.allclose(fit_results_1.uncertainty, fit_results_2.uncertainty, rtol=0.005)
+    assert np.allclose(fit_results_1.corr_mat, fit_results_2.corr_mat, rtol=0.005)
     assert np.allclose(fit_results_1.best_twice_nll, fit_results_2.best_twice_nll)
     assert np.allclose(fit_results_1.goodness_of_fit, fit_results_2.goodness_of_fit)
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -23,8 +23,8 @@ def test_backend_integration(backend, reset_backend):
     """
     pyhf.set_backend(backend)
     # construct a simple workspace
-    model = pyhf.simplemodels.hepdata_like(
-        signal_data=[24.0, 22.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0]
+    model = pyhf.simplemodels.uncorrelated_background(
+        signal=[24.0, 22.0], bkg=[50.0, 52.0], bkg_uncertainty=[3.0, 7.0]
     )
     ws = pyhf.Workspace.build(model, [74, 74])
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -35,9 +35,9 @@ def test_backend_integration(backend, reset_backend):
     fit_results_2 = cabinetry.fit.fit(
         model, data, minos="mu", goodness_of_fit=True, custom_fit=True
     )
-    assert np.allclose(fit_results_1.bestfit, fit_results_2.bestfit)
+    assert np.allclose(fit_results_1.bestfit, fit_results_2.bestfit, rtol=0.005)
     assert np.allclose(fit_results_1.uncertainty, fit_results_2.uncertainty, rtol=0.005)
-    assert np.allclose(fit_results_1.corr_mat, fit_results_2.corr_mat, rtol=0.005)
+    assert np.allclose(fit_results_1.corr_mat, fit_results_2.corr_mat, rtol=0.01)
     assert np.allclose(fit_results_1.best_twice_nll, fit_results_2.best_twice_nll)
     assert np.allclose(fit_results_1.goodness_of_fit, fit_results_2.goodness_of_fit)
 


### PR DESCRIPTION
`cabinetry` previously had the `numpy` backend for `pyhf` hardcoded. This PR removes this restriction, allowing users to call `pyhf.set_backend("jax")` etc. outside of `cabinetry` code. Fits via `cabinetry` will then respect the backend set. The return type of several `pyhf` functions is backend-dependent, so conversions to `numpy` are added where required. This allows for consistent types within `cabinetry`.

A new integration test is added for the backends other than `numpy`. Since this test is slow, it will only run via `pytest` if the new `--runslow` flag is used. The test ensures consistency of the two MLE fit implementations, and calls the relevant parts of the `cabinetry.fit` API where the different `pyhf` backends may return different results. It similarly calls the relevant `cabinetry.model_utils` parts. Since the test runs with `typeguard`, cases where a `pyhf.tensorlib.to_numpy` call is missing can be caught. The inference results of this new test are not compared to reference values, since `pyhf` itself ensures consistency across backends in that regard.

Since the testing at the moment is strongly based on typing, another approach could be to replace it with `mypy` completely. `pyhf` would still ensure consistent inference results across backends, and `cabinetry` tests the `numpy` backend in detail. Typing could catch instances of missing `pyhf.tensorlib.to_numpy` calls. This is outlined in https://github.com/scikit-hep/pyhf/issues/1472. Example: a possible future introduction of a `pyhf.pdf.Model.expected_data` call without `pyhf.tensorlib.to_numpy` conversion could be caught with typing if `pyhf` declares the return value of `expected_data` to be `object` or similar.

Possible consideration for a separate PR: flag for setting the backend in the CLI, similar to the `pyhf` implementation:
```
  --backend [numpy|pytorch|tensorflow|jax|np|torch|tf]
                                  The tensor backend used for the calculation.
```

resolves #227