### PR TITLE
fix: NamedTuple compatibility in typeguard, Codecov token for upload

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,6 +51,7 @@ jobs:
       if: matrix.python-version == 3.7
       uses: codecov/codecov-action@v1
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         name: codecov-umbrella
         fail_ci_if_error: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 21.5b0
+    rev: 21.5b2
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
@@ -10,17 +10,17 @@ repos:
         files: src/cabinetry
         additional_dependencies: ["numpy>=1.20", "boost-histogram>=1.0.1"]
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.1
+    rev: 3.9.2
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.14.0
+    rev: v2.19.1
     hooks:
     -   id: pyupgrade
         args: ["--py37-plus"]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
     -   id: check-added-large-files
         args: ["--maxkb=100"]

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extras_require["test"] = sorted(
             "flake8-import-order",
             "flake8-print",
             "mypy",
-            "typeguard!=2.11.*,!=2.12",  # NamedTuple incompatibility in Python 3.7
+            "typeguard!=2.11.*,!=2.12.*",  # NamedTuple incompatibility in Python 3.7
             "black",
         ]
     )


### PR DESCRIPTION
The recently released `typeguard` 2.12.1 does not work with`NamedTuple` in Python 3.6 and 3.7, so this skips all versions 2.12.*. Related: #209, #199.

The Codecov upload was broken with error message
```python
{'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
```
so this adds back the Codecov token previously removed in #215 to fix this. #231 is therefore no longer needed.