### PR TITLE
fix: configs without systematics

### DIFF
--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -263,7 +263,8 @@ def apply_to_all_templates(
             log.debug(f"    reading sample {sample['Name']}")
             # region dependence of sample is checked below via histogram_is_needed
 
-            for systematic in [{"Name": "Nominal"}] + config["Systematics"]:
+            # loop over nominal templates and all existing systematics
+            for systematic in [{"Name": "Nominal"}] + config.get("Systematics", []):
                 # determine how many templates need to be considered
                 if systematic["Name"] == "Nominal":
                     # only nominal template is needed
@@ -275,6 +276,7 @@ def apply_to_all_templates(
                 for template in templates:
                     # determine whether a histogram is needed for this
                     # specific combination of sample-region-systematic-template
+                    # could consider caching the results of histogram_is_needed
                     histo_needed = configuration.histogram_is_needed(
                         region, sample, systematic, template
                     )

--- a/src/cabinetry/visualize/__init__.py
+++ b/src/cabinetry/visualize/__init__.py
@@ -466,7 +466,8 @@ def templates(
                 # skip data
                 continue
 
-            for systematic in config["Systematics"]:
+            # loop over systematics (if they exist)
+            for systematic in config.get("Systematics", []):
                 histo_name = (
                     region["Name"]
                     + "_"

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -280,3 +280,4 @@ def test_apply_to_all_templates():
     route.apply_to_all_templates(example_config, default_func)
     # previously 3 calls of default_func, now one more for nominal template
     assert default_func.call_count == 4
+    assert default_func.call_args_list[3][0][3] == "Nominal"

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -226,7 +226,7 @@ def test_apply_to_all_templates():
     route.apply_to_all_templates(example_config, default_func, match_func=None)
 
     # check that the default function was called for all templates
-    assert len(default_func.call_args_list) == 3
+    assert default_func.call_count == 3
     assert default_func.call_args_list[0] == (
         ({"Name": "test_region"}, {"Name": "sample"}, {"Name": "Nominal"}, "Nominal"),
         {},
@@ -271,3 +271,12 @@ def test_apply_to_all_templates():
         {"Name": "var", "Type": "NormPlusShape"},
         "Down",
     )
+
+    # no systematics
+    example_config = {
+        "Regions": [{"Name": "test_region"}],
+        "Samples": [{"Name": "sample"}],
+    }
+    route.apply_to_all_templates(example_config, default_func)
+    # previously 3 calls of default_func, now one more for nominal template
+    assert default_func.call_count == 4

--- a/tests/visualize/test_visualize.py
+++ b/tests/visualize/test_visualize.py
@@ -523,6 +523,15 @@ def test_templates(mock_draw, mock_histo_config, mock_histo_path, tmp_path):
     visualize.templates(config, figure_folder=folder_path)
     assert mock_draw.call_count == 2  # no new call, since no variations found
 
+    # no systematics in config
+    config = {
+        "General": {"HistogramFolder": tmp_path},
+        "Regions": [region],
+        "Samples": [sample, {"Name": "data", "Data": True}],
+    }
+    visualize.templates(config, figure_folder=folder_path)
+    assert mock_draw.call_count == 2  # no systematics, so no new calls
+
 
 @mock.patch("cabinetry.visualize.plot_result.scan")
 def test_scan(mock_draw):


### PR DESCRIPTION
The JSON schema for `cabinetry` configs does not require systematics, but so far the internal handling relied on them being present in the config, at least in form of an empty list. This fixes the behavior such that configs without systematics work as expected.

```
* fix handling of configs without systematics
```