### PR TITLE
chore: updating version to 0.2.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cabinetry
-version = 0.2.1
+version = 0.2.2
 author = Alexander Held
 description = design and steer profile likelihood fits
 long_description = file: README.md

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -12,7 +12,7 @@ from . import visualize  # NOQA
 from . import workspace  # NOQA
 
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 
 def set_logging() -> None:


### PR DESCRIPTION
Updating to version `0.2.2`. This adds support for all `pyhf` backends and a helper function for log formatting, and fixes Asimov generation with `shapesys` modifiers.