### PR TITLE
refactor: small string handling improvements

### DIFF
--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -852,9 +852,15 @@ def significance(model: pyhf.pdf.Model, data: List[float]) -> SignificanceResult
     obs_significance = scipy.stats.norm.isf(obs_p_val, 0, 1)
     exp_significance = scipy.stats.norm.isf(exp_p_val, 0, 1)
 
-    log.info(f"observed p-value: {obs_p_val:.8%}")
+    if obs_p_val >= 1e-3:
+        log.info(f"observed p-value: {obs_p_val:.3%}")
+    else:
+        log.info(f"observed p-value: {obs_p_val:.3e}")
     log.info(f"observed significance: {obs_significance:.3f}")
-    log.info(f"expected p-value: {exp_p_val:.8%}")
+    if exp_p_val >= 1e-3:
+        log.info(f"expected p-value: {exp_p_val:.3%}")
+    else:
+        log.info(f"expected p-value: {exp_p_val:.3e}")
     log.info(f"expected significance: {exp_significance:.3f}")
 
     significance_results = SignificanceResults(

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -253,7 +253,7 @@ def build_name(
     Returns:
         str: unique name for the histogram
     """
-    name = region["Name"] + "_" + sample["Name"] + "_" + systematic["Name"]
+    name = f"{region['Name']}_{sample['Name']}_{systematic['Name']}"
     if template != "Nominal":
         name += "_" + template
     name = name.replace(" ", "-")

--- a/src/cabinetry/visualize.py
+++ b/src/cabinetry/visualize.py
@@ -30,9 +30,9 @@ def _build_figure_name(region_name: str, is_prefit: bool) -> str:
     """
     figure_name = region_name.replace(" ", "-")
     if is_prefit:
-        figure_name += "_" + "prefit"
+        figure_name += "_prefit"
     else:
-        figure_name += "_" + "postfit"
+        figure_name += "_postfit"
     figure_name += ".pdf"
     return figure_name
 

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -639,17 +639,23 @@ def test_limit(example_spec_with_background, caplog):
 
 
 def test_significance(example_spec_with_background):
+    # increase observed data for smaller observed p-value
+    example_spec_with_background["observations"][0]["data"] = [196]
+
     model, data = model_utils.model_and_data(example_spec_with_background)
     significance_results = fit.significance(model, data)
-    assert np.allclose(significance_results.observed_p_value, 0.23773068)
-    assert np.allclose(significance_results.observed_significance, 0.71362132)
-    assert np.allclose(significance_results.expected_p_value, 0.00049159)
-    assert np.allclose(significance_results.expected_significance, 3.29529432)
+    assert np.allclose(significance_results.observed_p_value, 0.00080517)
+    assert np.allclose(significance_results.observed_significance, 3.15402672)
+    assert np.allclose(significance_results.expected_p_value, 0.00033333)
+    assert np.allclose(significance_results.expected_significance, 3.40293444)
+
+    # reduce signal for larger expected p-value
+    example_spec_with_background["channels"][0]["samples"][0]["data"] = [30]
 
     # Asimov dataset, observed = expected
     model, data = model_utils.model_and_data(example_spec_with_background, asimov=True)
     significance_results = fit.significance(model, data)
-    assert np.allclose(significance_results.observed_p_value, 0.00031984)
-    assert np.allclose(significance_results.observed_significance, 3.41421033)
-    assert np.allclose(significance_results.expected_p_value, 0.00031984)
-    assert np.allclose(significance_results.expected_significance, 3.41421033)
+    assert np.allclose(significance_results.observed_p_value, 0.02062714)
+    assert np.allclose(significance_results.observed_significance, 2.04096523)
+    assert np.allclose(significance_results.expected_p_value, 0.02062714)
+    assert np.allclose(significance_results.expected_significance, 2.04096523)

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -123,7 +123,7 @@ def test_Histogram_from_path(tmp_path, caplog, example_histograms, histogram_hel
     # try loading a modified one, without success since it does not exist
     h_from_path_modified = histo.Histogram.from_path(tmp_path, modified=True)
     expected_warning = (
-        "the modified histogram " + str(tmp_path) + "_modified.npz " + "does not exist"
+        f"the modified histogram {str(tmp_path)}_modified.npz does not exist"
     )
     assert expected_warning in [rec.message for rec in caplog.records]
     assert "loading the un-modified histogram instead!" in [


### PR DESCRIPTION
Small improvements to string handling, including switches to f-strings in two more places. The formatting of p-values reported in significance calculations has been improved, now switching to scientific notation for small p-values.

```
* improved formatting of p-values reported in significance calculations
* small string handling improvements
```