### PR TITLE
build: list direct dependencies explicitly

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     tabulate>=0.8.1  # multiline text
     matplotlib
     typing_extensions;python_version<"3.8"  # for Literal type
-    # dependencies below are included via pyhf, listed explicitly since they are also direct dependencies of cabinetry
+    # below are direct dependencies of cabinetry, which are also included via pyhf[iminuit]
     numpy
     pyyaml
     iminuit

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,13 @@ install_requires =
     tabulate>=0.8.1  # multiline text
     matplotlib
     typing_extensions;python_version<"3.8"  # for Literal type
+    # dependencies below are included via pyhf, listed explicitly since they are also direct dependencies of cabinetry
+    numpy
+    pyyaml
+    iminuit
+    jsonschema
+    click
+    scipy
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Direct dependencies of `cabinetry` are now listed explicitly under `install_requires`. These dependencies are already provided via `pyhf`, and as such this change does not have an immediate effect. There are advantages to listing them explicitly anyway:
- in case `pyhf` decided to drop one of the dependencies, `cabinetry` would break, and this protects against that scenario,
- users can tell more easily which other libraries `cabinetry` makes direct use of,
- the dependency tree is more correct, as visualized e.g. by [`pipdeptree`](https://pypi.org/project/pipdeptree/).

The slightly more verbose `setup.cfg` seems like a negligible problem in comparison.

This partially reverts #168.

```
* explicitly require all direct dependencies of cabinetry via install_requires
```