### PR TITLE
fix: Asimov generation with shapesys modifiers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.902
+    rev: v0.910
     hooks:
     -   id: mypy
         name: mypy with Python 3.7

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -208,9 +208,9 @@ def calculate_stdev(
     # within the respective uncertainties
     for i_par in range(model.config.npars):
         # central parameter values, but one parameter varied within uncertainties
-        up_pars = parameters.copy()
+        up_pars = parameters.copy().astype(float)  # ensure float for correct addition
         up_pars[i_par] += uncertainty[i_par]
-        down_pars = parameters.copy()
+        down_pars = parameters.copy().astype(float)
         down_pars[i_par] -= uncertainty[i_par]
 
         # total model distribution with this parameter varied up

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -103,11 +103,11 @@ def get_asimov_parameters(model: pyhf.pdf.Model) -> np.ndarray:
             inits = model.config.param_set(parameter).suggested_init
         elif dict(model.config.modifiers)[parameter] in ["histosys", "normsys", "lumi"]:
             # histosys/normsys/lumi: Gaussian constraint, nominal value 0
-            inits = [0] * model.config.param_set(parameter).n_parameters
+            inits = [0.0] * model.config.param_set(parameter).n_parameters
         else:
             # remaining modifiers are staterror/shapesys, with Gaussian/Poisson
             # constraint and nominal value of 1
-            inits = [1] * model.config.param_set(parameter).n_parameters
+            inits = [1.0] * model.config.param_set(parameter).n_parameters
 
         asimov_parameters += inits
 

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -84,8 +84,8 @@ def build_Asimov_data(model: pyhf.Model, with_aux: bool = True) -> List[float]:
 def get_asimov_parameters(model: pyhf.pdf.Model) -> np.ndarray:
     """Returns a list of Asimov parameter values for a model.
 
-    For normalization factors, initial parameter settings (specified in the workspace)
-    are treated as nominal settings.
+    For normfactors and shapefactors, initial parameter settings (specified in the
+    workspace) are treated as nominal settings.
 
     Args:
         model (pyhf.pdf.Model): model for which to extract the parameters
@@ -105,16 +105,25 @@ def get_asimov_parameters(model: pyhf.pdf.Model) -> np.ndarray:
     # the init specified in the workspace)
     asimov_parameters = []
     for parameter in model.config.par_order:
-        # indices in auxdata list that match the current parameter
-        aux_indices = [i for i, par in enumerate(auxdata_pars_all) if par == parameter]
-        if aux_indices:
+        if not model.config.param_set(parameter).constrained:
+            # unconstrained parameter: use suggested inits (for normfactor/shapefactor)
+            inits = model.config.param_set(parameter).suggested_init
+        elif model.config.param_set(parameter).pdf_type == "poisson":
+            # Poisson constraint: nominal parameter value is 0 (shapesys)
+            inits = [1] * model.config.param_set(parameter).n_parameters
+        else:
+            # Gaussian constraint (histosys/normsys/lumi, currently also staterror):
+            # nominal value is 0 for histosys/normsys/lumi and 1 for staterror
+
+            # indices in auxdata list that match the current parameter
+            aux_indices = [
+                i for i, par in enumerate(auxdata_pars_all) if par == parameter
+            ]
             # pick up best-fit value from auxdata
             inits = [
                 aux for i, aux in enumerate(model.config.auxdata) if i in aux_indices
             ]
-        else:
-            # pick up suggested inits (for normfactors)
-            inits = model.config.param_set(parameter).suggested_init
+
         asimov_parameters += inits
 
     return np.asarray(asimov_parameters)


### PR DESCRIPTION
The Asimov dataset generation used auxiliary data to determine suitable Asimov parameter values. This does not work for `shapesys` modifiers, where the auxiliary data is (nominal/uncertainty)^2. This PR fixes the behavior and introduces a simplified way to determine parameter settings without needing to refer to auxiliary data, but by using the modifier type instead.

The parameters need to be floats. If all are integers, the model uncertainty calculation via `model_utils.calculate_stdev` produced a different result due to `dtype` mismatch, example:
```python
>>> import numpy as np
>>> a = np.array([1,2])
>>> a[1] += 0.5
>>> a
array([1, 2])
```
Besides ensuring float returns from `get_asimov_parameters`, the up/down parameter variations in `model_utils.calculate_stdev` are now converted to float to avoid this issue even when parameters are provided from elsewhere.