### PR TITLE
build: PEP 517/518 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.19.4
+    rev: v2.21.0
     hooks:
     -   id: pyupgrade
         args: ["--py37-plus"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 target-version = ['py37', 'py38']
 include = '\.pyi?$'

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ description = design and steer profile likelihood fits
 long_description = file: README.md
 long_description_content_type = text/markdown
 license = BSD 3-Clause
+license_files = LICENSE
 url = https://github.com/alexander-held/cabinetry
 classifiers =
     Development Status :: 3 - Alpha


### PR DESCRIPTION
Adds support for PEP 517/518 via settings in `pyproject.toml`. For more information, see links in #74 and
- [Scikit-HEP developer information](https://scikit-hep.org/developer/packaging#pep-517518-support-high-priority),
- [`pip` documentation](https://pip.pypa.io/en/stable/cli/pip/#pep-517-and-518-support).

The `setuptools>=42` requirement is adopted from the Scikit-HEP documentation, and likely aimed at `setuptools_scm` support. `40.8.0` may in principle be sufficient for `cabinetry` at the moment, but this implementation follows the Scikit-HEP recommendation anyway.

SDist / wheel building can be done with `pipx run build`.

Also adding `license_files` to metadata explicitly, which has defaulted to pick up the license correctly so far regardless (see [`setuptools` documentation](https://setuptools.readthedocs.io/en/latest/references/keywords.html) under `license_file`).

resolves #74 

```
* added support for PEP 517/518 build
* updated pre-commit
```