### PR TITLE
feat: notebook rendering for figures

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ filterwarnings =
     ignore:no code associated:UserWarning:typeguard:
 
 [flake8]
-max-complexity = 16
+max-complexity = 15
 max-line-length = 88
 exclude = docs/conf.py
 count = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ filterwarnings =
     ignore:no code associated:UserWarning:typeguard:
 
 [flake8]
-max-complexity = 15
+max-complexity = 16
 max-line-length = 88
 exclude = docs/conf.py
 count = True

--- a/src/cabinetry/contrib/matplotlib_visualize.py
+++ b/src/cabinetry/contrib/matplotlib_visualize.py
@@ -17,6 +17,7 @@ def data_MC(
     figure_path: pathlib.Path,
     log_scale: Optional[bool] = None,
     log_scale_x: bool = False,
+    close_figure: bool = False,
 ) -> None:
     """Draws a data/MC histogram with uncertainty bands and ratio panel.
 
@@ -32,6 +33,9 @@ def data_MC(
             scale)
         log_scale_x (bool, optional): whether to use logarithmic horizontal axis,
             defaults to False
+        close_figure (bool, optional): whether to close each figure immediately after
+            saving it, defaults to False (enable when producing many figures to avoid
+            memory issues, prevents rendering in notebooks)
     """
     mc_histograms_yields = []
     mc_labels = []
@@ -198,13 +202,15 @@ def data_MC(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
-    plt.close(fig)
+    if close_figure:  # pragma: no cover
+        plt.close(fig)
 
 
 def correlation_matrix(
     corr_mat: np.ndarray,
     labels: Union[List[str], np.ndarray],
     figure_path: pathlib.Path,
+    close_figure: bool = True,
 ) -> None:
     """Draws a correlation matrix.
 
@@ -213,6 +219,9 @@ def correlation_matrix(
         labels (Union[List[str], np.ndarray]): names of parameters in the correlation
             matrix
         figure_path (pathlib.Path): path where figure should be saved
+        close_figure (bool, optional): whether to close each figure immediately after
+            saving it, defaults to False (enable when producing many figures to avoid
+            memory issues, prevents rendering in notebooks)
     """
     # rounding for test in CI to match reference
     fig, ax = plt.subplots(
@@ -242,7 +251,8 @@ def correlation_matrix(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
-    plt.close(fig)
+    if close_figure:  # pragma: no cover
+        plt.close(fig)
 
 
 def pulls(
@@ -250,6 +260,7 @@ def pulls(
     uncertainty: np.ndarray,
     labels: Union[List[str], np.ndarray],
     figure_path: pathlib.Path,
+    close_figure: bool = True,
 ) -> None:
     """Draws a pull plot.
 
@@ -258,6 +269,9 @@ def pulls(
         uncertainty (np.ndarray): parameter uncertainties
         labels (Union[List[str], np.ndarray]): parameter names
         figure_path (pathlib.Path): path where figure should be saved
+        close_figure (bool, optional): whether to close each figure immediately after
+            saving it, defaults to False (enable when producing many figures to avoid
+            memory issues, prevents rendering in notebooks)
     """
     num_pars = len(bestfit)
     y_positions = np.arange(num_pars)[::-1]
@@ -281,7 +295,8 @@ def pulls(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
-    plt.close(fig)
+    if close_figure:  # pragma: no cover
+        plt.close(fig)
 
 
 def ranking(
@@ -293,6 +308,7 @@ def ranking(
     impact_postfit_up: np.ndarray,
     impact_postfit_down: np.ndarray,
     figure_path: pathlib.Path,
+    close_figure: bool = True,
 ) -> None:
     """Draws a ranking plot.
 
@@ -307,6 +323,9 @@ def ranking(
         impact_postfit_down (np.ndarray): post-fit impact in "down" direction per
             parameter
         figure_path (pathlib.Path): path where figure should be saved
+        close_figure (bool, optional): whether to close each figure immediately after
+            saving it, defaults to False (enable when producing many figures to avoid
+            memory issues, prevents rendering in notebooks)
     """
     num_pars = len(bestfit)
 
@@ -397,7 +416,8 @@ def ranking(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
-    plt.close(fig)
+    if close_figure:  # pragma: no cover
+        plt.close(fig)
 
 
 def templates(
@@ -409,6 +429,7 @@ def templates(
     bin_edges: np.ndarray,
     variable: str,
     figure_path: pathlib.Path,
+    close_figure: bool = True,
 ) -> None:
     """Draws a nominal template and the associated up/down variations.
 
@@ -423,6 +444,9 @@ def templates(
         bin_edges (np.ndarray): bin edges of histogram
         variable (str): variable name for the horizontal axis
         figure_path (pathlib.Path): path where figure should be saved
+        close_figure (bool, optional): whether to close each figure immediately after
+            saving it, defaults to False (enable when producing many figures to avoid
+            memory issues, prevents rendering in notebooks)
     """
     bin_width = bin_edges[1:] - bin_edges[:-1]
     bin_centers = 0.5 * (bin_edges[:-1] + bin_edges[1:])
@@ -569,7 +593,8 @@ def templates(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
-    plt.close(fig)
+    if close_figure:  # pragma: no cover
+        plt.close(fig)
 
 
 def scan(
@@ -579,6 +604,7 @@ def scan(
     par_vals: np.ndarray,
     par_nlls: np.ndarray,
     figure_path: pathlib.Path,
+    close_figure: bool = True,
 ) -> None:
     """Draws a figure showing the results of a likelihood scan.
 
@@ -589,6 +615,9 @@ def scan(
         par_vals (np.ndarray): values used in scan over parameter
         par_nlls (np.ndarray): -2 log(L) offset at each scan point
         figure_path (pathlib.Path): path where figure should be saved
+        close_figure (bool, optional): whether to close each figure immediately after
+            saving it, defaults to False (enable when producing many figures to avoid
+            memory issues, prevents rendering in notebooks)
     """
     mpl.style.use("seaborn-colorblind")
     fig, ax = plt.subplots()
@@ -654,7 +683,8 @@ def scan(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
-    plt.close(fig)
+    if close_figure:  # pragma: no cover
+        plt.close(fig)
 
 
 def limit(
@@ -662,6 +692,7 @@ def limit(
     expected_CLs: np.ndarray,
     poi_values: np.ndarray,
     figure_path: pathlib.Path,
+    close_figure: bool = True,
 ) -> None:
     """Draws observed and expected CLs values as function of the parameter of interest.
 
@@ -670,6 +701,9 @@ def limit(
         expected_CLs (np.ndarray): expected CLs values, including 1 and 2 sigma bands
         poi_values (np.ndarray): parameter of interest values used in scan
         figure_path (pathlib.Path): path where figure should be saved
+        close_figure (bool, optional): whether to close each figure immediately after
+            saving it, defaults to False (enable when producing many figures to avoid
+            memory issues, prevents rendering in notebooks)
     """
     fig, ax = plt.subplots()
 
@@ -738,4 +772,5 @@ def limit(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
-    plt.close(fig)
+    if close_figure:  # pragma: no cover
+        plt.close(fig)

--- a/src/cabinetry/contrib/matplotlib_visualize.py
+++ b/src/cabinetry/contrib/matplotlib_visualize.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 def _save_figure(
     fig: mpl.figure.Figure, path: pathlib.Path, close_figure: bool = False
 ) -> None:
-    """Saves a figure at a given location and optionally close it.
+    """Saves a figure at a given location and optionally closes it.
 
     Args:
         fig (matplotlib.figure.Figure): figure to save

--- a/src/cabinetry/contrib/matplotlib_visualize.py
+++ b/src/cabinetry/contrib/matplotlib_visualize.py
@@ -10,6 +10,24 @@ import numpy as np
 log = logging.getLogger(__name__)
 
 
+def _save_figure(
+    fig: mpl.figure.Figure, path: pathlib.Path, close_figure: bool = False
+) -> None:
+    """Saves a figure at a given location and optionally close it.
+
+    Args:
+        fig (matplotlib.figure.Figure): figure to save
+        figure_path (pathlib.Path): path where figure should be saved
+        close_figure (bool, optional): whether to close figure after saving, defaults to
+            False
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    log.debug(f"saving figure as {path}")
+    fig.savefig(path)
+    if close_figure:
+        plt.close(fig)
+
+
 def data_MC(
     histogram_dict_list: List[Dict[str, Any]],
     total_model_unc: np.ndarray,
@@ -199,11 +217,7 @@ def data_MC(
 
     fig.tight_layout()
 
-    figure_path.parent.mkdir(parents=True, exist_ok=True)
-    log.debug(f"saving figure as {figure_path}")
-    fig.savefig(figure_path)
-    if close_figure:
-        plt.close(fig)
+    _save_figure(fig, figure_path, close_figure)
 
 
 def correlation_matrix(
@@ -248,11 +262,7 @@ def correlation_matrix(
         if abs(corr) > 0.005:
             ax.text(i, j, f"{corr:.2f}", ha="center", va="center", color=text_color)
 
-    figure_path.parent.mkdir(parents=True, exist_ok=True)
-    log.debug(f"saving figure as {figure_path}")
-    fig.savefig(figure_path)
-    if close_figure:
-        plt.close(fig)
+    _save_figure(fig, figure_path, close_figure)
 
 
 def pulls(
@@ -292,11 +302,7 @@ def pulls(
     ax.tick_params(direction="in", top=True, right=True, which="both")
     fig.tight_layout()
 
-    figure_path.parent.mkdir(parents=True, exist_ok=True)
-    log.debug(f"saving figure as {figure_path}")
-    fig.savefig(figure_path)
-    if close_figure:
-        plt.close(fig)
+    _save_figure(fig, figure_path, close_figure)
 
 
 def ranking(
@@ -413,11 +419,7 @@ def ranking(
     leg_space = 1.0 / (num_pars + 3) + 0.03
     fig.tight_layout(rect=[0, 0, 1.0, 1 - leg_space])  # make space for legend on top
 
-    figure_path.parent.mkdir(parents=True, exist_ok=True)
-    log.debug(f"saving figure as {figure_path}")
-    fig.savefig(figure_path)
-    if close_figure:
-        plt.close(fig)
+    _save_figure(fig, figure_path, close_figure)
 
 
 def templates(
@@ -590,11 +592,7 @@ def templates(
 
     fig.tight_layout()
 
-    figure_path.parent.mkdir(parents=True, exist_ok=True)
-    log.debug(f"saving figure as {figure_path}")
-    fig.savefig(figure_path)
-    if close_figure:
-        plt.close(fig)
+    _save_figure(fig, figure_path, close_figure)
 
 
 def scan(
@@ -680,11 +678,7 @@ def scan(
 
     fig.tight_layout()
 
-    figure_path.parent.mkdir(parents=True, exist_ok=True)
-    log.debug(f"saving figure as {figure_path}")
-    fig.savefig(figure_path)
-    if close_figure:
-        plt.close(fig)
+    _save_figure(fig, figure_path, close_figure)
 
 
 def limit(
@@ -769,8 +763,4 @@ def limit(
 
     fig.tight_layout()
 
-    figure_path.parent.mkdir(parents=True, exist_ok=True)
-    log.debug(f"saving figure as {figure_path}")
-    fig.savefig(figure_path)
-    if close_figure:
-        plt.close(fig)
+    _save_figure(fig, figure_path, close_figure)

--- a/src/cabinetry/contrib/matplotlib_visualize.py
+++ b/src/cabinetry/contrib/matplotlib_visualize.py
@@ -202,7 +202,7 @@ def data_MC(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
-    if close_figure:  # pragma: no cover
+    if close_figure:
         plt.close(fig)
 
 
@@ -210,7 +210,7 @@ def correlation_matrix(
     corr_mat: np.ndarray,
     labels: Union[List[str], np.ndarray],
     figure_path: pathlib.Path,
-    close_figure: bool = True,
+    close_figure: bool = False,
 ) -> None:
     """Draws a correlation matrix.
 
@@ -251,7 +251,7 @@ def correlation_matrix(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
-    if close_figure:  # pragma: no cover
+    if close_figure:
         plt.close(fig)
 
 
@@ -260,7 +260,7 @@ def pulls(
     uncertainty: np.ndarray,
     labels: Union[List[str], np.ndarray],
     figure_path: pathlib.Path,
-    close_figure: bool = True,
+    close_figure: bool = False,
 ) -> None:
     """Draws a pull plot.
 
@@ -295,7 +295,7 @@ def pulls(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
-    if close_figure:  # pragma: no cover
+    if close_figure:
         plt.close(fig)
 
 
@@ -308,7 +308,7 @@ def ranking(
     impact_postfit_up: np.ndarray,
     impact_postfit_down: np.ndarray,
     figure_path: pathlib.Path,
-    close_figure: bool = True,
+    close_figure: bool = False,
 ) -> None:
     """Draws a ranking plot.
 
@@ -416,7 +416,7 @@ def ranking(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
-    if close_figure:  # pragma: no cover
+    if close_figure:
         plt.close(fig)
 
 
@@ -429,7 +429,7 @@ def templates(
     bin_edges: np.ndarray,
     variable: str,
     figure_path: pathlib.Path,
-    close_figure: bool = True,
+    close_figure: bool = False,
 ) -> None:
     """Draws a nominal template and the associated up/down variations.
 
@@ -593,7 +593,7 @@ def templates(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
-    if close_figure:  # pragma: no cover
+    if close_figure:
         plt.close(fig)
 
 
@@ -604,7 +604,7 @@ def scan(
     par_vals: np.ndarray,
     par_nlls: np.ndarray,
     figure_path: pathlib.Path,
-    close_figure: bool = True,
+    close_figure: bool = False,
 ) -> None:
     """Draws a figure showing the results of a likelihood scan.
 
@@ -683,7 +683,7 @@ def scan(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
-    if close_figure:  # pragma: no cover
+    if close_figure:
         plt.close(fig)
 
 
@@ -692,7 +692,7 @@ def limit(
     expected_CLs: np.ndarray,
     poi_values: np.ndarray,
     figure_path: pathlib.Path,
-    close_figure: bool = True,
+    close_figure: bool = False,
 ) -> None:
     """Draws observed and expected CLs values as function of the parameter of interest.
 
@@ -772,5 +772,5 @@ def limit(
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     log.debug(f"saving figure as {figure_path}")
     fig.savefig(figure_path)
-    if close_figure:  # pragma: no cover
+    if close_figure:
         plt.close(fig)

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -56,6 +56,7 @@ def data_MC_from_histograms(
     log_scale: Optional[bool] = None,
     log_scale_x: bool = False,
     method: str = "matplotlib",
+    close_figure: bool = False,
 ) -> None:
     """Draws pre-fit data/MC histograms, using histograms created by cabinetry.
 
@@ -70,6 +71,9 @@ def data_MC_from_histograms(
         log_scale_x (bool, optional): whether to use logarithmic horizontal axis,
             defaults to False
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
+        close_figure (bool, optional): whether to close each figure immediately after
+            saving it, defaults to False (enable when producing many figures to avoid
+            memory issues, prevents rendering in notebooks)
 
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
@@ -112,6 +116,7 @@ def data_MC_from_histograms(
                 figure_path,
                 log_scale=log_scale,
                 log_scale_x=log_scale_x,
+                close_figure=close_figure,
             )
         else:
             raise NotImplementedError(f"unknown backend: {method}")
@@ -127,6 +132,7 @@ def data_MC(
     log_scale_x: bool = False,
     include_table: bool = True,
     method: str = "matplotlib",
+    close_figure: bool = False,
 ) -> None:
     """Draws pre- and post-fit data/MC histograms for a ``pyhf`` model and data.
 
@@ -154,6 +160,9 @@ def data_MC(
         include_table (bool, optional): whether to also output a yield table, defaults
             to True
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
+        close_figure (bool, optional): whether to close each figure immediately after
+            saving it, defaults to False (enable when producing many figures to avoid
+            memory issues, prevents rendering in notebooks)
 
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
@@ -272,6 +281,7 @@ def data_MC(
                 figure_path,
                 log_scale=log_scale,
                 log_scale_x=log_scale_x,
+                close_figure=close_figure,
             )
         else:
             raise NotImplementedError(f"unknown backend: {method}")
@@ -282,6 +292,7 @@ def correlation_matrix(
     figure_folder: Union[str, pathlib.Path] = "figures",
     pruning_threshold: float = 0.0,
     method: str = "matplotlib",
+    close_figure: bool = False,
 ) -> None:
     """Draws a correlation matrix.
 
@@ -293,6 +304,9 @@ def correlation_matrix(
         pruning_threshold (float, optional): minimum correlation for a parameter to
             have with any other parameters to not get pruned, defaults to 0.0
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
+        close_figure (bool, optional): whether to close each figure immediately after
+            saving it, defaults to False (enable when producing many figures to avoid
+            memory issues, prevents rendering in notebooks)
 
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
@@ -322,7 +336,9 @@ def correlation_matrix(
     if method == "matplotlib":
         from .contrib import matplotlib_visualize
 
-        matplotlib_visualize.correlation_matrix(corr_mat, labels, figure_path)
+        matplotlib_visualize.correlation_matrix(
+            corr_mat, labels, figure_path, close_figure=close_figure
+        )
     else:
         raise NotImplementedError(f"unknown backend: {method}")
 
@@ -332,6 +348,7 @@ def pulls(
     figure_folder: Union[str, pathlib.Path] = "figures",
     exclude: Optional[Union[str, List[str], Tuple[str, ...]]] = None,
     method: str = "matplotlib",
+    close_figure: bool = False,
 ) -> None:
     """Draws a pull plot of parameter results and uncertainties.
 
@@ -343,6 +360,9 @@ def pulls(
         exclude (Optional[Union[str, List[str], Tuple[str, ...]]], optional): parameter
             or parameters to exclude from plot, defaults to None (nothing excluded)
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
+        close_figure (bool, optional): whether to close each figure immediately after
+            saving it, defaults to False (enable when producing many figures to avoid
+            memory issues, prevents rendering in notebooks)
 
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
@@ -378,7 +398,13 @@ def pulls(
     if method == "matplotlib":
         from .contrib import matplotlib_visualize
 
-        matplotlib_visualize.pulls(bestfit, uncertainty, labels_np, figure_path)
+        matplotlib_visualize.pulls(
+            bestfit,
+            uncertainty,
+            labels_np,
+            figure_path,
+            close_figure=close_figure,
+        )
     else:
         raise NotImplementedError(f"unknown backend: {method}")
 
@@ -388,6 +414,7 @@ def ranking(
     figure_folder: Union[str, pathlib.Path] = "figures",
     max_pars: Optional[int] = None,
     method: str = "matplotlib",
+    close_figure: bool = False,
 ) -> None:
     """Produces a ranking plot showing the impact of parameters on the POI.
 
@@ -398,6 +425,9 @@ def ranking(
         max_pars (Optional[int], optional): number of parameters to include, defaults to
             None (which means all parameters are included)
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
+        close_figure (bool, optional): whether to close each figure immediately after
+            saving it, defaults to False (enable when producing many figures to avoid
+            memory issues, prevents rendering in notebooks)
 
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
@@ -441,6 +471,7 @@ def ranking(
             postfit_up,
             postfit_down,
             figure_path,
+            close_figure=close_figure,
         )
     else:
         raise NotImplementedError(f"unknown backend: {method}")
@@ -450,6 +481,7 @@ def templates(
     config: Dict[str, Any],
     figure_folder: Union[str, pathlib.Path] = "figures",
     method: str = "matplotlib",
+    close_figure: bool = False,
 ) -> None:
     """Visualizes template histograms (after post-processing) for systematic variations.
 
@@ -461,6 +493,9 @@ def templates(
         figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
             figures in, defaults to "figures"
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
+        close_figure (bool, optional): whether to close each figure immediately after
+            saving it, defaults to False (enable when producing many figures to avoid
+            memory issues, prevents rendering in notebooks)
 
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
@@ -563,6 +598,7 @@ def templates(
                         bins,
                         variable,
                         figure_path,
+                        close_figure=close_figure,
                     )
 
                 else:
@@ -573,6 +609,7 @@ def scan(
     scan_results: fit.ScanResults,
     figure_folder: Union[str, pathlib.Path] = "figures",
     method: str = "matplotlib",
+    close_figure: bool = False,
 ) -> None:
     """Visualizes the results of a likelihood scan.
 
@@ -581,6 +618,9 @@ def scan(
         figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
             figures in, defaults to "figures"
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
+        close_figure (bool, optional): whether to close each figure immediately after
+            saving it, defaults to False (enable when producing many figures to avoid
+            memory issues, prevents rendering in notebooks)
 
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
@@ -601,6 +641,7 @@ def scan(
             scan_results.parameter_values,
             scan_results.delta_nlls,
             figure_path,
+            close_figure=close_figure,
         )
     else:
         raise NotImplementedError(f"unknown backend: {method}")
@@ -610,6 +651,7 @@ def limit(
     limit_results: fit.LimitResults,
     figure_folder: Union[str, pathlib.Path] = "figures",
     method: str = "matplotlib",
+    close_figure: bool = False,
 ) -> None:
     """Visualizes observed and expected CLs values as a function of the POI.
 
@@ -618,6 +660,9 @@ def limit(
         figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
             figures in, defaults to "figures"
         method (str, optional): backend to use for plotting, defaults to "matplotlib"
+        close_figure (bool, optional): whether to close each figure immediately after
+            saving it, defaults to False (enable when producing many figures to avoid
+            memory issues, prevents rendering in notebooks)
 
     Raises:
         NotImplementedError: when trying to plot with a method that is not supported
@@ -632,6 +677,7 @@ def limit(
             limit_results.expected_CLs,
             limit_results.poi_values,
             figure_path,
+            close_figure=close_figure,
         )
     else:
         raise NotImplementedError(f"unknown backend: {method}")

--- a/tests/contrib/test_matplotlib_visualize.py
+++ b/tests/contrib/test_matplotlib_visualize.py
@@ -13,6 +13,18 @@ def test_no_open_figure():
     assert len(plt.get_fignums()) == 0
 
 
+def test__save_figure(tmp_path):
+    fig = plt.figure()
+    fname = tmp_path / "fig.pdf"
+    matplotlib_visualize._save_figure(fig, fname)
+    assert len(plt.get_fignums()) == 1
+
+    fig = plt.figure()  # new figure to test closing
+    matplotlib_visualize._save_figure(fig, fname, close_figure=True)
+    assert len(plt.get_fignums()) == 1  # previous figure still open
+    plt.close("all")
+
+
 def test_data_MC(tmp_path):
     fname = tmp_path / "fig.pdf"
     histo_dict_list = [
@@ -39,7 +51,6 @@ def test_data_MC(tmp_path):
     bin_edges = np.asarray([1, 2, 3])
     matplotlib_visualize.data_MC(histo_dict_list, total_model_unc, bin_edges, fname)
     assert compare_images("tests/contrib/reference/data_MC.pdf", str(fname), 0) is None
-    fname.unlink()  # delete figure
 
     histo_dict_list_log = copy.deepcopy(histo_dict_list)
     histo_dict_list_log[0]["yields"] = np.asarray([2000, 14])
@@ -56,14 +67,12 @@ def test_data_MC(tmp_path):
         compare_images("tests/contrib/reference/data_MC_log.pdf", str(fname_log), 0)
         is None
     )
-    fname_log.unlink()
 
     # linear scale forced
     matplotlib_visualize.data_MC(
         histo_dict_list, total_model_unc, bin_edges, fname, log_scale=False
     )
     assert compare_images("tests/contrib/reference/data_MC.pdf", str(fname), 0) is None
-    fname.unlink()
 
     # three open figures, does not change when calling with close_figure
     assert len(plt.get_fignums()) == 3
@@ -82,7 +91,6 @@ def test_data_MC(tmp_path):
         compare_images("tests/contrib/reference/data_MC_log.pdf", str(fname_log), 0)
         is None
     )
-    fname_log.unlink()
     assert len(plt.get_fignums()) == 3
     plt.close("all")
 

--- a/tests/contrib/test_matplotlib_visualize.py
+++ b/tests/contrib/test_matplotlib_visualize.py
@@ -7,6 +7,12 @@ import numpy as np
 from cabinetry.contrib import matplotlib_visualize
 
 
+def test_no_open_figure():
+    # ensure there are no open figures at the start, if this fails then some other part
+    # of the test suite opened a figure without closing it
+    assert len(plt.get_fignums()) == 0
+
+
 def test_data_MC(tmp_path):
     fname = tmp_path / "fig.pdf"
     histo_dict_list = [

--- a/tests/contrib/test_matplotlib_visualize.py
+++ b/tests/contrib/test_matplotlib_visualize.py
@@ -17,7 +17,8 @@ def test__save_figure(tmp_path):
     fig = plt.figure()
     fname = tmp_path / "fig.pdf"
     matplotlib_visualize._save_figure(fig, fname)
-    assert len(plt.get_fignums()) == 1
+    assert fname.is_file()  # file was saved
+    assert len(plt.get_fignums()) == 1  # figure is open
 
     fig = plt.figure()  # new figure to test closing
     matplotlib_visualize._save_figure(fig, fname, close_figure=True)

--- a/tests/contrib/test_matplotlib_visualize.py
+++ b/tests/contrib/test_matplotlib_visualize.py
@@ -1,5 +1,6 @@
 import copy
 
+import matplotlib.pyplot as plt
 from matplotlib.testing.compare import compare_images
 import numpy as np
 
@@ -58,6 +59,9 @@ def test_data_MC(tmp_path):
     assert compare_images("tests/contrib/reference/data_MC.pdf", str(fname), 0) is None
     fname.unlink()
 
+    # three open figures, does not change when calling with close_figure
+    assert len(plt.get_fignums()) == 3
+
     # log scale forced
     matplotlib_visualize.data_MC(
         histo_dict_list_log,
@@ -66,12 +70,15 @@ def test_data_MC(tmp_path):
         fname,
         log_scale=True,
         log_scale_x=True,
+        close_figure=True,
     )
     assert (
         compare_images("tests/contrib/reference/data_MC_log.pdf", str(fname_log), 0)
         is None
     )
     fname_log.unlink()
+    assert len(plt.get_fignums()) == 3
+    plt.close("all")
 
 
 def test_correlation_matrix(tmp_path):
@@ -85,6 +92,12 @@ def test_correlation_matrix(tmp_path):
         is None
     )
 
+    # single open figure, does not change when calling with close_figure
+    assert len(plt.get_fignums()) == 1
+    matplotlib_visualize.correlation_matrix(corr_mat, labels, fname, close_figure=True)
+    assert len(plt.get_fignums()) == 1
+    plt.close("all")
+
 
 def test_pulls(tmp_path):
     fname = tmp_path / "fig.pdf"
@@ -93,6 +106,12 @@ def test_pulls(tmp_path):
     labels = np.asarray(["a", "b", "c"])
     matplotlib_visualize.pulls(bestfit, uncertainty, labels, fname)
     assert compare_images("tests/contrib/reference/pulls.pdf", str(fname), 0) is None
+
+    # single open figure, does not change when calling with close_figure
+    assert len(plt.get_fignums()) == 1
+    matplotlib_visualize.pulls(bestfit, uncertainty, labels, fname, close_figure=True)
+    assert len(plt.get_fignums()) == 1
+    plt.close("all")
 
 
 def test_ranking(tmp_path):
@@ -116,6 +135,22 @@ def test_ranking(tmp_path):
         fname,
     )
     assert compare_images("tests/contrib/reference/ranking.pdf", str(fname), 0) is None
+
+    # single open figure, does not change when calling with close_figure
+    assert len(plt.get_fignums()) == 1
+    matplotlib_visualize.ranking(
+        bestfit,
+        uncertainty,
+        labels,
+        impact_prefit_up,
+        impact_prefit_down,
+        impact_postfit_up,
+        impact_postfit_down,
+        fname,
+        close_figure=True,
+    )
+    assert len(plt.get_fignums()) == 1
+    plt.close("all")
 
 
 def test_templates(tmp_path):
@@ -157,6 +192,9 @@ def test_templates(tmp_path):
         compare_images("tests/contrib/reference/templates.pdf", str(fname), 0) is None
     )
 
+    # single open figure, does not change when calling with close_figure
+    assert len(plt.get_fignums()) == 1
+
     # only single variation specified
     matplotlib_visualize.templates(
         nominal_histo,
@@ -167,7 +205,10 @@ def test_templates(tmp_path):
         bin_edges,
         variable,
         fname,
+        close_figure=True,
     )
+    assert len(plt.get_fignums()) == 1
+    plt.close("all")
 
 
 def test_scan(tmp_path):
@@ -181,9 +222,16 @@ def test_scan(tmp_path):
     matplotlib_visualize.scan(par_name, par_mle, par_unc, par_vals, par_nlls, fname)
     assert compare_images("tests/contrib/reference/scan.pdf", str(fname), 0) is None
 
+    # single open figure, does not change when calling with close_figure
+    assert len(plt.get_fignums()) == 1
+
     # no 68% CL / 95% CL text
     par_nlls = np.asarray([0.1, 0.04, 0.0, 0.04, 0.1])
-    matplotlib_visualize.scan(par_name, par_mle, par_unc, par_vals, par_nlls, fname)
+    matplotlib_visualize.scan(
+        par_name, par_mle, par_unc, par_vals, par_nlls, fname, close_figure=True
+    )
+    assert len(plt.get_fignums()) == 1
+    plt.close("all")
 
 
 def test_limit(tmp_path):
@@ -201,3 +249,11 @@ def test_limit(tmp_path):
 
     matplotlib_visualize.limit(observed_CLs, expected_CLs, poi_values, fname)
     assert compare_images("tests/contrib/reference/limit.pdf", str(fname), 0) is None
+
+    # single open figure, does not change when calling with close_figure
+    assert len(plt.get_fignums()) == 1
+    matplotlib_visualize.limit(
+        observed_CLs, expected_CLs, poi_values, fname, close_figure=True
+    )
+    assert len(plt.get_fignums()) == 1
+    plt.close("all")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -154,14 +154,14 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     caplog.clear()
 
     # pre- and post-fit yield uncertainties
-    cabinetry.visualize.data_MC(model, data)
+    cabinetry.visualize.data_MC(model, data, close_figure=True)
     assert "total stdev is [[69, 58.3, 38.2, 45.3]]" in [
         rec.message for rec in caplog.records
     ]
     assert "total stdev per channel is [137]" in [rec.message for rec in caplog.records]
     caplog.clear()
 
-    cabinetry.visualize.data_MC(model, data, fit_results=fit_results)
+    cabinetry.visualize.data_MC(model, data, fit_results=fit_results, close_figure=True)
     assert "total stdev is [[11.9, 7.28, 7.41, 7.69]]" in [
         rec.message for rec in caplog.records
     ]

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -560,6 +560,7 @@ def test_templates(mock_draw, mock_histo_config, mock_histo_path, tmp_path):
     up_path.unlink()
     down_path.unlink()
 
+    assert mock_draw.call_count == 2  # two calls so far
     visualize.templates(config, figure_folder=folder_path)
     assert mock_draw.call_count == 2  # no new call, since no variations found
 

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -103,19 +103,24 @@ def test_data_MC_from_histograms(mock_load, mock_draw, mock_stdev):
                 [0.0, 1.0],
                 figure_folder / "reg_1_prefit.pdf",
             ),
-            {"log_scale": None, "log_scale_x": False},
+            {"log_scale": None, "log_scale_x": False, "close_figure": False},
         )
     ]
 
-    # custom log scale settings
+    # custom log scale settings, close figure
     visualize.data_MC_from_histograms(
         config,
         figure_folder=figure_folder,
         method="matplotlib",
         log_scale=True,
         log_scale_x=True,
+        close_figure=True,
     )
-    assert mock_draw.call_args[1] == {"log_scale": True, "log_scale_x": True}
+    assert mock_draw.call_args[1] == {
+        "log_scale": True,
+        "log_scale_x": True,
+        "close_figure": True,
+    }
 
     # other plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
@@ -215,9 +220,13 @@ def test_data_MC(
     assert mock_draw.call_args_list[0][0][3] == pathlib.Path(
         "tmp/Signal-Region_prefit.pdf"
     )
-    assert mock_draw.call_args_list[0][1] == {"log_scale": None, "log_scale_x": False}
+    assert mock_draw.call_args_list[0][1] == {
+        "log_scale": None,
+        "log_scale_x": False,
+        "close_figure": False,
+    }
 
-    # post-fit plot and custom scale
+    # post-fit plot, custom scale, close figure
     fit_results = fit.FitResults(
         np.asarray([1.01, 1.1]),
         np.asarray([0.03, 0.1]),
@@ -232,6 +241,7 @@ def test_data_MC(
         figure_folder=figure_folder,
         fit_results=fit_results,
         log_scale=False,
+        close_figure=True,
     )
 
     assert mock_asimov.call_count == 1  # no new call
@@ -254,7 +264,11 @@ def test_data_MC(
     assert mock_draw.call_args_list[1][0][3] == pathlib.Path(
         "tmp/Signal-Region_postfit.pdf"
     )
-    assert mock_draw.call_args_list[1][1] == {"log_scale": False, "log_scale_x": False}
+    assert mock_draw.call_args_list[1][1] == {
+        "log_scale": False,
+        "log_scale_x": False,
+        "close_figure": True,
+    }
 
     # no yield table
     visualize.data_MC(model, data, config=config, include_table=False)
@@ -296,14 +310,17 @@ def test_correlation_matrix(mock_draw):
         [mock_draw.call_args[0][1][i] == labels[i] for i in range(len(labels_pruned))]
     )
     assert mock_draw.call_args[0][2] == figure_path
-    assert mock_draw.call_args[1] == {}
+    assert mock_draw.call_args[1] == {"close_figure": False}
 
-    # pruning of fixed parameter (all zeros in correlation matrix row/column)
+    # pruning of fixed parameter (all zeros in correlation matrix row/column), close
+    # figure
     corr_mat_fixed = np.asarray([[1.0, 0.2, 0.0], [0.2, 1.0, 0.0], [0.0, 0.0, 0.0]])
     fit_results_fixed = fit.FitResults(
         np.empty(0), np.empty(0), labels, corr_mat_fixed, 1.0
     )
-    visualize.correlation_matrix(fit_results_fixed, figure_folder=folder_path)
+    visualize.correlation_matrix(
+        fit_results_fixed, figure_folder=folder_path, close_figure=True
+    )
     assert np.allclose(mock_draw.call_args_list[1][0][0], corr_mat_pruned)
     assert np.any(
         [
@@ -311,6 +328,7 @@ def test_correlation_matrix(mock_draw):
             for i in range(len(labels_pruned))
         ]
     )
+    assert mock_draw.call_args[1] == {"close_figure": True}
 
     # unknown plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
@@ -351,7 +369,7 @@ def test_pulls(mock_draw):
         ]
     )
     assert mock_draw.call_args[0][3] == figure_path
-    assert mock_draw.call_args[1] == {}
+    assert mock_draw.call_args[1] == {"close_figure": False}
 
     # filtering single parameter instead of list
     visualize.pulls(
@@ -369,14 +387,16 @@ def test_pulls(mock_draw):
         ]
     )
 
-    # without filtering via list, but with staterror removal
-    # and fixed parameter removal
+    # without filtering via list, but with staterror removal, fixed parameter removal
+    # and closing figure
     fit_results.uncertainty[0] = 0.0
 
     bestfit_expected = np.asarray([1.0, 1.1])
     uncertainty_expected = np.asarray([1.0, 0.7])
     labels_expected = ["b", "c"]
-    visualize.pulls(fit_results, figure_folder=folder_path, method="matplotlib")
+    visualize.pulls(
+        fit_results, figure_folder=folder_path, method="matplotlib", close_figure=True
+    )
 
     assert np.allclose(mock_draw.call_args[0][0], bestfit_expected)
     assert np.allclose(mock_draw.call_args[0][1], uncertainty_expected)
@@ -387,7 +407,7 @@ def test_pulls(mock_draw):
         ]
     )
     assert mock_draw.call_args[0][3] == figure_path
-    assert mock_draw.call_args[1] == {}
+    assert mock_draw.call_args[1] == {"close_figure": True}
 
     # unknown plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
@@ -435,10 +455,12 @@ def test_ranking(mock_draw):
     assert np.allclose(mock_draw.call_args[0][5], impact_postfit_up[::-1])
     assert np.allclose(mock_draw.call_args[0][6], impact_postfit_down[::-1])
     assert mock_draw.call_args[0][7] == figure_path
-    assert mock_draw.call_args[1] == {}
+    assert mock_draw.call_args[1] == {"close_figure": False}
 
-    # maximum parameter amount specified
-    visualize.ranking(ranking_results, figure_folder=folder_path, max_pars=1)
+    # maximum parameter amount specified, close figure
+    visualize.ranking(
+        ranking_results, figure_folder=folder_path, max_pars=1, close_figure=True
+    )
     assert mock_draw.call_count == 2
     assert np.allclose(mock_draw.call_args[0][0], bestfit_expected[0])
     assert np.allclose(mock_draw.call_args[0][1], uncertainty_expected[0])
@@ -448,7 +470,7 @@ def test_ranking(mock_draw):
     assert np.allclose(mock_draw.call_args[0][5], impact_postfit_up[1])
     assert np.allclose(mock_draw.call_args[0][6], impact_postfit_down[1])
     assert mock_draw.call_args[0][7] == figure_path
-    assert mock_draw.call_args[1] == {}
+    assert mock_draw.call_args[1] == {"close_figure": True}
 
     # unknown plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
@@ -517,7 +539,17 @@ def test_templates(mock_draw, mock_histo_config, mock_histo_path, tmp_path):
     down_mod = {"yields": [3.0], "stdev": [0.3]}
     bins = [0.0, 1.0]
     assert mock_draw.call_args_list == [
-        [(nominal, up_orig, up_mod, down_orig, down_mod, bins, "x", figure_path), {}]
+        [
+            (nominal, up_orig, up_mod, down_orig, down_mod, bins, "x", figure_path),
+            {"close_figure": False},
+        ]
+    ]
+
+    # close figure
+    visualize.templates(config, figure_folder=folder_path, close_figure=True)
+    assert mock_draw.call_args == [
+        (nominal, up_orig, up_mod, down_orig, down_mod, bins, "x", figure_path),
+        {"close_figure": True},
     ]
 
     # unknown plotting method
@@ -529,7 +561,7 @@ def test_templates(mock_draw, mock_histo_config, mock_histo_path, tmp_path):
     down_path.unlink()
 
     visualize.templates(config, figure_folder=folder_path)
-    assert mock_draw.call_count == 1  # no new call, since no variations found
+    assert mock_draw.call_count == 2  # no new call, since no variations found
 
 
 @mock.patch("cabinetry.contrib.matplotlib_visualize.scan")
@@ -553,7 +585,11 @@ def test_scan(mock_draw):
     assert np.allclose(mock_draw.call_args[0][3], par_vals)
     assert np.allclose(mock_draw.call_args[0][4], par_nlls)
     assert mock_draw.call_args[0][5] == figure_path
-    assert mock_draw.call_args[1] == {}
+    assert mock_draw.call_args[1] == {"close_figure": False}
+
+    # close figure
+    visualize.scan(scan_results, figure_folder=folder_path, close_figure=True)
+    assert mock_draw.call_args[1] == {"close_figure": True}
 
     # unknown plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):
@@ -579,7 +615,11 @@ def test_limit(mock_draw):
     assert np.allclose(mock_draw.call_args[0][1], limit_results.expected_CLs)
     assert np.allclose(mock_draw.call_args[0][2], limit_results.poi_values)
     assert mock_draw.call_args[0][3] == figure_path
-    assert mock_draw.call_args[1] == {}
+    assert mock_draw.call_args[1] == {"close_figure": False}
+
+    # close figure
+    visualize.limit(limit_results, figure_folder=folder_path, close_figure=True)
+    assert mock_draw.call_args[1] == {"close_figure": True}
 
     # unknown plotting method
     with pytest.raises(NotImplementedError, match="unknown backend: unknown"):


### PR DESCRIPTION
#115 ensured that figures are closed immediately after saving them, which avoids memory issues when keeping many open figures around. This also prevents figures from being rendered in notebooks, which look for figures known to `matplotlib.pyplot` at the end of a cell. With all figures already closed, no figures are drawn.

This changes the default behavior again to not close figures. A new optional argument `close_figure` can be used in the `cabinetry.visualize` API to change back to the old behavior (via `close_figure=True`). This means that by default now figures will be drawn in notebooks again. Users may also use `matplotlib.pyplot.close("all")` anywhere to close all currently open figures.

The figure saving/closing is factored out into a separate function to avoid duplication in `contrib.matplotlib_visualize`.

```
* figures are no longer closed by default and show up in notebooks
* added close_figure argument in visualize API to control closing behavior
* factored out figure saving/closing into separate function
```