### PR TITLE
refactor: streamline histogram loading

### DIFF
--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -96,8 +96,8 @@ class Histogram(bh.Histogram, family=cabinetry):
         region: Dict[str, Any],
         sample: Dict[str, Any],
         systematic: Dict[str, Any],
-        modified: bool = True,
         template: Optional[Literal["Up", "Down"]] = None,
+        modified: bool = True,
     ) -> H:
         """Loads a histogram, using information specified in the configuration file.
 
@@ -110,10 +110,10 @@ class Histogram(bh.Histogram, family=cabinetry):
             region (Dict[str, Any]): containing all region information
             sample (Dict[str, Any]): containing all sample information
             systematic (Dict[str, Any]): containing all systematic information
-            modified (bool, optional): whether to load the modified histogram (after
-                post-processing), defaults to True
             template (Optional[Literal["Up", "Down"]], optional): which template to
                 consider: "Up", "Down", None for the nominal case, defaults to None
+            modified (bool, optional): whether to load the modified histogram (after
+                post-processing), defaults to True
 
         Returns:
             cabinetry.histo.Histogram: the loaded histogram

--- a/src/cabinetry/template_postprocessor.py
+++ b/src/cabinetry/template_postprocessor.py
@@ -155,8 +155,8 @@ def _get_postprocessor(histogram_folder: pathlib.Path) -> route.ProcessorFunc:
             region,
             sample,
             systematic,
-            modified=False,
             template=template,
+            modified=False,
         )
         histogram_name = histo.build_name(region, sample, systematic, template)
 

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -62,58 +62,6 @@ class WorkspaceBuilder:
         )
         return fixed_value
 
-    def get_yield_for_sample(
-        self,
-        region: Dict[str, Any],
-        sample: Dict[str, Any],
-        systematic: Optional[Dict[str, Any]] = None,
-    ) -> List[float]:
-        """Returns the yield for a specific sample.
-
-        Args:
-            region (Dict[str, Any]): specific region to use
-            sample (Dict[str, Any]): specific sample to use
-            systematic (Optional[Dict[str, Any]], optional): specific systematic
-                variation to use, defaults to None (nominal)
-
-        Returns:
-            List[float]: yields per bin for the sample
-        """
-        if systematic is None:
-            systematic = {}
-
-        histogram = histo.Histogram.from_config(
-            self.histogram_folder, region, sample, systematic, modified=True
-        )
-        histo_yield = histogram.yields.tolist()
-        return histo_yield
-
-    def get_unc_for_sample(
-        self,
-        region: Dict[str, Any],
-        sample: Dict[str, Any],
-        systematic: Optional[Dict[str, Any]] = None,
-    ) -> List[float]:
-        """Returns the MC stat. uncertainty for a specific sample.
-
-        Args:
-            region (Dict[str, Any]): specific region to use
-            sample (Dict[str, Any]): specific sample to use
-            systematic (Optional[Dict[str, Any]], optional): specific systematic
-                variation to use, defaults to None (nominal)
-
-        Returns:
-            List[float]: statistical uncertainty of yield per bin for the sample
-        """
-        if systematic is None:
-            systematic = {}
-
-        histogram = histo.Histogram.from_config(
-            self.histogram_folder, region, sample, systematic, modified=True
-        )
-        histo_stdev = histogram.stdev.tolist()
-        return histo_stdev
-
     def get_NF_modifiers(
         self, region: Dict[str, Any], sample: Dict[str, Any]
     ) -> List[Dict[str, Any]]:
@@ -206,9 +154,7 @@ class WorkspaceBuilder:
         )
 
         if systematic.get("Down", {}).get("Symmetrize", False):
-            # add support for two-sided variations that do not require symmetrization
             # if symmetrization is desired, should support different implementations
-
             # symmetrization according to "method 1" from issue #26:
             # first normalization, then symmetrization
 
@@ -328,21 +274,23 @@ class WorkspaceBuilder:
                     # current region does not contain this sample, so skip it
                     continue
 
-                # yield of the samples
-                histo_yield = self.get_yield_for_sample(region, sample)
+                sample_hist = histo.Histogram.from_config(
+                    self.histogram_folder, region, sample, {}, modified=True
+                )
+
+                # yield of the sample
                 current_sample = {}
                 current_sample.update({"name": sample["Name"]})
-                current_sample.update({"data": histo_yield})
+                current_sample.update({"data": sample_hist.yields.tolist()})
 
                 # collect all modifiers for the sample
                 modifiers = []
 
                 # gammas
-                stat_unc = self.get_unc_for_sample(region, sample)
                 gammas = {}
                 gammas.update({"name": "staterror_" + region["Name"].replace(" ", "-")})
                 gammas.update({"type": "staterror"})
-                gammas.update({"data": stat_unc})
+                gammas.update({"data": sample_hist.stdev.tolist()})
                 modifiers.append(gammas)
 
                 # modifiers can have region and sample dependence, which is checked
@@ -426,7 +374,9 @@ class WorkspaceBuilder:
         observations = []
         for region in self.config["Regions"]:
             observation = {}
-            histo_yield = self.get_yield_for_sample(region, data_sample)
+            histo_yield = histo.Histogram.from_config(
+                self.histogram_folder, region, data_sample, {}, modified=True
+            ).yields.tolist()
             observation.update({"name": region["Name"]})
             observation.update({"data": histo_yield})
             observations.append(observation)

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -196,8 +196,8 @@ class WorkspaceBuilder:
             region,
             sample,
             systematic,
-            modified=True,
             template="Up",
+            modified=True,
         )
 
         # also need the nominal histogram
@@ -232,8 +232,8 @@ class WorkspaceBuilder:
                 region,
                 sample,
                 systematic,
-                modified=True,
                 template="Down",
+                modified=True,
             )
             norm_effect_up = sum(histogram_up.yields) / sum(histogram_nominal.yields)
             norm_effect_down = sum(histogram_down.yields) / sum(

--- a/tests/test_histo.py
+++ b/tests/test_histo.py
@@ -145,6 +145,7 @@ def test_Histogram_from_path(tmp_path, caplog, example_histograms, histogram_hel
 
 
 def test_Histogram_from_config(tmp_path, example_histograms, histogram_helpers):
+    # could mock build_name here
     h_ref = histo.Histogram.from_arrays(*example_histograms.normal())
     histo_path = tmp_path / "region_sample.npz"
     h_ref.save(histo_path)
@@ -154,6 +155,16 @@ def test_Histogram_from_config(tmp_path, example_histograms, histogram_helpers):
     systematic = {}
     h_from_path = histo.Histogram.from_config(
         tmp_path, region, sample, systematic, modified=False
+    )
+    histogram_helpers.assert_equal(h_ref, h_from_path)
+
+    # non-nominal and modified template
+    histo_path = tmp_path / "region_sample_sys_Up_modified.npz"
+    h_ref.save(histo_path)
+
+    systematic = {"Name": "sys"}
+    h_from_path = histo.Histogram.from_config(
+        tmp_path, region, sample, systematic, template="Up"
     )
     histogram_helpers.assert_equal(h_ref, h_from_path)
 

--- a/tests/test_template_postprocessor.py
+++ b/tests/test_template_postprocessor.py
@@ -158,7 +158,7 @@ def test__get_postprocessor(mock_name):
             assert mock_from_config.call_args_list == [
                 (
                     (pathlib.Path("path"), region, sample, systematic),
-                    {"modified": False, "template": template},
+                    {"template": template, "modified": False},
                 )
             ]  # histogram was created
 


### PR DESCRIPTION
Histogram loading in the `workspace` module made (in a few cases) use of two functions `workspace.WorkspaceBuilder.get_yield_for_sample` and `workspace.WorkspaceBuilder.get_unc_for_sample`. These functions were thin wrappers around `histo.Histogram.from_config`, and did not properly support loading histograms for systematic variations. Following the refactoring in #260, these functions are now dropped in favor of using `histo.Histogram.from_config` directly. They did not offer sufficient extra convenience to justify their existence, and loading yields / uncertainties separately was inefficient.

The `histo.Histogram.from_config` interface changes very slightly: the keyword arguments `template` and `modified` switch places.

**Breaking changes:**
- removed `workspace.WorkspaceBuilder.get_yield_for_sample` and `get_unc_for_sample`
- `histo.Histogram.from_config` keyword arguments `template` and `modified` flipped

```
* breaking change: removed workspace.WorkspaceBuilder.get_yield_for_sample and get_unc_for_sample
* breaking change: keyword arguments for histo.Histogram.from_config flipped
* refactored histogram loading in workspace module
```