### PR TITLE
refactor: improved nominal template handling

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     awkward>=1.0  # new API
     tabulate>=0.8.1  # multiline text
     matplotlib
+    typing_extensions;python_version<"3.8"  # for Literal type
 
 [options.packages.find]
 where = src

--- a/src/cabinetry/_typing.py
+++ b/src/cabinetry/_typing.py
@@ -1,0 +1,8 @@
+"""Utility to import the Literal type."""
+
+import sys
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal  # noqa: F401
+else:
+    from typing import Literal  # noqa: F401

--- a/src/cabinetry/_typing.py
+++ b/src/cabinetry/_typing.py
@@ -3,6 +3,6 @@
 import sys
 
 if sys.version_info < (3, 8):
-    from typing_extensions import Literal  # noqa: F401
+    from typing_extensions import Literal  # noqa: F401, # pragma: no cover
 else:
-    from typing import Literal  # noqa: F401
+    from typing import Literal  # noqa: F401, # pragma: no cover

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -206,7 +206,7 @@ def histogram_is_needed(
         region (Dict[str, Any]): containing all region information
         sample (Dict[str, Any]): containing all sample information
         systematic (Dict[str, Any]): containing all systematic information
-        template (Optional[Literal["Up", "Down"]]): which template is considered: "Up",
+        template (Optional[Literal["Up", "Down"]]): which template to consider: "Up",
             "Down", None for the nominal case
 
     Raises:

--- a/src/cabinetry/configuration.py
+++ b/src/cabinetry/configuration.py
@@ -2,10 +2,12 @@ import json
 import logging
 import pathlib
 import pkgutil
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import jsonschema
 import yaml
+
+from cabinetry._typing import Literal
 
 
 log = logging.getLogger(__name__)
@@ -193,18 +195,19 @@ def histogram_is_needed(
     region: Dict[str, Any],
     sample: Dict[str, Any],
     systematic: Dict[str, Any],
-    template: str,
+    template: Optional[Literal["Up", "Down"]],
 ) -> bool:
     """Determines whether a histogram is needed for a specific configuration.
 
-    The configuration is defined by the region, sample, systematic and template
-    ("Nominal", "Up" or "Down").
+    The configuration is defined by the region, sample, systematic and template ("Up" or
+    "Down", None for nominal).
 
     Args:
         region (Dict[str, Any]): containing all region information
         sample (Dict[str, Any]): containing all sample information
         systematic (Dict[str, Any]): containing all systematic information
-        template (str): which template is considered: "Nominal", "Up", "Down"
+        template (Optional[Literal["Up", "Down"]]): which template is considered: "Up",
+            "Down", None for the nominal case
 
     Raises:
         NotImplementedError: non-supported systematic variations based on histograms are
@@ -217,7 +220,7 @@ def histogram_is_needed(
         # region does not contain sample
         return False
 
-    if systematic.get("Name", None) == "Nominal":
+    if template is None:
         # for nominal, histograms are generally needed
         histo_needed = True
     else:
@@ -227,6 +230,7 @@ def histogram_is_needed(
             histo_needed = False
         else:
             # handle non-nominal, non-data histograms
+            # this assumes that the systematic dict satisfies config schema requirements
             if systematic["Type"] == "Normalization":
                 # no histogram needed for normalization variation
                 histo_needed = False

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -1,12 +1,13 @@
 import logging
 import os
 import pathlib
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 
 import boost_histogram as bh
 import numpy as np
 
 import cabinetry
+from cabinetry._typing import Literal
 
 
 log = logging.getLogger(__name__)
@@ -96,7 +97,7 @@ class Histogram(bh.Histogram, family=cabinetry):
         sample: Dict[str, Any],
         systematic: Dict[str, Any],
         modified: bool = True,
-        template: str = "Nominal",
+        template: Optional[Literal["Up", "Down"]] = None,
     ) -> H:
         """Loads a histogram, using information specified in the configuration file.
 
@@ -111,8 +112,8 @@ class Histogram(bh.Histogram, family=cabinetry):
             systematic (Dict[str, Any]): containing all systematic information
             modified (bool, optional): whether to load the modified histogram (after
                 post-processing), defaults to True
-            template (str): which template (nominal/up/down) to consider, defaults to
-                "Nominal"
+            template (Optional[Literal["Up", "Down"]]): which template ("Up", "Down") to
+                consider, or None in the nominal case, defaults to None
 
         Returns:
             cabinetry.histo.Histogram: the loaded histogram
@@ -239,22 +240,25 @@ def build_name(
     region: Dict[str, Any],
     sample: Dict[str, Any],
     systematic: Dict[str, Any],
-    template: str = "Nominal",
+    template: Optional[Literal["Up", "Down"]] = None,
 ) -> str:
     """Returns a unique name for each histogram.
+
+    If the template is not None, the systematic is required to have a name (guaranteed
+    as long as it follows the config schema).
 
     Args:
         region (Dict[str, Any]): containing all region information
         sample (Dict[str, Any]): containing all sample information
         systematic (Dict[str, Any]): containing all systematic information
-        template (str): which template (nominal/up/down) to consider, defaults to
-            "Nominal"
+        template (Optional[Literal["Up", "Down"]]): which template ("Up", "Down") to
+            consider, or None in the nominal case, defaults to None
 
     Returns:
         str: unique name for the histogram
     """
-    name = f"{region['Name']}_{sample['Name']}_{systematic['Name']}"
-    if template != "Nominal":
-        name += "_" + template
+    name = f"{region['Name']}_{sample['Name']}"
+    if template is not None:
+        name += f"_{systematic['Name']}_{template}"
     name = name.replace(" ", "-")
     return name

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -113,7 +113,7 @@ class Histogram(bh.Histogram, family=cabinetry):
             modified (bool, optional): whether to load the modified histogram (after
                 post-processing), defaults to True
             template (Optional[Literal["Up", "Down"]], optional): which template to
-            consider: "Up", "Down", None for the nominal case, defaults to None
+                consider: "Up", "Down", None for the nominal case, defaults to None
 
         Returns:
             cabinetry.histo.Histogram: the loaded histogram

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -112,8 +112,8 @@ class Histogram(bh.Histogram, family=cabinetry):
             systematic (Dict[str, Any]): containing all systematic information
             modified (bool, optional): whether to load the modified histogram (after
                 post-processing), defaults to True
-            template (Optional[Literal["Up", "Down"]]): which template ("Up", "Down") to
-                consider, or None in the nominal case, defaults to None
+            template (Optional[Literal["Up", "Down"]], optional): which template to
+            consider: "Up", "Down", None for the nominal case, defaults to None
 
         Returns:
             cabinetry.histo.Histogram: the loaded histogram
@@ -251,8 +251,8 @@ def build_name(
         region (Dict[str, Any]): containing all region information
         sample (Dict[str, Any]): containing all sample information
         systematic (Dict[str, Any]): containing all systematic information
-        template (Optional[Literal["Up", "Down"]]): which template ("Up", "Down") to
-            consider, or None in the nominal case, defaults to None
+        template (Optional[Literal["Up", "Down"]], optional): which template to
+            consider: "Up", "Down", None for the nominal case, defaults to None
 
     Returns:
         str: unique name for the histogram

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -314,7 +314,7 @@ def apply_to_all_templates(
 
                     log.debug(
                         f"      variation "
-                        f"{systematic['Name'] if systematic != {} else 'Nominal'}"
+                        f"{systematic['Name'] if template is not None else 'Nominal'}"
                         f"{' ' + template if template is not None else ''}"
                     )
 
@@ -322,7 +322,9 @@ def apply_to_all_templates(
                     if match_func is not None:
                         # check whether a user-defined function was registered that
                         # matches this region-sample-systematic-template
-                        systematic_name = systematic["Name"] if systematic != {} else ""
+                        systematic_name = (
+                            systematic["Name"] if template is not None else ""
+                        )
                         func_override = match_func(
                             region["Name"], sample["Name"], systematic_name, template
                         )

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -84,8 +84,8 @@ class Router:
                 apply to all samples
             systematic_name (str): name of the systematic to apply the function to, or
                "*" to apply to all systematics
-            template (str): name of the template to apply the function to, "*" to
-                apply to all templates, or None to apply to nominal only
+            template (Optional[str]): name of the template to apply the function to, "*"
+                to apply to all templates, or None to apply to nominal only
 
         Returns:
             Callable[[UserTemplateFunc], UserTemplateFunc]: the function to

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -185,8 +185,8 @@ class Router:
             #   - "*": apply to all templates
             #   - another string: do normal matching, can never match nominal then
             if template is None:
-                # nominal template is matched by processors applying nominal templates,
-                # and by processors applying to all templates
+                # nominal template is matched by processors applying to nominal
+                # templates (None), and by processors applying to all templates ("*")
                 template_matches = (processor["template"] is None) or (
                     processor["template"] == "*"
                 )

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, List, Optional
 import boost_histogram as bh
 
 from cabinetry import configuration
+from cabinetry._typing import Literal
 
 
 log = logging.getLogger(__name__)
@@ -12,17 +13,25 @@ log = logging.getLogger(__name__)
 
 # type of a function processing templates, takes sample-region-systematic-template,
 # returns None
-ProcessorFunc = Callable[[Dict[str, Any], Dict[str, Any], Dict[str, Any], str], None]
+# template can be "Up" / "Down" for variations, or None for nominal
+ProcessorFunc = Callable[
+    [Dict[str, Any], Dict[str, Any], Dict[str, Any], Optional[Literal["Up", "Down"]]],
+    None,
+]
 
 # type of a user-defined function for template processing, takes sample-region-
 # systematic-template, returns a boost_histogram.Histogram
+# template can be any string (to match "Up" / "Down"), or None / "*" to match nominal
 UserTemplateFunc = Callable[
-    [Dict[str, Any], Dict[str, Any], Dict[str, Any], str], bh.Histogram
+    [Dict[str, Any], Dict[str, Any], Dict[str, Any], Optional[str]], bh.Histogram
 ]
 
 # type of a function called with names of region-sample-systematic-template,
-# which returns either a ProcessorFunc or None
-MatchFunc = Callable[[str, str, str, str], Optional[ProcessorFunc]]
+# which returns either a ProcessorFunc or None (in case of no match)
+# the template argument is None for the nominal case, and "Up" / "Down" otherwise
+MatchFunc = Callable[
+    [str, str, str, Optional[Literal["Up", "Down"]]], Optional[ProcessorFunc]
+]
 
 # type of wrapper function that that turns a user-defined template processing function
 # (which returns a histogram) into a function that returns None
@@ -56,9 +65,9 @@ class Router:
     @staticmethod
     def _register_processor(
         processor_list: List[Dict[str, Any]],
-        region_name: Optional[str],
-        sample_name: Optional[str],
-        systematic_name: Optional[str],
+        region_name: str,
+        sample_name: str,
+        systematic_name: str,
         template: Optional[str],
     ) -> Callable[[UserTemplateFunc], UserTemplateFunc]:
         """Decorator for registering a custom processor function.
@@ -69,27 +78,19 @@ class Router:
         accordingly.
 
         Args:
-            region_name  (Optional[str]): name of the region to apply the function to,
-                or None to apply to all regions
-            sample_name  (Optional[str]): name of the sample to apply the function to,
-                or None to apply to all samples
-            systematic_name  (Optional[str]): name of the systematic to apply the
-                function to, or None to apply to all systematics
-            template (Optional[str]): name of the template to apply the function to, or
-                None to apply to all templates
+            region_name (str): name of the region to apply the function to, or "*" to
+                apply to all regions
+            sample_name (str): name of the sample to apply the function to, or "*" to
+                apply to all samples
+            systematic_name (str): name of the systematic to apply the function to, or
+               "*" to apply to all systematics
+            template (str): name of the template to apply the function to, "*" to
+                apply to all templates, or None to apply to nominal only
 
         Returns:
             Callable[[UserTemplateFunc], UserTemplateFunc]: the function to
             register a processor
         """
-        if region_name is None:
-            region_name = "*"
-        if sample_name is None:
-            sample_name = "*"
-        if systematic_name is None:
-            systematic_name = "*"
-        if template is None:
-            template = "*"
 
         def _register(func: UserTemplateFunc) -> UserTemplateFunc:
             """Registers a processor function to be applied when matching a pattern.
@@ -117,10 +118,10 @@ class Router:
 
     def register_template_builder(
         self,
-        region_name: Optional[str] = None,
-        sample_name: Optional[str] = None,
-        systematic_name: Optional[str] = None,
-        template: Optional[str] = None,
+        region_name: str = "*",
+        sample_name: str = "*",
+        systematic_name: str = "*",
+        template: Optional[str] = "*",
     ) -> Callable[[UserTemplateFunc], UserTemplateFunc]:
         """Decorator for registering a template builder function.
 
@@ -128,14 +129,15 @@ class Router:
         variable.
 
         Args:
-            region_name (Optional[str], optional): name of the region to apply the
-                function to, defaults to None (apply to all regions)
-            sample_name (Optional[str], optional): name of the sample to apply the
-                function to, defaults to None (apply to all samples)
-            systematic_name (Optional[str], optional): name of the systematic to apply
-                the function to, defaults to None (apply to all systematics)
+            region_name (str, optional): name of the region to apply the function to,
+                defaults to "*" (apply to all regions)
+            sample_name (str, optional): name of the sample to apply the function to,
+                defaults to "*" (apply to all samples)
+            systematic_name (str, optional): name of the systematic to apply the
+                function to, defaults to "*" (apply to all systematics)
             template (Optional[str], optional): name of the template to apply the
-                function to, defaults to None (apply to all templates)
+                function to (e.g. "Up" or "Down"), or None to apply to nominal only,
+                defaults to "*" (apply to all templates, including nominal)
 
         Returns:
             Callable[[UserTemplateFunc], UserTemplateFunc]: the function to register a
@@ -151,7 +153,7 @@ class Router:
         region_name: str,
         sample_name: str,
         systematic_name: str,
-        template: str,
+        template: Optional[Literal["Up", "Down"]],
     ) -> Optional[UserTemplateFunc]:
         """Returns a function matching the provided specification.
 
@@ -162,8 +164,9 @@ class Router:
             processor_list (List[Dict[str, Any]]): list of processors to search in
             region_name (str): region name
             sample_name (str): sample name
-            systematic_name (str): systematic name
-            template (str): template name
+            systematic_name (str): systematic name (can use empty string for nominal)
+            template (Optional[Literal["Up", "Down"]]): template name ("Up", "Down"), or
+                None for nominal
 
         Returns:
             Optional[UserTemplateFunc]: processor function matching the description,
@@ -176,7 +179,24 @@ class Router:
             systematic_matches = fnmatch.fnmatch(
                 systematic_name, processor["systematic"]
             )
-            template_matches = fnmatch.fnmatch(template, processor["template"])
+            # template can only be None (nominal), "Up", "Down"
+            # processor["template"] can be
+            #   - None: apply to nominal only
+            #   - "*": apply to all templates
+            #   - another string: do normal matching, can never match nominal then
+            if template is None:
+                # nominal template is matched by processors applying nominal templates,
+                # and by processors applying to all templates
+                template_matches = (processor["template"] is None) or (
+                    processor["template"] == "*"
+                )
+            elif processor["template"] is None:
+                # template is not None (nominal), but processor is None (nominal), so it
+                # does not match
+                template_matches = False
+            else:
+                # neither template nor processor are none, can do normal matching
+                template_matches = fnmatch.fnmatch(template, processor["template"])
             if (
                 region_matches
                 and sample_matches
@@ -195,7 +215,11 @@ class Router:
         return matches[0]
 
     def _find_template_builder_match(
-        self, region_name: str, sample_name: str, systematic_name: str, template: str
+        self,
+        region_name: str,
+        sample_name: str,
+        systematic_name: str,
+        template: Optional[Literal["Up", "Down"]],
     ) -> Optional[ProcessorFunc]:
         """Returns wrapped template builder function matching provided specification.
 
@@ -205,8 +229,9 @@ class Router:
         Args:
             region_name (str): region name
             sample_name (str): sample name
-            systematic_name (str): systematic name
-            template (str): template name
+            systematic_name (str): systematic name (can use empty string for nominal)
+            template (Optional[Literal["Up", "Down"]]): template name ("Up", "Down"), or
+                None for nominal
 
         Raises:
             ValueError: when no template wrapper is set
@@ -243,7 +268,7 @@ def apply_to_all_templates(
     - the dict specifying region information
     - the dict specifying sample information
     - the dict specifying systematic information
-    - name of the template being considered: "Nominal", "Up", "Down"
+    - the template being considered: "Up", "Down", or None for the nominal template
 
     In addition it is possible to specify a function that returns custom overrides. If
     one is found for a given template, it is used instead of the default.
@@ -264,11 +289,12 @@ def apply_to_all_templates(
             # region dependence of sample is checked below via histogram_is_needed
 
             # loop over nominal templates and all existing systematics
-            for systematic in [{"Name": "Nominal"}] + config.get("Systematics", []):
+            for systematic in [{}] + config.get("Systematics", []):
                 # determine how many templates need to be considered
-                if systematic["Name"] == "Nominal":
+                templates: List[Optional[Literal["Up", "Down"]]]
+                if systematic == {}:
                     # only nominal template is needed
-                    templates = ["Nominal"]
+                    templates = [None]
                 else:
                     # systematics can have up and down template
                     templates = ["Up", "Down"]
@@ -287,16 +313,18 @@ def apply_to_all_templates(
                         continue
 
                     log.debug(
-                        f"      variation {systematic['Name']}"
-                        f"{' ' + template if template != 'Nominal' else ''}"
+                        f"      variation "
+                        f"{systematic['Name'] if systematic != {} else 'Nominal'}"
+                        f"{' ' + template if template is not None else ''}"
                     )
 
                     func_override = None
                     if match_func is not None:
                         # check whether a user-defined function was registered that
                         # matches this region-sample-systematic-template
+                        systematic_name = systematic["Name"] if systematic != {} else ""
                         func_override = match_func(
-                            region["Name"], sample["Name"], systematic["Name"], template
+                            region["Name"], sample["Name"], systematic_name, template
                         )
                     if func_override is not None:
                         # call the user-defined function

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -195,7 +195,7 @@ class Router:
                 # does not match
                 template_matches = False
             else:
-                # neither template nor processor are none, can do normal matching
+                # neither template nor processor are None, can do normal matching
                 template_matches = fnmatch.fnmatch(template, processor["template"])
             if (
                 region_matches

--- a/src/cabinetry/schemas/config.json
+++ b/src/cabinetry/schemas/config.json
@@ -216,8 +216,7 @@
             "properties": {
                 "Name": {
                     "description": "name of the systematic uncertainty",
-                    "type": "string",
-                    "not": {"const": "Nominal", "$comment": "systematics may not be called \"Nominal\""}
+                    "type": "string"
                 },
                 "Type": {
                     "description": "type of systematic uncertainty",

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -11,6 +11,7 @@ from cabinetry import histo
 from cabinetry import route
 from cabinetry._typing import Literal
 
+
 log = logging.getLogger(__name__)
 
 

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -26,7 +26,7 @@ def _check_for_override(
 
     Args:
         systematic (Dict[str, Any]): containing all systematic information
-        template (Literal["Up", "Down"]): template to consider: "Up" or "Down"
+        template (Literal["Up", "Down"]): template considered: "Up" or "Down"
         option (str): the option for which the presence of an override is checked
 
     Returns:

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -9,13 +9,13 @@ import numpy as np
 from cabinetry import configuration
 from cabinetry import histo
 from cabinetry import route
-
+from cabinetry._typing import Literal
 
 log = logging.getLogger(__name__)
 
 
 def _check_for_override(
-    systematic: Dict[str, Any], template: str, option: str
+    systematic: Dict[str, Any], template: Literal["Up", "Down"], option: str
 ) -> Optional[Union[str, List[str]]]:
     """Returns an override if specified by a template of a systematic.
 
@@ -25,7 +25,7 @@ def _check_for_override(
 
     Args:
         systematic (Dict[str, Any]): containing all systematic information
-        template (str): template to consider: "Nominal", "Up", "Down"
+        template (Literal["Up", "Down"]): template to consider: "Up" or "Down"
         option (str): the option for which the presence of an override is checked
 
     Returns:
@@ -40,7 +40,7 @@ def _get_ntuple_paths(
     region: Dict[str, Any],
     sample: Dict[str, Any],
     systematic: Dict[str, Any],
-    template: str,
+    template: Optional[Literal["Up", "Down"]],
 ) -> List[pathlib.Path]:
     """Returns the paths to ntuples for a region-sample-systematic-template.
 
@@ -57,7 +57,8 @@ def _get_ntuple_paths(
         region (Dict[str, Any]): containing all region information
         sample (Dict[str, Any]): containing all sample information
         systematic (Dict[str, Any]): containing all systematic information
-        template (str): which template is considered: "Nominal", "Up", "Down"
+        template (Optional[Literal["Up", "Down"]]): template considered: "Up", "Down",
+            or None for nominal
 
     Returns:
         List[pathlib.Path]: list of paths to ntuples
@@ -67,7 +68,7 @@ def _get_ntuple_paths(
     sample_paths = sample.get("SamplePaths", None)
 
     # check whether a systematic is being processed, and whether overrides exist
-    if systematic.get("Name", "Nominal") != "Nominal":
+    if template is not None:
         # determine whether the template has an override for RegionPath specified
         region_override = _check_for_override(systematic, template, "RegionPath")
         if region_override is not None:
@@ -115,7 +116,7 @@ def _get_variable(
     region: Dict[str, Any],
     sample: Dict[str, Any],
     systematic: Dict[str, Any],
-    template: str,
+    template: Optional[Literal["Up", "Down"]],
 ) -> str:
     """Returns the variable the histogram will be binned in.
 
@@ -126,14 +127,15 @@ def _get_variable(
         region (Dict[str, Any]): containing all region information
         sample (Dict[str, Any]): containing all sample information
         systematic (Dict[str, Any]): containing all systematic information
-        template (str): which template is considered: "Nominal", "Up", "Down"
+        template (Optional[Literal["Up", "Down"]]): template considered: "Up", "Down",
+            or None for nominal
 
     Returns:
         str: name of variable to bin histogram in
     """
     axis_variable = region["Variable"]
     # check whether a systematic is being processed
-    if systematic.get("Name", "Nominal") != "Nominal":
+    if template is not None:
         # determine whether the template has an override specified
         axis_variable_override = _check_for_override(systematic, template, "Variable")
         if axis_variable_override is not None:
@@ -145,7 +147,7 @@ def _get_filter(
     region: Dict[str, Any],
     sample: Dict[str, Any],
     systematic: Dict[str, Any],
-    template: str,
+    template: Optional[Literal["Up", "Down"]],
 ) -> Optional[str]:
     """Returns the filter to be applied for event selection.
 
@@ -156,14 +158,15 @@ def _get_filter(
         region (Dict[str, Any]): containing all region information
         sample (Dict[str, Any]): containing all sample information
         systematic (Dict[str, Any]): containing all systematic information
-        template (str): which template is considered: "Nominal", "Up", "Down"
+        template (Optional[Literal["Up", "Down"]]): template considered: "Up", "Down",
+            or None for nominal
 
     Returns:
         Optional[str]: expression for the filter to be used, or None for no filtering
     """
     selection_filter = region.get("Filter", None)
     # check whether a systematic is being processed
-    if systematic.get("Name", "Nominal") != "Nominal":
+    if template is not None:
         # determine whether the template has an override specified
         selection_filter_override = _check_for_override(systematic, template, "Filter")
         if selection_filter_override is not None:
@@ -175,7 +178,7 @@ def _get_weight(
     region: Dict[str, Any],
     sample: Dict[str, Any],
     systematic: Dict[str, Any],
-    template: str,
+    template: Optional[Literal["Up", "Down"]],
 ) -> Optional[str]:
     """Returns the weight to be used for events in histograms.
 
@@ -186,7 +189,8 @@ def _get_weight(
         region (Dict[str, Any]): containing all region information
         sample (Dict[str, Any]): containing all sample information
         systematic (Dict[str, Any]): containing all systematic information
-        template (str): which template is considered: "Nominal", "Up", "Down"
+        template (Optional[Literal["Up", "Down"]]): template considered: "Up", "Down",
+            or None for nominal
 
     Returns:
         Optional[str]: weight used for events when filled into histograms, or None for
@@ -194,7 +198,7 @@ def _get_weight(
     """
     weight = sample.get("Weight", None)
     # check whether a systematic is being processed
-    if systematic.get("Name", "Nominal") != "Nominal":
+    if template is not None:
         # determine whether the template has an override specified
         weight_override = _check_for_override(systematic, template, "Weight")
         if weight_override is not None:
@@ -203,7 +207,9 @@ def _get_weight(
 
 
 def _get_position_in_file(
-    sample: Dict[str, Any], systematic: Dict[str, Any], template: str
+    sample: Dict[str, Any],
+    systematic: Dict[str, Any],
+    template: Optional[Literal["Up", "Down"]],
 ) -> str:
     """Returns the location of data within a file (e.g. a tree name).
 
@@ -213,14 +219,15 @@ def _get_position_in_file(
     Args:
         sample (Dict[str, Any]): containing all sample information
         systematic (Dict[str, Any]): containing all systematic information
-        template (str): which template is considered: "Nominal", "Up", "Down"
+        template (Optional[Literal["Up", "Down"]]): template considered: "Up", "Down",
+            or None for nominal
 
     Returns:
         str: where in the file to find the data (the name of a tree)
     """
     position = sample["Tree"]
     # check whether a systematic is being processed
-    if systematic.get("Name", "Nominal") != "Nominal":
+    if template is not None:
         # determine whether the template has an override specified
         position_override = _check_for_override(systematic, template, "Tree")
         if position_override is not None:
@@ -271,7 +278,7 @@ class _Builder:
         region: Dict[str, Any],
         sample: Dict[str, Any],
         systematic: Dict[str, Any],
-        template: str,
+        template: Optional[Literal["Up", "Down"]],
     ) -> None:
         """Creates a histogram and writes it to a file.
 
@@ -279,10 +286,11 @@ class _Builder:
         the argument.
 
         Args:
-            region (Dict[str, Any]): specifying region information
-            sample (Dict[str, Any]): specifying sample information
-            systematic (Dict[str, Any]): specifying systematic information
-            template (str): name of the template: "Nominal", "Up", "Down"
+            region (Dict[str, Any]): containing all region information
+            sample (Dict[str, Any]): containing all sample information
+            systematic (Dict[str, Any]): containing all systematic information
+            template (Optional[Literal["Up", "Down"]]): template considered: "Up",
+                "Down", or None for nominal
 
         Raises:
             NotImplementedError: when requesting an unknown backend
@@ -322,16 +330,17 @@ class _Builder:
         region: Dict[str, Any],
         sample: Dict[str, Any],
         systematic: Dict[str, Any],
-        template: str,
+        template: Optional[Literal["Up", "Down"]],
     ) -> None:
         """Generates a unique name for a histogram and saves the histogram.
 
         Args:
             histogram (histo.Histogram): histogram to save
-            region (Dict[str, Any]): dict with region information
-            sample (Dict[str, Any]): dict with sample information
-            systematic (Dict[str, Any]): dict with systematic information
-            template (str): name of the template: "Nominal", "Up", "Down"
+            region (Dict[str, Any]): containing all region information
+            sample (Dict[str, Any]): containing all sample information
+            systematic (Dict[str, Any]): containing all systematic
+            template (Optional[Literal["Up", "Down"]]): template considered: "Up",
+                "Down", or None for nominal
         """
         # generate a name for the histogram
         histogram_name = histo.build_name(region, sample, systematic, template)
@@ -365,7 +374,7 @@ class _Builder:
             region: Dict[str, Any],
             sample: Dict[str, Any],
             systematic: Dict[str, Any],
-            template: str,
+            template: Optional[Literal["Up", "Down"]],
         ) -> None:
             """Executes a user-defined function that returns a histogram and saves it.
 
@@ -373,10 +382,11 @@ class _Builder:
             wrapped with this.
 
             Args:
-                region (Dict[str, Any]): dict with region information
-                sample (Dict[str, Any]): dict with sample information
-                systematic (Dict[str, Any]): dict with systematic information
-                template (str): name of the template: "Nominal", "Up", "Down"
+                region (Dict[str, Any]): containing all region information
+                sample (Dict[str, Any]): containing all sample information
+                systematic (Dict[str, Any]): containing all systematic information
+                template (Optional[Literal["Up", "Down"]]): template considered: "Up",
+                    "Down", or None for nominal
             """
             histogram = func(region, sample, systematic, template)
             if not isinstance(histogram, bh.Histogram):

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -164,7 +164,9 @@ def _get_postprocessor(histogram_folder: pathlib.Path) -> route.ProcessorFunc:
         if smoothing_algorithm is None:
             nominal_histogram = None
         else:
-            # to apply smoothing, the associated nominal histogram is needed
+            # to apply smoothing, the associated nominal histogram is needed (smoothing
+            # can currently not be applied to nominal itself, but for systematics is
+            # applied to the ratio variation / nominal)
             nominal_histogram = histo.Histogram.from_config(
                 histogram_folder, region, sample, {}, modified=False
             )

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -9,6 +9,7 @@ from cabinetry import configuration
 from cabinetry import histo
 from cabinetry import route
 from cabinetry import smooth
+from cabinetry._typing import Literal
 
 
 log = logging.getLogger(__name__)
@@ -59,9 +60,9 @@ def _get_smoothing_algorithm(
     """Returns name of algorithm to use for smoothing, or None otherwise.
 
     Args:
-        region (Dict[str, Any]): specifying region information
-        sample (Dict[str, Any]): specifying sample information
-        systematic (Dict[str, Any]): specifying systematic information
+        region (Dict[str, Any]): containing all region information
+        sample (Dict[str, Any]): containing all sample information
+        systematic (Dict[str, Any]): containing all systematic information
 
     Returns:
         Optional[str]: name of smoothing algorithm or None
@@ -138,15 +139,16 @@ def _get_postprocessor(histogram_folder: pathlib.Path) -> route.ProcessorFunc:
         region: Dict[str, Any],
         sample: Dict[str, Any],
         systematic: Dict[str, Any],
-        template: str,
+        template: Optional[Literal["Up", "Down"]],
     ) -> None:
         """Applies post-processing to a single histogram.
 
         Args:
-            region (Dict[str, Any]): specifying region information
-            sample (Dict[str, Any]): specifying sample information
-            systematic (Dict[str, Any]): specifying systematic information
-            template (str): name of the template: "Nominal", "Up", "Down"
+            region (Dict[str, Any]): containing all region information
+            sample (Dict[str, Any]): containing all sample information
+            systematic (Dict[str, Any]): containing all systematic information
+            template (Optional[Literal["Up", "Down"]]): template considered: "Up",
+                "Down", or None for nominal
         """
         histogram = histo.Histogram.from_config(
             histogram_folder,
@@ -164,7 +166,7 @@ def _get_postprocessor(histogram_folder: pathlib.Path) -> route.ProcessorFunc:
         else:
             # to apply smoothing, the associated nominal histogram is needed
             nominal_histogram = histo.Histogram.from_config(
-                histogram_folder, region, sample, {"Name": "Nominal"}, modified=False
+                histogram_folder, region, sample, {}, modified=False
             )
 
         new_histogram = apply_postprocessing(

--- a/src/cabinetry/visualize/__init__.py
+++ b/src/cabinetry/visualize/__init__.py
@@ -493,10 +493,7 @@ def templates(
 
                 # extract nominal histogram
                 nominal_histo = histo.Histogram.from_config(
-                    histogram_folder,
-                    region,
-                    sample,
-                    {},
+                    histogram_folder, region, sample, {}
                 )
                 bins = nominal_histo.bins
                 variable = region["Variable"]

--- a/src/cabinetry/visualize/__init__.py
+++ b/src/cabinetry/visualize/__init__.py
@@ -87,7 +87,7 @@ def data_MC_from_histograms(
         for sample in config["Samples"][::-1]:
             is_data = sample.get("Data", False)
             histogram = histo.Histogram.from_config(
-                histogram_folder, region, sample, {"Name": "Nominal"}, modified=True
+                histogram_folder, region, sample, {}, modified=True
             )
             histogram_dict_list.append(
                 {
@@ -496,7 +496,7 @@ def templates(
                     histogram_folder,
                     region,
                     sample,
-                    {"Name": "Nominal"},
+                    {},
                 )
                 bins = nominal_histo.bins
                 variable = region["Variable"]

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -74,13 +74,13 @@ class WorkspaceBuilder:
             region (Dict[str, Any]): specific region to use
             sample (Dict[str, Any]): specific sample to use
             systematic (Optional[Dict[str, Any]], optional): specific systematic
-                variation to use, defaults to None -> {"Name": "Nominal"}
+                variation to use, defaults to None (nominal)
 
         Returns:
             List[float]: yields per bin for the sample
         """
         if systematic is None:
-            systematic = {"Name": "Nominal"}
+            systematic = {}
 
         histogram = histo.Histogram.from_config(
             self.histogram_folder, region, sample, systematic, modified=True
@@ -100,13 +100,13 @@ class WorkspaceBuilder:
             region (Dict[str, Any]): specific region to use
             sample (Dict[str, Any]): specific sample to use
             systematic (Optional[Dict[str, Any]], optional): specific systematic
-                variation to use, defaults to None -> {"Name": "Nominal"}
+                variation to use, defaults to None (nominal)
 
         Returns:
             List[float]: statistical uncertainty of yield per bin for the sample
         """
         if systematic is None:
-            systematic = {"Name": "Nominal"}
+            systematic = {}
 
         histogram = histo.Histogram.from_config(
             self.histogram_folder, region, sample, systematic, modified=True
@@ -202,7 +202,7 @@ class WorkspaceBuilder:
 
         # also need the nominal histogram
         histogram_nominal = histo.Histogram.from_config(
-            self.histogram_folder, region, sample, {"Name": "Nominal"}, modified=True
+            self.histogram_folder, region, sample, {}, modified=True
         )
 
         if systematic.get("Down", {}).get("Symmetrize", False):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -184,11 +184,11 @@ def test_sample_contains_modifier(sample_and_modifier, contained):
     "reg_sam_sys_tem, is_needed",
     [
         # nominal
-        (({}, {}, {"Name": "Nominal"}, "Nominal"), True),
+        (({}, {}, {"Name": "abc"}, None), True),
         # non-nominal data
-        (({}, {"Data": True}, {"Name": "var"}, ""), False),
+        (({}, {"Data": True}, {"Name": "var"}, "Up"), False),
         # overall normalization variation
-        (({}, {}, {"Type": "Normalization"}, ""), False),
+        (({}, {}, {"Type": "Normalization"}, "Up"), False),
         # normalization + shape variation
         (({}, {"Name": "Signal"}, {"Type": "NormPlusShape"}, "Up"), True),
         # normalization + shape variation on specified and affected sample
@@ -207,7 +207,7 @@ def test_sample_contains_modifier(sample_and_modifier, contained):
                 {},
                 {"Name": "Background"},
                 {"Type": "NormPlusShape", "Samples": "Signal"},
-                "",
+                "Up",
             ),
             False,
         ),
@@ -244,7 +244,7 @@ def test_sample_contains_modifier(sample_and_modifier, contained):
                 {"Name": "CR"},
                 {"Name": "Signal", "Regions": "SR"},
                 {"Type": "NormPlusShape"},
-                "Nominal",
+                None,
             ),
             False,
         ),
@@ -254,7 +254,7 @@ def test_sample_contains_modifier(sample_and_modifier, contained):
                 {"Name": "CR"},
                 {"Name": "Signal", "Regions": "CR"},
                 {"Type": "NormPlusShape"},
-                "Nominal",
+                None,
             ),
             True,
         ),
@@ -290,7 +290,7 @@ def test_histogram_is_needed(reg_sam_sys_tem, is_needed):
 def test_histogram_is_needed_unknown():
     # non-supported systematic
     with pytest.raises(ValueError, match="unknown systematics type: unknown"):
-        configuration.histogram_is_needed({}, {}, {"Type": "unknown"}, "")
+        configuration.histogram_is_needed({}, {}, {"Type": "unknown"}, "Up")
 
 
 def test_get_region_dict(caplog):

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -146,12 +146,12 @@ def test_Histogram_from_path(tmp_path, caplog, example_histograms, histogram_hel
 
 def test_Histogram_from_config(tmp_path, example_histograms, histogram_helpers):
     h_ref = histo.Histogram.from_arrays(*example_histograms.normal())
-    histo_path = tmp_path / "region_sample_Nominal.npz"
+    histo_path = tmp_path / "region_sample.npz"
     h_ref.save(histo_path)
 
     region = {"Name": "region"}
     sample = {"Name": "sample"}
-    systematic = {"Name": "Nominal"}
+    systematic = {}
     h_from_path = histo.Histogram.from_config(
         tmp_path, region, sample, systematic, modified=False
     )
@@ -225,13 +225,18 @@ def test_build_name():
     systematic = {"Name": "Systematic"}
     template = "Up"
     assert (
-        histo.build_name(region, sample, systematic, template)
+        histo.build_name(region, sample, systematic, template=template)
         == "Region_Sample_Systematic_Up"
     )
 
+    # no template specified
     region = {"Name": "Region 1"}
     sample = {"Name": "Sample 1"}
     systematic = {"Name": "Systematic 1"}
+    assert histo.build_name(region, sample, systematic) == "Region-1_Sample-1"
+
+    # nominal template requested explicitly
     assert (
-        histo.build_name(region, sample, systematic) == "Region-1_Sample-1_Systematic-1"
+        histo.build_name(region, sample, systematic, template=None)
+        == "Region-1_Sample-1"
     )

--- a/tests/test_template_postprocessor.py
+++ b/tests/test_template_postprocessor.py
@@ -188,7 +188,7 @@ def test__get_postprocessor(mock_name):
                 ]
 
             # nominal histogram was read
-            assert mock_from_config.call_args[0][3] == {"Name": "Nominal"}
+            assert mock_from_config.call_args[0][3] == {}
 
             # postprocessing called with smoothing algorithm and nominal histogram
             assert mock_postprocessing.call_args == (

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -77,12 +77,7 @@ def test_WorkspaceBuilder_get_yield_for_sample(mock_histogram):
 
     assert mock_histogram.call_args_list == [
         (
-            (
-                pathlib.Path("path"),
-                {"Name": "region"},
-                {"Name": "signal"},
-                {"Name": "Nominal"},
-            ),
+            (pathlib.Path("path"), {"Name": "region"}, {"Name": "signal"}, {}),
             {"modified": True},
         ),
         (
@@ -115,12 +110,7 @@ def test_WorkspaceBuilder_get_unc_for_sample(mock_histogram):
 
     assert mock_histogram.call_args_list == [
         (
-            (
-                pathlib.Path("path"),
-                {"Name": "region"},
-                {"Name": "signal"},
-                {"Name": "Nominal"},
-            ),
+            (pathlib.Path("path"), {"Name": "region"}, {"Name": "signal"}, {}),
             {"modified": True},
         ),
         (
@@ -239,10 +229,7 @@ def test_WorkspaceBuilder_get_NormPlusShape_modifiers(mock_histogram):
             (pathlib.Path("path"), region, sample, systematic),
             {"modified": True, "template": "Up"},
         ),
-        (
-            (pathlib.Path("path"), region, sample, {"Name": "Nominal"}),
-            {"modified": True},
-        ),
+        ((pathlib.Path("path"), region, sample, {}), {"modified": True}),
         (
             (pathlib.Path("path"), region, sample, systematic),
             {"modified": True, "template": "Down"},
@@ -270,10 +257,7 @@ def test_WorkspaceBuilder_get_NormPlusShape_modifiers(mock_histogram):
             (pathlib.Path("path"), region, sample, systematic),
             {"modified": True, "template": "Up"},
         ),
-        (
-            (pathlib.Path("path"), region, sample, {"Name": "Nominal"}),
-            {"modified": True},
-        ),
+        ((pathlib.Path("path"), region, sample, {}), {"modified": True}),
     ]
 
 

--- a/tests/visualize/test_visualize.py
+++ b/tests/visualize/test_visualize.py
@@ -59,7 +59,7 @@ def test_data_MC_from_histograms(mock_load, mock_draw, mock_stdev):
                 histogram_folder,
                 {"Name": "reg_1", "Variable": "x"},
                 {"Name": "data", "Data": True},
-                {"Name": "Nominal"},
+                {},
             ),
             {"modified": True},
         ),
@@ -68,7 +68,7 @@ def test_data_MC_from_histograms(mock_load, mock_draw, mock_stdev):
                 histogram_folder,
                 {"Name": "reg_1", "Variable": "x"},
                 {"Name": "sample_1"},
-                {"Name": "Nominal"},
+                {},
             ),
             {"modified": True},
         ),
@@ -477,9 +477,9 @@ def test_templates(mock_draw, mock_histo_config, mock_histo_path, tmp_path):
 
     visualize.templates(config, figure_folder=folder_path)
 
-    assert mock_histo_config.call_args_list == [
-        [(tmp_path, region, sample, {"Name": "Nominal"}), {}]
-    ]
+    # nominal histogram loading
+    assert mock_histo_config.call_args_list == [[(tmp_path, region, sample, {}), {}]]
+    # variation histograms
     down_path_orig = pathlib.Path(str(down_path).replace("_modified", ""))
     up_path_orig = pathlib.Path(str(up_path).replace("_modified", ""))
     assert mock_histo_path.call_args_list == [


### PR DESCRIPTION
The `cabinetry` internals previously used a placeholder for systematics via `{"Name": "Nominal"}` to indicate the nominal template being processed. This switches the treatment: "Nominal" is no longer treated as a reserved name (now possible to name systematics "Nominal" if desired), and the template choice is instead performed via the `template` arguments of functions. The two templates "Up" and "Down" are used throughout the code, and also referred to with the same name in the config. The "Nominal" template was previously used in some places, but this replaces this with `None` templates instead. If the template is `None`, that means the nominal setup is being considered.

The update requires slight changes in the custom template override API. Region/sample/systematic arguments can no longer be `None`, and default to `"*"` to match everything. The template argument can now be `None` to only match nominal templates. It defaults to `"*"`, matching all (including nominal) templates. Any other string cannot match nominal templates. The documentation has been updated to reflect this.

Typing for templates has been improved and been made more strict in a few places, taking advantage of `Literal` (which requires `typing_extensions` for Python 3.7).

**Breaking changes**:
- histogram naming has changed (`_Nominal` suffix for nominal templates no longer used)
- `cabinetry.route.Router.register_template_builder` API changed
  - no longer accepts `None` for region/sample/systematic, corresponding behavior is now achieved via `"*"` (default)
  - if template argument is `None`, now only nominal templates will be matched

```
* breaking change: behavior and defaults of cabinetry.route.Router.register_template_builder changed
* breaking change: histogram names for nominal templates changed
* template function arguments throughout cabinetry now control when nominal templates are being processed
* "Nominal" is no longer a reserved name for systematics
* added typing_extensions as dependency for Python 3.7
* small typing improvements for template arguments
```