### PR TITLE
feat: variable overrides in systematic templates

### DIFF
--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -264,6 +264,10 @@
                     "description": "weight to apply",
                     "type": "string"
                 },
+                "Variable": {
+                    "description": "variable to bin in (override for nominal setting)",
+                    "type": "string"
+                },
                 "Normalization": {
                     "description": "normalization uncertainty to apply",
                     "type": "number"

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -111,16 +111,33 @@ def _get_ntuple_paths(
     return paths
 
 
-def _get_variable(region: Dict[str, Any]) -> str:
+def _get_variable(
+    region: Dict[str, Any],
+    sample: Dict[str, Any],
+    systematic: Dict[str, Any],
+    template: str,
+) -> str:
     """Returns the variable the histogram will be binned in.
+
+    For non-nominal templates, overrides the nominal variable if an alternative is
+    specified for the template.
 
     Args:
         region (Dict[str, Any]): containing all region information
+        sample (Dict[str, Any]): containing all sample information
+        systematic (Dict[str, Any]): containing all systematic information
+        template (str): which template is considered: "Nominal", "Up", "Down"
 
     Returns:
         str: name of variable to bin histogram in
     """
     axis_variable = region["Variable"]
+    # check whether a systematic is being processed
+    if systematic.get("Name", "Nominal") != "Nominal":
+        # determine whether the template has an override specified
+        axis_variable_override = _check_for_override(systematic, template, "Variable")
+        if axis_variable_override is not None:
+            axis_variable = axis_variable_override
     return axis_variable
 
 
@@ -274,7 +291,7 @@ class _Builder:
             self.general_path, region, sample, systematic, template
         )
         pos_in_file = _get_position_in_file(sample, systematic, template)
-        variable = _get_variable(region)
+        variable = _get_variable(region, sample, systematic, template)
         bins = _get_binning(region)
         weight = _get_weight(region, sample, systematic, template)
         selection_filter = _get_filter(region, sample, systematic, template)

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -127,7 +127,29 @@ def test__get_ntuple_paths(caplog):
 
 
 def test__get_variable():
-    assert template_builder._get_variable({"Variable": "jet_pt"}) == "jet_pt"
+    # no override
+    assert (
+        template_builder._get_variable({"Variable": "jet_pt"}, {}, {}, "") == "jet_pt"
+    )
+
+    # systematic with override
+    assert (
+        template_builder._get_variable(
+            {"Variable": "jet_pt"},
+            {},
+            {"Name": "variation", "Up": {"Variable": "jet_pt_up"}},
+            "Up",
+        )
+        == "jet_pt_up"
+    )
+
+    # systematic without override
+    assert (
+        template_builder._get_variable(
+            {"Variable": "jet_pt"}, {}, {"Name": "variation"}, "Up"
+        )
+        == "jet_pt"
+    )
 
 
 def test__get_filter():


### PR DESCRIPTION
This adds support for overriding the histogram variable/observable in systematic templates. The `"Variable"` key in up/down templates (the nominal value is a required region property) is used for that, and any value specified overrides the nominal setting.

This can be useful if observables under systematic variations are saved in a branch with a different name (rather than just a different tree, but same branch name). It could also be used to simulate simplified systematic variations, for example by multiplying observables by a number (ignoring possible acceptance effects).

```
* support overriding histogram variable in systematic templates
```