### PR TITLE
chore: updating version to 0.2.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cabinetry
-version = 0.2.2
+version = 0.2.3
 author = Alexander Held
 description = design and steer profile likelihood fits
 long_description = file: README.md

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -12,7 +12,7 @@ from . import visualize  # NOQA
 from . import workspace  # NOQA
 
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 
 def set_logging() -> None:


### PR DESCRIPTION
Updating to version `0.2.3`. This update includes a few small changes in preparation of the [PyHEP 2021 talk on cabinetry](https://indico.cern.ch/event/1019958/contributions/4421868/). Figure rendering in notebooks is enabled again, Asimov dataset generation for `lumi` modifiers is fixed and the readme is updated.

```
* updating version to 0.2.3
```