### PR TITLE
feat: manual correlation of systematics

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     boost_histogram>=1.0.0  # subclassing with family, 1.02 for stdev scaling fix (currently not needed)
     awkward>=1.0  # new API
     tabulate>=0.8.1  # multiline text
-    matplotlib
+    matplotlib==3.4.2
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     boost_histogram>=1.0.0  # subclassing with family, 1.02 for stdev scaling fix (currently not needed)
     awkward>=1.0  # new API
     tabulate>=0.8.1  # multiline text
-    matplotlib==3.4.2
+    matplotlib
 
 [options.packages.find]
 where = src

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -243,6 +243,10 @@
                 "Smoothing": {
                     "description": "smoothing to apply",
                     "$ref": "#/definitions/smoothing_setting"
+                },
+                "ModifierName": {
+                    "description": "name of modifier in workspace, modifiers with same name are correlated",
+                    "type": "string"
                 }
             },
             "additionalProperties": false

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -245,7 +245,7 @@
                     "$ref": "#/definitions/smoothing_setting"
                 },
                 "ModifierName": {
-                    "description": "name of modifier in workspace, modifiers with same name are correlated",
+                    "description": "name of modifier in workspace, overrides default set by Name",
                     "type": "string"
                 }
             },

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -245,7 +245,7 @@
                     "$ref": "#/definitions/smoothing_setting"
                 },
                 "ModifierName": {
-                    "description": "name of modifier in workspace, overrides default set by Name",
+                    "description": "name of modifier in workspace, defaults to value set by Name",
                     "type": "string"
                 }
             },

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -151,8 +151,11 @@ class WorkspaceBuilder:
         Returns:
             Dict[str, Any]: single `normsys` modifier for ``pyhf`` workspace
         """
+        # take name of modifier from ModifierName if set, default to systematics name
+        modifier_name = systematic.get("ModifierName", systematic["Name"])
+
         modifier = {}
-        modifier.update({"name": systematic["Name"]})
+        modifier.update({"name": modifier_name})
         modifier.update({"type": "normsys"})
         modifier.update(
             {
@@ -240,17 +243,20 @@ class WorkspaceBuilder:
             histo_yield_up = list(histogram_up.yields / norm_effect_up)
             histo_yield_down = list(histogram_down.yields / norm_effect_down)
 
+        # take name of modifier from ModifierName if set, defaults to systematics name
+        modifier_name = systematic.get("ModifierName", systematic["Name"])
+
         # add the normsys
         modifiers = []
         norm_modifier = {}
-        norm_modifier.update({"name": systematic["Name"]})
+        norm_modifier.update({"name": modifier_name})
         norm_modifier.update({"type": "normsys"})
         norm_modifier.update({"data": {"hi": norm_effect_up, "lo": norm_effect_down}})
         modifiers.append(norm_modifier)
 
         # add the shape part in a histosys
         shape_modifier = {}
-        shape_modifier.update({"name": systematic["Name"]})
+        shape_modifier.update({"name": modifier_name})
         shape_modifier.update({"type": "histosys"})
         shape_modifier.update(
             {"data": {"hi_data": histo_yield_up, "lo_data": histo_yield_down}}

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -243,7 +243,7 @@ class WorkspaceBuilder:
             histo_yield_up = list(histogram_up.yields / norm_effect_up)
             histo_yield_down = list(histogram_down.yields / norm_effect_down)
 
-        # take name of modifier from ModifierName if set, defaults to systematics name
+        # take name of modifier from ModifierName if set, default to systematics name
         modifier_name = systematic.get("ModifierName", systematic["Name"])
 
         # add the normsys

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -192,6 +192,15 @@ def test_WorkspaceBuilder_get_Normalization_modifier():
     ws_builder = workspace.WorkspaceBuilder({"General": {"HistogramFolder": "path"}})
     assert ws_builder.get_Normalization_modifier(systematic) == expected_modifier
 
+    # ModifierName set
+    systematic = {
+        "Name": "sys",
+        "Up": {"Normalization": 0.1},
+        "Down": {"Normalization": -0.05},
+        "ModifierName": "mod_name",
+    }
+    assert ws_builder.get_Normalization_modifier(systematic)["name"] == "mod_name"
+
 
 @mock.patch(
     "cabinetry.workspace.histo.Histogram.from_config",
@@ -240,13 +249,18 @@ def test_WorkspaceBuilder_get_NormPlusShape_modifiers(mock_histogram):
         ),
     ]
 
-    # down template via symmetrized up template
-    systematic = {"Name": "sys", "Up": {}, "Down": {"Symmetrize": True}}
+    # down template via symmetrized up template, ModifierName set
+    systematic = {
+        "Name": "sys",
+        "Up": {},
+        "Down": {"Symmetrize": True},
+        "ModifierName": "mod_name",
+    }
     modifiers = ws_builder.get_NormPlusShape_modifiers(region, sample, systematic)
     assert modifiers == [
-        {"name": "sys", "type": "normsys", "data": {"hi": 1.25, "lo": 0.75}},
+        {"name": "mod_name", "type": "normsys", "data": {"hi": 1.25, "lo": 0.75}},
         {
-            "name": "sys",
+            "name": "mod_name",
             "type": "histosys",
             "data": {"hi_data": [20.8, 19.2], "lo_data": [19.2, 20.8]},
         },


### PR DESCRIPTION
This adds a new optional setting `ModifierName` for systematics. If set, the name of affected modifiers in the workspace will be taken from this setting. By default the name is taken from the name of the systematic instead. This new setting enables manual correlation of systematics: modifiers with the same name in the workspace are correlated. This name set by `ModifierName` only enters the workspace (and subsequently shows up in inference results, which extract the name from the workspace). Everything in `cabinetry` leading up to workspace creation does not make use of the name, and instead uses the unique name of each systematic to identify it.

Added a section to the "advanced concepts" docs to explain the behavior.

resolves #213

```
* new systematics setting ModifierName to manually correlate systematics
* added documentation section about manual correlation of systematics
```