### PR TITLE
fix: compatibility with pyhf 0.6.3 (parameter label API, auxdata)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -53,7 +53,12 @@ jobs:
         sudo apt-get install ghostscript  # for pdf comparison
         pytest --cov-report=xml --typeguard-packages=""  # typeguard issue with typing.NamedTuple in Python 3.7
     - name: Test with pytest and typeguard
-      if: matrix.python-version != 3.7
+      if: matrix.python-version == 3.8
+      run: |
+        sudo apt-get install ghostscript  # for pdf comparison
+        pytest
+    - name: Test with pytest and typeguard, test pyhf backends
+      if: matrix.python-version == 3.9
       run: |
         sudo apt-get install ghostscript  # for pdf comparison
         pytest --runslow  # also test pyhf backends

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -53,12 +53,7 @@ jobs:
         sudo apt-get install ghostscript  # for pdf comparison
         pytest --cov-report=xml --typeguard-packages=""  # typeguard issue with typing.NamedTuple in Python 3.7
     - name: Test with pytest and typeguard
-      if: matrix.python-version == 3.8
-      run: |
-        sudo apt-get install ghostscript  # for pdf comparison
-        pytest
-    - name: Test with pytest and typeguard, test pyhf backends
-      if: matrix.python-version == 3.9
+      if: matrix.python-version != 3.7
       run: |
         sudo apt-get install ghostscript  # for pdf comparison
         pytest --runslow  # also test pyhf backends

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,6 +56,7 @@ jobs:
       if: matrix.python-version != 3.7
       run: |
         sudo apt-get install ghostscript  # for pdf comparison
+        python -m pip install .[pyhf_backends]  # install pyhf backends
         pytest --runslow  # also test pyhf backends
     - name: Upload coverage to codecov
       if: matrix.python-version == 3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ packages = find:
 package_dir = =src
 python_requires = >=3.7
 install_requires =
-    pyhf[minuit]~=0.6.0  # API updates and iminuit v2 compatibility
+    pyhf[minuit]~=0.6.3  # addition of model.config.par_names()
     boost_histogram>=1.0.0  # subclassing with family, 1.02 for stdev scaling fix (currently not needed)
     awkward>=1.0  # new API
     tabulate>=0.8.1  # multiline text

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ extras_require["test"] = sorted(
             "types-tabulate",
             "types-PyYAML",
             "typeguard>=2.12.1",  # click 8.0 compatibility
-            "pyhf[backends]",
             "black",
+            "pyhf[backends]",
         ]
     )
 )

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,10 @@ extras_require["test"] = sorted(
             "types-PyYAML",
             "typeguard>=2.12.1",  # click 8.0 compatibility
             "black",
-            "pyhf[torch,jax]",
         ]
     )
 )
+extras_require = {"pyhf_backends": ["pyhf[backends]"]}  # JAX, PyTorch, Tensorflow
 extras_require["docs"] = sorted(
     {
         "sphinx",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras_require["test"] = sorted(
             "types-PyYAML",
             "typeguard>=2.12.1",  # click 8.0 compatibility
             "black",
-            "pyhf[backends]",
+            "pyhf[torch,jax]",
         ]
     )
 )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ extras_require["test"] = sorted(
         ]
     )
 )
-extras_require = {"pyhf_backends": ["pyhf[backends]"]}  # JAX, PyTorch, Tensorflow
+extras_require["pyhf_backends"] = ["pyhf[backends]"]
 extras_require["docs"] = sorted(
     {
         "sphinx",

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ extras_require["test"] = sorted(
             "types-tabulate",
             "types-PyYAML",
             "typeguard>=2.12.1",  # click 8.0 compatibility
-            "black",
             "pyhf[backends]",
+            "black",
         ]
     )
 )

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -78,7 +78,7 @@ def _fit_model_pyhf(
 
     bestfit = pyhf.tensorlib.to_numpy(result[:, 0])
     uncertainty = pyhf.tensorlib.to_numpy(result[:, 1])
-    labels = model_utils.parameter_names(model)
+    labels = model.config.par_names()
     corr_mat = pyhf.tensorlib.to_numpy(corr_mat)
     best_twice_nll = float(best_twice_nll)  # convert 0-dim np.ndarray to float
 
@@ -125,7 +125,7 @@ def _fit_model_custom(
     # use fix_pars provided in function argument if they exist, else use default
     fix_pars = fix_pars or model.config.suggested_fixed()
 
-    labels = model_utils.parameter_names(model)
+    labels = model.config.par_names()
 
     # set initial step size to 0 for fixed parameters
     # this will cause the associated parameter uncertainties to be 0 post-fit
@@ -381,7 +381,7 @@ def ranking(
     if fit_results is None:
         fit_results = _fit_model(model, data, custom_fit=custom_fit)
 
-    labels = model_utils.parameter_names(model)
+    labels = model.config.par_names()
     prefit_unc = model_utils.prefit_uncertainties(model)
     nominal_poi = fit_results.bestfit[model.config.poi_index]
 
@@ -482,7 +482,7 @@ def scan(
         ScanResults: includes parameter name, scanned values and 2*log(likelihood)
         offset
     """
-    labels = model_utils.parameter_names(model)
+    labels = model.config.par_names()
     init_pars = model.config.suggested_init()
     fix_pars = model.config.suggested_fixed()
 

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -37,14 +37,15 @@ class ModelPrediction(NamedTuple):
 
 
 def model_and_data(
-    spec: Dict[str, Any], asimov: bool = False, with_aux: bool = True
+    spec: Dict[str, Any], asimov: bool = False, include_auxdata: bool = True
 ) -> Tuple[pyhf.pdf.Model, List[float]]:
     """Returns model and data for a ``pyhf`` workspace specification.
 
     Args:
         spec (Dict[str, Any]): a ``pyhf`` workspace specification
         asimov (bool, optional): whether to return the Asimov dataset, defaults to False
-        with_aux (bool, optional): whether to also return auxdata, defaults to True
+        include_auxdata (bool, optional): whether to also return auxdata, defaults to
+            True
 
     Returns:
         Tuple[pyhf.pdf.Model, List[float]]:
@@ -59,13 +60,13 @@ def model_and_data(
         }
     )  # use HistFactory InterpCode=4 (default in pyhf since v0.6.0)
     if not asimov:
-        data = workspace.data(model, with_aux=with_aux)
+        data = workspace.data(model, include_auxdata=include_auxdata)
     else:
-        data = asimov_data(model, with_aux=with_aux)
+        data = asimov_data(model, include_auxdata=include_auxdata)
     return model, data
 
 
-def asimov_data(model: pyhf.Model, with_aux: bool = True) -> List[float]:
+def asimov_data(model: pyhf.Model, include_auxdata: bool = True) -> List[float]:
     """Returns the Asimov dataset (optionally with auxdata) for a model.
 
     Initial parameter settings for normalization factors in the workspace are treated as
@@ -75,13 +76,14 @@ def asimov_data(model: pyhf.Model, with_aux: bool = True) -> List[float]:
 
     Args:
         model (pyhf.Model): the model from which to construct the dataset
-        with_aux (bool, optional): whether to also return auxdata, defaults to True
+        include_auxdata (bool, optional): whether to also return auxdata, defaults to
+            True
 
     Returns:
         List[float]: the Asimov dataset
     """
     asimov_data = pyhf.tensorlib.tolist(
-        model.expected_data(asimov_parameters(model), include_auxdata=with_aux)
+        model.expected_data(asimov_parameters(model), include_auxdata=include_auxdata)
     )
     return asimov_data
 

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -65,20 +65,6 @@ def model_and_data(
     return model, data
 
 
-def parameter_names(model: pyhf.pdf.Model) -> List[str]:
-    """Returns the labels of all fit parameters.
-
-    Vectors that act on one bin per vector entry (gammas) are expanded.
-
-    Args:
-        model (pyhf.pdf.Model): a HistFactory-style model in ``pyhf`` format
-
-    Returns:
-        List[str]: names of fit parameters
-    """
-    return model.config.par_names()
-
-
 def asimov_data(model: pyhf.Model, with_aux: bool = True) -> List[float]:
     """Returns the Asimov dataset (optionally with auxdata) for a model.
 
@@ -279,7 +265,7 @@ def yield_stdev(
         symmetric_uncertainty = (up_variations[i_par] - down_variations[i_par]) / 2
         total_variance = total_variance + symmetric_uncertainty ** 2
 
-    labels = parameter_names(model)
+    labels = model.config.par_names()
     # continue with off-diagonal contributions if there are any
     if np.count_nonzero(corr_mat - np.diag(np.ones_like(parameters))) > 0:
         # loop over pairs of parameters
@@ -411,9 +397,9 @@ def unconstrained_parameter_count(model: pyhf.pdf.Model) -> int:
 def _parameter_index(par_name: str, labels: Union[List[str], Tuple[str, ...]]) -> int:
     """Returns the position of a parameter with a given name in the list of parameters.
 
-    Useful together with ``parameter_names`` to find the position of a parameter
-    when the name is known. If the parameter is not found, logs an error and returns a
-    default value of -1.
+    Useful together with ``pyhf.pdf._ModelConfig.par_names`` to find the position of a
+    parameter when the name is known. If the parameter is not found, logs an error and
+    returns a default value of -1.
 
     Args:
         par_name (str): name of parameter to find in list

--- a/src/cabinetry/model_utils.py
+++ b/src/cabinetry/model_utils.py
@@ -76,15 +76,7 @@ def parameter_names(model: pyhf.pdf.Model) -> List[str]:
     Returns:
         List[str]: names of fit parameters
     """
-    labels = []
-    for parname in model.config.par_order:
-        for i_par in range(model.config.param_set(parname).n_parameters):
-            labels.append(
-                f"{parname}[bin_{i_par}]"
-                if model.config.param_set(parname).n_parameters > 1
-                else parname
-            )
-    return labels
+    return model.config.par_names()
 
 
 def asimov_data(model: pyhf.Model, with_aux: bool = True) -> List[float]:

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -68,7 +68,7 @@ def test__fit_model_pyhf(mock_minos, example_spec, example_spec_multibin):
     fit_results = fit._fit_model_pyhf(model, data, minos=["Signal strength", "abc"])
     assert mock_minos.call_count == 1
     # first argument to minos call is the Minuit instance
-    assert mock_minos.call_args[0][1] == ["x1"]
+    assert mock_minos.call_args[0][1] == ["Signal strength", "abc"]
     assert mock_minos.call_args[0][2] == ["staterror_Signal-Region", "Signal strength"]
     assert mock_minos.call_args[1] == {}
 
@@ -216,15 +216,6 @@ def test__run_minos(caplog):
     fit._run_minos(m, ["b"], ["a", "b"])
     assert "running MINOS for b" in [rec.message for rec in caplog.records]
     assert "b =  1.5909 -0.7262 +0.4738" in [rec.message for rec in caplog.records]
-    caplog.clear()
-
-    # proper labels not known to iminuit
-    m = iminuit.Minuit(func_to_minimize, [1.0, 1.0])
-    m.errordef = 1
-    m.migrad()
-    fit._run_minos(m, ["x0"], ["a", "b"])
-    assert "running MINOS for a" in [rec.message for rec in caplog.records]
-    assert "a =  1.3827 -0.8713 +0.5715" in [rec.message for rec in caplog.records]
     caplog.clear()
 
     # unknown parameter, MINOS does not run
@@ -467,7 +458,7 @@ def test_scan(mock_fit, example_spec):
     assert mock_fit.call_args[1]["custom_fit"] is True
 
     # unknown parameter
-    with pytest.raises(ValueError, match="could not find parameter abc in model"):
+    with pytest.raises(ValueError, match="parameter abc not found in model"):
         fit.scan(model, data, "abc")
 
 

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -33,7 +33,7 @@ def test__fit_model_pyhf(mock_minos, example_spec, example_spec_multibin):
     fit_results = fit._fit_model_pyhf(model, data)
     assert np.allclose(fit_results.bestfit, [1.1, 8.33624084])
     assert np.allclose(fit_results.uncertainty, [0.0, 0.38182003])
-    assert fit_results.labels == ["staterror_Signal-Region", "Signal strength"]
+    assert fit_results.labels == ["staterror_Signal-Region[0]", "Signal strength"]
     assert np.allclose(fit_results.best_twice_nll, 7.82495235)
     assert np.allclose(fit_results.corr_mat, [[0.0, 0.0], [0.0, 1.0]])
 
@@ -44,7 +44,7 @@ def test__fit_model_pyhf(mock_minos, example_spec, example_spec_multibin):
     # signal strength needs to be 1/1.1 to compensate
     assert np.allclose(fit_results.bestfit, [1.1, 0.90917877])
     assert np.allclose(fit_results.uncertainty, [0.0, 0.12628017])
-    assert fit_results.labels == ["staterror_Signal-Region", "Signal strength"]
+    assert fit_results.labels == ["staterror_Signal-Region[0]", "Signal strength"]
     assert np.allclose(fit_results.best_twice_nll, 5.61189476)
     assert np.allclose(fit_results.corr_mat, [[0.0, 0.0], [0.0, 1.0]])
 
@@ -69,7 +69,10 @@ def test__fit_model_pyhf(mock_minos, example_spec, example_spec_multibin):
     assert mock_minos.call_count == 1
     # first argument to minos call is the Minuit instance
     assert mock_minos.call_args[0][1] == ["Signal strength", "abc"]
-    assert mock_minos.call_args[0][2] == ["staterror_Signal-Region", "Signal strength"]
+    assert mock_minos.call_args[0][2] == [
+        "staterror_Signal-Region[0]",
+        "Signal strength",
+    ]
     assert mock_minos.call_args[1] == {}
 
 
@@ -80,7 +83,7 @@ def test__fit_model_custom(mock_minos, example_spec, example_spec_multibin):
     fit_results = fit._fit_model_custom(model, data)
     assert np.allclose(fit_results.bestfit, [1.1, 8.33625071])
     assert np.allclose(fit_results.uncertainty, [0.0, 0.38182151])
-    assert fit_results.labels == ["staterror_Signal-Region", "Signal strength"]
+    assert fit_results.labels == ["staterror_Signal-Region[0]", "Signal strength"]
     assert np.allclose(fit_results.best_twice_nll, 7.82495235)
     assert np.allclose(fit_results.corr_mat, [[0.0, 0.0], [0.0, 1.0]])
 
@@ -91,7 +94,7 @@ def test__fit_model_custom(mock_minos, example_spec, example_spec_multibin):
     # signal strength needs to be 1/1.1 to compensate
     assert np.allclose(fit_results.bestfit, [1.1, 0.90917877])
     assert np.allclose(fit_results.uncertainty, [0.0, 0.12628023])
-    assert fit_results.labels == ["staterror_Signal-Region", "Signal strength"]
+    assert fit_results.labels == ["staterror_Signal-Region[0]", "Signal strength"]
     assert np.allclose(fit_results.best_twice_nll, 5.61189476)
     assert np.allclose(fit_results.corr_mat, [[0.0, 0.0], [0.0, 1.0]])
 
@@ -116,7 +119,10 @@ def test__fit_model_custom(mock_minos, example_spec, example_spec_multibin):
     assert mock_minos.call_count == 1
     # first argument to minos call is the Minuit instance
     assert mock_minos.call_args[0][1] == ["Signal strength"]
-    assert mock_minos.call_args[0][2] == ["staterror_Signal-Region", "Signal strength"]
+    assert mock_minos.call_args[0][2] == [
+        "staterror_Signal-Region[0]",
+        "Signal strength",
+    ]
     assert mock_minos.call_args[1] == {}
 
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -16,7 +16,7 @@ def reset_backend():
 
 @pytest.mark.slow
 @pytest.mark.no_cover
-@pytest.mark.parametrize("backend", ["jax", "pytorch", "tensorflow"])
+@pytest.mark.parametrize("backend", ["jax", "pytorch"])
 def test_backend_integration(backend, reset_backend):
     """Integration test for the inference pipeline that can be run with all ``pyhf``
     backends to ensure they work. ``typeguard`` will catch type issues at runtime.

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -16,7 +16,7 @@ def reset_backend():
 
 @pytest.mark.slow
 @pytest.mark.no_cover
-@pytest.mark.parametrize("backend", ["jax", "pytorch"])
+@pytest.mark.parametrize("backend", ["jax", "pytorch", "tensorflow"])
 def test_backend_integration(backend, reset_backend):
     """Integration test for the inference pipeline that can be run with all ``pyhf``
     backends to ensure they work. ``typeguard`` will catch type issues at runtime.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -166,6 +166,7 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     assert np.allclose(
         model_postfit.total_stdev_model_bins,
         [[11.898333, 7.283185, 7.414715, 7.687922]],
+        rtol=1e-5,
     )
     assert np.allclose(model_postfit.total_stdev_model_channels, [20.329523])
     _ = cabinetry.visualize.data_mc(model_postfit, data, close_figure=True)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -148,7 +148,7 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     assert np.allclose(fit_results.goodness_of_fit, 0.24679341)
 
     # minos result
-    assert "Signal_norm                    =  1.6895 -0.9580 +0.9052" in [
+    assert "Signal_norm                =  1.6895 -0.9580 +0.9052" in [
         rec.message for rec in caplog.records
     ]
     caplog.clear()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -166,7 +166,7 @@ def test_integration(tmp_path, ntuple_creator, caplog):
     assert np.allclose(
         model_postfit.total_stdev_model_bins,
         [[11.898333, 7.283185, 7.414715, 7.687922]],
-        rtol=1e-5,
+        rtol=1e-4,
     )
     assert np.allclose(model_postfit.total_stdev_model_channels, [20.329523])
     _ = cabinetry.visualize.data_mc(model_postfit, data, close_figure=True)

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -43,12 +43,6 @@ def test_model_and_data(example_spec):
     assert data == [475]
 
 
-def test_parameter_names(example_spec):
-    model = pyhf.Workspace(example_spec).model()
-    labels = model_utils.parameter_names(model)
-    assert labels == ["staterror_Signal-Region", "Signal strength"]
-
-
 def test_asimov_data(example_spec):
     ws = pyhf.Workspace(example_spec)
     model = ws.model()

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -39,7 +39,7 @@ def test_model_and_data(example_spec):
     assert data == [51.8, 1.0]
 
     # without auxdata
-    model, data = model_utils.model_and_data(example_spec, with_aux=False)
+    model, data = model_utils.model_and_data(example_spec, include_auxdata=False)
     assert data == [475]
 
 
@@ -49,7 +49,7 @@ def test_asimov_data(example_spec):
     assert model_utils.asimov_data(model) == [51.8, 1]
 
     # without auxdata
-    assert model_utils.asimov_data(model, with_aux=False) == [51.8]
+    assert model_utils.asimov_data(model, include_auxdata=False) == [51.8]
 
     # respect nominal settings for normfactors
     example_spec["measurements"][0]["config"]["parameters"].append(
@@ -57,7 +57,7 @@ def test_asimov_data(example_spec):
     )
     ws = pyhf.Workspace(example_spec)
     model = ws.model()
-    assert model_utils.asimov_data(model, with_aux=False) == [103.6]
+    assert model_utils.asimov_data(model, include_auxdata=False) == [103.6]
 
 
 def test_asimov_parameters(example_spec, example_spec_shapefactor, example_spec_lumi):

--- a/tests/visualize/test_visualize.py
+++ b/tests/visualize/test_visualize.py
@@ -394,7 +394,7 @@ def test_correlation_matrix(mock_draw):
 def test_pulls(mock_draw):
     bestfit = np.asarray([0.8, 1.0, 1.05, 1.1])
     uncertainty = np.asarray([0.9, 1.0, 0.03, 0.7])
-    labels = ["a", "b", "staterror_region[bin_0]", "c"]
+    labels = ["a", "b", "staterror_region[0]", "c"]
     exclude = ["a"]
     folder_path = "tmp"
     fit_results = fit.FitResults(bestfit, uncertainty, labels, np.empty(0), 1.0)


### PR DESCRIPTION
https://github.com/scikit-hep/pyhf/pull/1536 (see also discussion in https://github.com/scikit-hep/pyhf/issues/867) added `model.config.par_names()` to the `pyhf` model config API. This provides the same functionality as `cabinetry.model_utils.parameter_names`, but the parameter names are now also passed through to MINUIT. A fix is included to pass the correct names when using MINOS (they used to be `x0`, `x1` etc.). `cabinetry.model_utils.parameter_names` is removed, since the functionality is now available directly in `pyhf`.

The parameter naming format has changed: `parameter[bin_0]` -> `parameter[0]` etc., and the index is now included even for parameters like shapesys/shapefactors that only have a single component (because there is only a single bin in the region, see https://github.com/scikit-hep/pyhf/pull/1560).

https://github.com/scikit-hep/pyhf/pull/1562 introduces an API change for the auxdata kwarg naming, from `with_aux` to `include_auxdata`. `cabinetry` used `with_aux` also in its own API, and this now switches to `include_auxdata` for consistency with `pyhf`.

Due to a `typing-extensions` requirements conflict that results in the `tensorflow-probability` installation being incompatible with the installed `tensorflow` version (see also https://github.com/scikit-hep/pyhf/discussions/1595, https://github.com/tensorflow/tensorflow/issues/51743), the `pyhf[backends]` installation is removed from the `cabinetry` `test` setup extra. It is now available via a new `pyhf_backends` setup extra and installed only when needed for the backend tests. That allows installing a working `tensorflow` setup (and picks up a conflict with `black` that does not matter at that point in the CI, as `black` already ran earlier).

**Breaking changes:**
- removed `cabinetry.model_utils.parameter_names` in favor of the `pyhf` implementation `model.config.par_names()`
- `model_utils.model_and_data` and `model_utils.asimov_data`: renamed `with_aux` kwarg to `include_auxdata` for consistency with `pyhf`
- `test` setup extra no longer includes all `pyhf` backends, now moved to `pyhf_backends` setup extra

```
* breaking change: removed model_utils.parameter_names in favor of model.config.par_names provided by pyhf
* breaking change: renamed with_aux arguments in model_utils to include_auxdata for consistency with pyhf
* breaking change: pyhf backends removed from cabinetry test setup extra
* parameter naming format changed from parameter[bin_0] to parameter[0]
* raised minimum required pyhf version to v0.6.3
```