### PR TITLE
fix: workaround for coverage bug

### DIFF
--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -135,6 +135,7 @@ def fit(
         cabinetry_visualize.pulls(fit_results, figure_folder=figfolder)
     if corrmat:
         cabinetry_visualize.correlation_matrix(fit_results, figure_folder=figfolder)
+    pass  # fixes coverage, see https://github.com/nedbat/coveragepy/issues/198
 
 
 @click.command()


### PR DESCRIPTION
The `fit` function in the CLI has the structure

https://github.com/alexander-held/cabinetry/blob/d888ec054e080f474a12de6de375857631c55987/src/cabinetry/cli/__init__.py#L134-L137

and both branches are tested:

https://github.com/alexander-held/cabinetry/blob/d888ec054e080f474a12de6de375857631c55987/tests/cli/test_cli.py#L172-L182

In CI, where the coverage is calculated with Python 3.7, everything shows up as covered. When using Python 3.8 it does not. This is presumably due to a CPython optimization, and can seemingly be fixed by the addition of a `pass`:

https://github.com/alexander-held/cabinetry/blob/1a11641e214072c3922d7a1269304c97754496b8/src/cabinetry/cli/__init__.py#L138

This PR adds this `pass` and a link to a coverage issue which discusses what I believe is the same underlying issue.