### PR TITLE
ci: add Codecov token again

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,6 +51,7 @@ jobs:
       if: matrix.python-version == 3.7
       uses: codecov/codecov-action@v1
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         name: codecov-umbrella
         fail_ci_if_error: true


### PR DESCRIPTION
#215 removed the token for Codecov, since it was not required. The upload is broken for #230 with error message
```python
{'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
```
so this adds back the token to fix this.