### PR TITLE
feat: validate uniqueness of names in config

### DIFF
--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -64,18 +64,18 @@ def validate(config: Dict[str, Any]) -> bool:
     if len(set(sample_names)) != len(sample_names):
         raise ValueError(f"all sample names must be unique: {sample_names}")
 
-    # check that systematic names are unique
-    # systematics are optional, may be empty
-    systematic_names = [sys["Name"] for sys in config.get("Systematics", [])]
-    if len(set(systematic_names)) != len(systematic_names):
-        raise ValueError(f"all systematic names must be unique: {systematic_names}")
-
     # check that normfactor names are unique
     # may technically not be required, but non-unique names do not seem to offer any
     # obvious advantages, so require uniqueness here for consistency
     normfactor_names = [normfactor["Name"] for normfactor in config["NormFactors"]]
     if len(set(normfactor_names)) != len(normfactor_names):
         raise ValueError(f"all normfactor names must be unique: {normfactor_names}")
+
+    # check that systematic names are unique
+    # systematics are optional, may be empty
+    systematic_names = [sys["Name"] for sys in config.get("Systematics", [])]
+    if len(set(systematic_names)) != len(systematic_names):
+        raise ValueError(f"all systematic names must be unique: {systematic_names}")
 
     # if no issues are found
     return True

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -38,7 +38,7 @@ def validate(config: Dict[str, Any]) -> bool:
 
     Raises:
         NotImplementedError: when more than one data sample is found
-        ValueError: when region / sample / systematic / normfactor names are not unique
+        ValueError: when region / sample / normfactor / systematic names are not unique
 
     Returns:
         bool: whether the validation was successful

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -37,11 +37,8 @@ def validate(config: Dict[str, Any]) -> bool:
         config (Dict[str, Any]): cabinetry configuration
 
     Raises:
-        ValueError: when missing required keys
-        ValueError: when unknown keys are found
         NotImplementedError: when more than one data sample is found
-        ValueError: when missing a name for a NormFactor
-        ValueError: when missing a samples for a NormFactor
+        ValueError: when region / sample / systematic / normfactor names are not unique
 
     Returns:
         bool: whether the validation was successful
@@ -57,8 +54,28 @@ def validate(config: Dict[str, Any]) -> bool:
     if sum(sample.get("Data", False) for sample in config["Samples"]) != 1:
         raise NotImplementedError("can only handle cases with exactly one data sample")
 
-    # should also check here for conflicting settings
-    ...
+    # check that region names are unique
+    region_names = [region["Name"] for region in config["Regions"]]
+    if len(set(region_names)) != len(region_names):
+        raise ValueError(f"all region names must be unique: {region_names}")
+
+    # check that sample names are unique
+    sample_names = [sample["Name"] for sample in config["Samples"]]
+    if len(set(sample_names)) != len(sample_names):
+        raise ValueError(f"all sample names must be unique: {sample_names}")
+
+    # check that systematic names are unique
+    # systematics are optional, may be empty
+    systematic_names = [sys["Name"] for sys in config.get("Systematics", [])]
+    if len(set(systematic_names)) != len(systematic_names):
+        raise ValueError(f"all systematic names must be unique: {systematic_names}")
+
+    # check that normfactor names are unique
+    # may technically not be required, but non-unique names do not seem to offer any
+    # obvious advantages, so require uniqueness here for consistency
+    normfactor_names = [normfactor["Name"] for normfactor in config["NormFactors"]]
+    if len(set(normfactor_names)) != len(normfactor_names):
+        raise ValueError(f"all normfactor names must be unique: {normfactor_names}")
 
     # if no issues are found
     return True

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -60,6 +60,41 @@ def test_validate():
             configuration.validate({})
         mock_get.assert_called_once()
 
+    # uniqueness of names
+    with mock.patch("jsonschema.validate", return_value=None):
+        config_region_names = {
+            "Regions": [{"Name": "abc"}, {"Name": "abc"}],
+            "Samples": [{"Name": "", "Tree": "", "Data": True}],
+            "NormFactors": [],
+        }
+        with pytest.raises(ValueError, match="all region names must be unique"):
+            configuration.validate(config_region_names)
+
+        config_sample_names = {
+            "Regions": [],
+            "Samples": [{"Name": "abc", "Tree": "", "Data": True}, {"Name": "abc"}],
+            "NormFactors": [],
+        }
+        with pytest.raises(ValueError, match="all sample names must be unique"):
+            configuration.validate(config_sample_names)
+
+        config_systematic_names = {
+            "Regions": [],
+            "Samples": [{"Name": "abc", "Tree": "", "Data": True}],
+            "Systematics": [{"Name": "abc"}, {"Name": "abc"}],
+            "NormFactors": [],
+        }
+        with pytest.raises(ValueError, match="all systematic names must be unique"):
+            configuration.validate(config_systematic_names)
+
+        config_normfactor_names = {
+            "Regions": [],
+            "Samples": [{"Name": "", "Tree": "", "Data": True}],
+            "NormFactors": [{"Name": "abc"}, {"Name": "abc"}],
+        }
+        with pytest.raises(ValueError, match="all normfactor names must be unique"):
+            configuration.validate(config_normfactor_names)
+
 
 def test_print_overview(caplog):
     caplog.set_level(logging.DEBUG)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -78,6 +78,14 @@ def test_validate():
         with pytest.raises(ValueError, match="all sample names must be unique"):
             configuration.validate(config_sample_names)
 
+        config_normfactor_names = {
+            "Regions": [],
+            "Samples": [{"Name": "", "Tree": "", "Data": True}],
+            "NormFactors": [{"Name": "abc"}, {"Name": "abc"}],
+        }
+        with pytest.raises(ValueError, match="all normfactor names must be unique"):
+            configuration.validate(config_normfactor_names)
+
         config_systematic_names = {
             "Regions": [],
             "Samples": [{"Name": "abc", "Tree": "", "Data": True}],
@@ -86,14 +94,6 @@ def test_validate():
         }
         with pytest.raises(ValueError, match="all systematic names must be unique"):
             configuration.validate(config_systematic_names)
-
-        config_normfactor_names = {
-            "Regions": [],
-            "Samples": [{"Name": "", "Tree": "", "Data": True}],
-            "NormFactors": [{"Name": "abc"}, {"Name": "abc"}],
-        }
-        with pytest.raises(ValueError, match="all normfactor names must be unique"):
-            configuration.validate(config_normfactor_names)
 
 
 def test_print_overview(caplog):


### PR DESCRIPTION
The names of regions/samples/systematics need to be unique, since they are used as keys within `cabinetry`. The names of normalization factors technically should not need to be unique, but there is no obvious gain by allowing non-unique names. This adds a check for uniqueness of all these names to `configuration.validate`, and raises `ValueError` if non-unique names are found.

Also updates the `configuration.validate` docstring, which had some outdated entries.

```
* validate uniqueness of region/sample/systematic/normfactor names in config
```