### PR TITLE
feat: helper function for log formatting

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,17 +1,12 @@
-import logging
 import os
 
 import cabinetry
 
 
-# set up log formatting and suppress verbose output from matplotlib
-logging.basicConfig(
-    level=logging.DEBUG, format="%(levelname)s - %(name)s - %(message)s"
-)
-logging.getLogger("matplotlib").setLevel(logging.WARNING)
-
-
 if __name__ == "__main__":
+    # set up customized log formatting
+    cabinetry.set_logging()
+
     # check whether input data exists
     if not os.path.exists("ntuples/"):
         print("run util/create_ntuples.py to create input data")

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from . import configuration  # NOQA
 from . import fit  # NOQA
 from . import route  # NOQA
@@ -11,3 +13,13 @@ from . import workspace  # NOQA
 
 
 __version__ = "0.2.1"
+
+
+def set_logging() -> None:
+    """Sets up customized and verbose logging output.
+
+    Logging can be alternatively customized with the Python ``logging`` module directly.
+    """
+    logging.basicConfig(format="%(levelname)s - %(name)s - %(message)s")
+    logging.getLogger("cabinetry").setLevel(logging.DEBUG)
+    logging.getLogger("pyhf").setLevel(logging.INFO)

--- a/tests/test_cabinetry.py
+++ b/tests/test_cabinetry.py
@@ -1,0 +1,17 @@
+import logging
+
+import cabinetry
+
+
+def test_set_logging(caplog):
+    log = logging.getLogger("cabinetry")
+
+    # message not recorded by default
+    log.debug("log message")
+    assert len(caplog.records) == 0
+    caplog.clear()
+
+    # set custom logging, now message is recorded
+    cabinetry.set_logging()
+    log.debug("log message")
+    assert "log message" in [rec.message for rec in caplog.records]

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -259,6 +259,8 @@ def test_histogram_is_needed_unknown():
 
 
 def test_get_region_dict(caplog):
+    caplog.set_level(logging.WARNING)
+
     config = {"Regions": [{"Name": "reg_a"}, {"Name": "reg_b"}]}
     assert configuration.get_region_dict(config, "reg_a") == {"Name": "reg_a"}
 

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -112,6 +112,7 @@ def test_Histogram_from_arrays(example_histograms):
 
 
 def test_Histogram_from_path(tmp_path, caplog, example_histograms, histogram_helpers):
+    caplog.set_level(logging.INFO)
     h_ref = histo.Histogram.from_arrays(*example_histograms.normal())
     h_ref.save(tmp_path)
 


### PR DESCRIPTION
Adds a new function `cabinetry.set_logging()` that sets up a basic customized log output. The logging is set to be verbose, with `DEBUG` level outputs for `cabinetry` and `INFO` for `pyhf`. This function also shows a basic example for how to customize logging if users wish to customize it themselves. In that case this function should not be called, as the logging can only be set up once.