### PR TITLE
fix: add missing template settings to config schema

### DIFF
--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -253,21 +253,29 @@
             "description": "a systematics template (up/down)",
             "type": "object",
             "properties": {
-                "SamplePaths": {
-                    "description": "override for nominal setting",
-                    "$ref": "#/definitions/samplepaths_setting"
-                },
                 "Tree": {
-                    "description": "name of tree",
+                    "description": "name of tree (override for nominal setting)",
                     "type": "string"
                 },
                 "Weight": {
-                    "description": "weight to apply",
+                    "description": "weight to apply (override for nominal setting)",
+                    "type": "string"
+                },
+                "Filter": {
+                    "description": "selection criteria to apply (override for nominal setting)",
                     "type": "string"
                 },
                 "Variable": {
                     "description": "variable to bin in (override for nominal setting)",
                     "type": "string"
+                },
+                "RegionPath": {
+                    "description": "(part of) path to file containing region (override for nominal setting)",
+                    "type": "string"
+                },
+                "SamplePaths": {
+                    "description": "(part of) path(s) to input file(s) (override for nominal setting)",
+                    "$ref": "#/definitions/samplepaths_setting"
                 },
                 "Normalization": {
                     "description": "normalization uncertainty to apply",

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -216,7 +216,8 @@
             "properties": {
                 "Name": {
                     "description": "name of the systematic uncertainty",
-                    "type": "string"
+                    "type": "string",
+                    "not": {"const": "Nominal", "$comment": "systematics may not be called \"Nominal\""}
                 },
                 "Type": {
                     "description": "type of systematic uncertainty",


### PR DESCRIPTION
The JSON schema for config validation was missing the `Filter` and `RegionPath` settings for systematics templates, even though they were already supported within `cabinetry`. This adds the missing settings. `Filter` was supported since #65, but not added when the JSON schema was created in #69. `RegionPath` was added in #98 and fixed to work in #117, but not added to the schema for templates.

Also adds a check for systematics names to the schema, since `"Nominal"` is a reserved name with special handling inside `cabinetry`. This name is now caught as invalid by the schema validation.

```
* add missing Filter and RegionPath settings for systematic templates to config schema
* invalidate reserved systematics names in config schema
```