### PR TITLE
fix: Asimov generation with lumi modifiers

### DIFF
--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -85,7 +85,8 @@ def get_asimov_parameters(model: pyhf.pdf.Model) -> np.ndarray:
     """Returns a list of Asimov parameter values for a model.
 
     For normfactors and shapefactors, initial parameter settings (specified in the
-    workspace) are treated as nominal settings.
+    workspace) are treated as nominal settings. This ignores custom auxiliary data set
+    in the measurement configuration in the workspace.
 
     Args:
         model (pyhf.pdf.Model): model for which to extract the parameters
@@ -101,12 +102,12 @@ def get_asimov_parameters(model: pyhf.pdf.Model) -> np.ndarray:
         if not model.config.param_set(parameter).constrained:
             # unconstrained parameter: use suggested inits (for normfactor/shapefactor)
             inits = model.config.param_set(parameter).suggested_init
-        elif dict(model.config.modifiers)[parameter] in ["histosys", "normsys", "lumi"]:
-            # histosys/normsys/lumi: Gaussian constraint, nominal value 0
+        elif dict(model.config.modifiers)[parameter] in ["histosys", "normsys"]:
+            # histosys/normsys: Gaussian constraint, nominal value 0
             inits = [0.0] * model.config.param_set(parameter).n_parameters
         else:
-            # remaining modifiers are staterror/shapesys, with Gaussian/Poisson
-            # constraint and nominal value of 1
+            # remaining modifiers are staterror/lumi with Gaussian constraint, and
+            # shapesys with Poisson constraint, all have nominal value of 1
             inits = [1.0] * model.config.param_set(parameter).n_parameters
 
         asimov_parameters += inits

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -285,7 +285,7 @@ def example_spec_lumi():
                     ],
                     "poi": "Signal strength",
                 },
-                "name": "no auxdata",
+                "name": "lumi modifier",
             }
         ],
         "observations": [{"data": [35], "name": "Signal Region"}],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,6 +250,50 @@ def example_spec_no_aux():
     return spec
 
 
+@pytest.fixture
+def example_spec_lumi():
+    spec = {
+        "channels": [
+            {
+                "name": "Signal Region",
+                "samples": [
+                    {
+                        "data": [35],
+                        "modifiers": [
+                            {
+                                "data": None,
+                                "name": "Signal strength",
+                                "type": "normfactor",
+                            },
+                            {"data": None, "name": "lumi", "type": "lumi"},
+                        ],
+                        "name": "Signal",
+                    }
+                ],
+            }
+        ],
+        "measurements": [
+            {
+                "config": {
+                    "parameters": [
+                        {
+                            "auxdata": [1.0],
+                            "inits": [1.05],
+                            "name": "lumi",
+                            "sigmas": [0.02],
+                        },
+                    ],
+                    "poi": "Signal strength",
+                },
+                "name": "no auxdata",
+            }
+        ],
+        "observations": [{"data": [35], "name": "Signal Region"}],
+        "version": "1.0.0",
+    }
+    return spec
+
+
 # code below allows marking tests as slow and adds --runslow to run them
 # implemented following https://docs.pytest.org/en/6.2.x/example/simple.html
 def pytest_addoption(parser):

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -48,7 +48,9 @@ def test_build_Asimov_data(example_spec):
     assert model_utils.build_Asimov_data(model, with_aux=False) == [103.6]
 
 
-def test_get_asimov_parameters(example_spec, example_spec_shapefactor):
+def test_get_asimov_parameters(
+    example_spec, example_spec_shapefactor, example_spec_lumi
+):
     model = pyhf.Workspace(example_spec).model()
     pars = model_utils.get_asimov_parameters(model)
     assert np.allclose(pars, [1.0, 1.0])
@@ -93,6 +95,11 @@ def test_get_asimov_parameters(example_spec, example_spec_shapefactor):
     model = pyhf.Workspace(shapesys_spec).model()
     pars = model_utils.get_asimov_parameters(model)
     assert np.allclose(pars, [1.0, 1.0, 1.0])
+
+    # lumi modifier with nominal value 1 and different initial value (ignored)
+    model = pyhf.Workspace(example_spec_lumi).model()
+    pars = model_utils.get_asimov_parameters(model)
+    assert np.allclose(pars, [1.0, 1.0])
 
 
 def test_get_prefit_uncertainties(


### PR DESCRIPTION
#238 fixed the Asimov dataset generation (more precisely, the generation of the parameters used to produce the Asimov dataset) for `shapesys` modifiers and refactored the parameter determination mechanism. This refactor introduced a bug in the `lumi` modifier treatment: the corresponding parameter was initialized at 0. Instead, it should be initialized at the corresponding auxiliary data value.

In most scenarios the auxiliary data is likely `1.0`, but in principle it can be different. In that case, the parameter setting should match the auxiliary data, with an approach as the one used prior to #238 of matching auxiliary data and parameters. This more general treatment will be implemented in a separate PR -> tracked in #242.

Reverting back to the approach of reading out auxiliary data also has the advantage that Asimov datasets could be generated from workspaces that specify custom auxiliary data values. At the moment, those custom settings are ignored.

Related: https://github.com/scikit-hep/pyhf/issues/1516 regarding the `lumi` modifier treatment in `pyhf`

```
* fixed lumi modifier setting for Asimov dataset generation
* added test with lumi modifier type
```