### PR TITLE
refactor: use absolute imports

### DIFF
--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -1,15 +1,15 @@
 import logging
 
-from . import configuration  # NOQA
-from . import fit  # NOQA
-from . import route  # NOQA
-from . import smooth  # NOQA
-from . import tabulate  # NOQA
-from . import template_builder  # NOQA
-from . import template_postprocessor  # NOQA
-from . import model_utils  # NOQA
-from . import visualize  # NOQA
-from . import workspace  # NOQA
+import cabinetry.configuration  # noqa: F401
+import cabinetry.fit  # noqa: F401
+import cabinetry.model_utils  # noqa: F401
+import cabinetry.route  # noqa: F401
+import cabinetry.smooth  # noqa: F401
+import cabinetry.tabulate  # noqa: F401
+import cabinetry.template_builder  # noqa: F401
+import cabinetry.template_postprocessor  # noqa: F401
+import cabinetry.visualize  # noqa: F401
+import cabinetry.workspace  # noqa: F401
 
 
 __version__ = "0.2.3"

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -135,7 +135,8 @@ def fit(
         cabinetry_visualize.pulls(fit_results, figure_folder=figfolder)
     if corrmat:
         cabinetry_visualize.correlation_matrix(fit_results, figure_folder=figfolder)
-    pass  # fixes coverage, see https://github.com/nedbat/coveragepy/issues/198
+    # pass fixes coverage, see https://github.com/nedbat/coveragepy/issues/198
+    pass  # noqa
 
 
 @click.command()

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -135,8 +135,7 @@ def fit(
         cabinetry_visualize.pulls(fit_results, figure_folder=figfolder)
     if corrmat:
         cabinetry_visualize.correlation_matrix(fit_results, figure_folder=figfolder)
-    # pass fixes coverage, see https://github.com/nedbat/coveragepy/issues/198
-    pass  # noqa
+    pass  # fixes coverage, see https://github.com/nedbat/coveragepy/issues/198
 
 
 @click.command()

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -7,13 +7,13 @@ from typing import Any, List, Optional, Tuple
 import click
 import yaml
 
-from .. import configuration as cabinetry_configuration
-from .. import fit as cabinetry_fit
-from .. import model_utils as cabinetry_model_utils
-from .. import template_builder as cabinetry_template_builder
-from .. import template_postprocessor as cabinetry_template_postprocessor
-from .. import visualize as cabinetry_visualize
-from .. import workspace as cabinetry_workspace
+from cabinetry import configuration as cabinetry_configuration
+from cabinetry import fit as cabinetry_fit
+from cabinetry import model_utils as cabinetry_model_utils
+from cabinetry import template_builder as cabinetry_template_builder
+from cabinetry import template_postprocessor as cabinetry_template_postprocessor
+from cabinetry import visualize as cabinetry_visualize
+from cabinetry import workspace as cabinetry_workspace
 
 
 class OrderedGroup(click.Group):

--- a/src/cabinetry/fit.py
+++ b/src/cabinetry/fit.py
@@ -7,7 +7,7 @@ import pyhf
 import scipy.optimize
 import scipy.stats
 
-from . import model_utils
+from cabinetry import model_utils
 
 
 log = logging.getLogger(__name__)

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 import boost_histogram as bh
 
-from . import configuration
+from cabinetry import configuration
 
 
 log = logging.getLogger(__name__)

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -6,9 +6,9 @@ from typing import Any, Dict, List, Optional, Union
 import boost_histogram as bh
 import numpy as np
 
-from . import configuration
-from . import histo
-from . import route
+from cabinetry import configuration
+from cabinetry import histo
+from cabinetry import route
 
 
 log = logging.getLogger(__name__)
@@ -281,7 +281,7 @@ class _Builder:
 
         # obtain the histogram
         if self.method == "uproot":
-            from .contrib import histogram_creation
+            from cabinetry.contrib import histogram_creation
 
             yields, stdev = histogram_creation.from_uproot(
                 ntuple_paths,

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -5,10 +5,10 @@ from typing import Any, Dict, Optional
 
 import numpy as np
 
-from . import configuration
-from . import histo
-from . import route
-from . import smooth
+from cabinetry import configuration
+from cabinetry import histo
+from cabinetry import route
+from cabinetry import smooth
 
 
 log = logging.getLogger(__name__)

--- a/src/cabinetry/visualize/__init__.py
+++ b/src/cabinetry/visualize/__init__.py
@@ -9,14 +9,14 @@ import awkward as ak
 import numpy as np
 import pyhf
 
-from . import plot_model
-from . import plot_result
-from .. import configuration
-from .. import fit
-from .. import histo
-from .. import model_utils
-from .. import tabulate
-from .. import template_builder
+from cabinetry import configuration
+from cabinetry import fit
+from cabinetry import histo
+from cabinetry import model_utils
+from cabinetry import tabulate
+from cabinetry import template_builder
+from cabinetry.visualize import plot_model
+from cabinetry.visualize import plot_result
 
 
 log = logging.getLogger(__name__)

--- a/src/cabinetry/visualize/plot_model.py
+++ b/src/cabinetry/visualize/plot_model.py
@@ -8,7 +8,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 
-from . import utils
+from cabinetry.visualize import utils
 
 
 log = logging.getLogger(__name__)

--- a/src/cabinetry/visualize/plot_result.py
+++ b/src/cabinetry/visualize/plot_result.py
@@ -8,7 +8,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 
-from . import utils
+from cabinetry.visualize import utils
 
 
 log = logging.getLogger(__name__)

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -5,8 +5,8 @@ from typing import Any, Dict, List, Optional, Union
 
 import pyhf
 
-from . import configuration
-from . import histo
+from cabinetry import configuration
+from cabinetry import histo
 
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Motivated by https://github.com/scikit-hep/pyhf/pull/1539, this switches from relative to absolute imports within `cabinetry`. Reasons are outlined in https://github.com/scikit-hep/pyhf/pull/1539#issuecomment-895382525, reproduced below:

The [imports section of PEP 8](https://www.python.org/dev/peps/pep-0008/#imports) says
> Absolute imports are recommended, as they are usually more readable and tend to be better behaved (or at least give better error messages) if the import system is incorrectly configured

and

> However, explicit relative imports are an acceptable alternative to absolute imports, especially when dealing with complex package layouts where using absolute imports would be unnecessarily verbose

PEP 8 [used to discourage relative imports more strongly](https://stackoverflow.com/a/4209771).

The [Google style guide section](https://google.github.io/styleguide/pyguide.html#22-imports) says
> Do not use relative names in imports. Even if the module is in the same package, use the full package name. This helps prevent unintentionally importing a package twice.

The relative imports used previously were originally motivated by `pyhf`, so it seems appropriate to switch to absolute imports together with `pyhf`.

```
* switch from relative to absolute imports
```