### PR TITLE
feat: close single figures by default

### DIFF
--- a/src/cabinetry/visualize/__init__.py
+++ b/src/cabinetry/visualize/__init__.py
@@ -386,7 +386,7 @@ def correlation_matrix(
             figures in, defaults to "figures"
         pruning_threshold (float, optional): minimum correlation for a parameter to
             have with any other parameters to not get pruned, defaults to 0.0
-        close_figure (bool, optional): whether to close each figure, defaults to True
+        close_figure (bool, optional): whether to close figure, defaults to True
         save_figure (bool, optional): whether to save figure, defaults to True
 
     Returns:
@@ -440,7 +440,7 @@ def pulls(
             figures in, defaults to "figures"
         exclude (Optional[Union[str, List[str], Tuple[str, ...]]], optional): parameter
             or parameters to exclude from plot, defaults to None (nothing excluded)
-        close_figure (bool, optional): whether to close each figure, defaults to True
+        close_figure (bool, optional): whether to close figure, defaults to True
         save_figure (bool, optional): whether to save figure, defaults to True
 
     Returns:
@@ -500,7 +500,7 @@ def ranking(
             figures in, defaults to "figures"
         max_pars (Optional[int], optional): number of parameters to include, defaults to
             None (which means all parameters are included)
-        close_figure (bool, optional): whether to close each figure, defaults to True
+        close_figure (bool, optional): whether to close figure, defaults to True
         save_figure (bool, optional): whether to save figure, defaults to True
 
     Returns:
@@ -560,7 +560,7 @@ def scan(
         scan_results (fit.ScanResults): results of a likelihood scan
         figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
             figures in, defaults to "figures"
-        close_figure (bool, optional): whether to close each figure, defaults to True
+        close_figure (bool, optional): whether to close figure, defaults to True
         save_figure (bool, optional): whether to save figure, defaults to True
 
     Returns:
@@ -597,7 +597,7 @@ def limit(
         limit_results (fit.LimitResults): results of upper limit determination
         figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
             figures in, defaults to "figures"
-        close_figure (bool, optional): whether to close each figure, defaults to True
+        close_figure (bool, optional): whether to close figure, defaults to True
         save_figure (bool, optional): whether to save figure, defaults to True
 
     Returns:

--- a/src/cabinetry/visualize/__init__.py
+++ b/src/cabinetry/visualize/__init__.py
@@ -69,9 +69,9 @@ def data_mc_from_histograms(
             defaults to None (automatically determine whether to use linear/log scale)
         log_scale_x (bool, optional): whether to use logarithmic horizontal axis,
             defaults to False
-        close_figure (bool, optional): whether to close each figure immediately after
-            saving it, defaults to False (enable when producing many figures to avoid
-            memory issues, prevents rendering in notebooks)
+        close_figure (bool, optional): whether to close each figure, defaults to False
+            (enable when producing many figures to avoid memory issues, prevents
+            automatic rendering in notebooks)
         save_figure (bool, optional): whether to save figures, defaults to True
 
     Returns:
@@ -156,9 +156,9 @@ def data_mc(
             defaults to False
         channels (Optional[Union[str, List[str]]], optional): name of channel to show,
             or list of names to include, defaults to None (uses all channels)
-        close_figure (bool, optional): whether to close each figure immediately after
-            saving it, defaults to False (enable when producing many figures to avoid
-            memory issues, prevents rendering in notebooks)
+        close_figure (bool, optional): whether to close each figure, defaults to False
+            (enable when producing many figures to avoid memory issues, prevents
+            automatic rendering in notebooks)
         save_figure (bool, optional): whether to save figures, defaults to True
 
     Returns:
@@ -254,9 +254,9 @@ def templates(
         config (Dict[str, Any]): cabinetry configuration
         figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
             figures in, defaults to "figures"
-        close_figure (bool, optional): whether to close each figure immediately after
-            saving it, defaults to False (enable when producing many figures to avoid
-            memory issues, prevents rendering in notebooks)
+        close_figure (bool, optional): whether to close each figure, defaults to False
+            (enable when producing many figures to avoid memory issues, prevents
+            automatic rendering in notebooks)
         save_figure (bool, optional): whether to save figures, defaults to True
 
     Returns:
@@ -374,7 +374,7 @@ def correlation_matrix(
     fit_results: fit.FitResults,
     figure_folder: Union[str, pathlib.Path] = "figures",
     pruning_threshold: float = 0.0,
-    close_figure: bool = False,
+    close_figure: bool = True,
     save_figure: bool = True,
 ) -> mpl.figure.Figure:
     """Draws a correlation matrix.
@@ -386,9 +386,7 @@ def correlation_matrix(
             figures in, defaults to "figures"
         pruning_threshold (float, optional): minimum correlation for a parameter to
             have with any other parameters to not get pruned, defaults to 0.0
-        close_figure (bool, optional): whether to close each figure immediately after
-            saving it, defaults to False (enable when producing many figures to avoid
-            memory issues, prevents rendering in notebooks)
+        close_figure (bool, optional): whether to close each figure, defaults to True
         save_figure (bool, optional): whether to save figure, defaults to True
 
     Returns:
@@ -430,7 +428,7 @@ def pulls(
     fit_results: fit.FitResults,
     figure_folder: Union[str, pathlib.Path] = "figures",
     exclude: Optional[Union[str, List[str], Tuple[str, ...]]] = None,
-    close_figure: bool = False,
+    close_figure: bool = True,
     save_figure: bool = True,
 ) -> mpl.figure.Figure:
     """Draws a pull plot of parameter results and uncertainties.
@@ -442,9 +440,7 @@ def pulls(
             figures in, defaults to "figures"
         exclude (Optional[Union[str, List[str], Tuple[str, ...]]], optional): parameter
             or parameters to exclude from plot, defaults to None (nothing excluded)
-        close_figure (bool, optional): whether to close each figure immediately after
-            saving it, defaults to False (enable when producing many figures to avoid
-            memory issues, prevents rendering in notebooks)
+        close_figure (bool, optional): whether to close each figure, defaults to True
         save_figure (bool, optional): whether to save figure, defaults to True
 
     Returns:
@@ -493,7 +489,7 @@ def ranking(
     ranking_results: fit.RankingResults,
     figure_folder: Union[str, pathlib.Path] = "figures",
     max_pars: Optional[int] = None,
-    close_figure: bool = False,
+    close_figure: bool = True,
     save_figure: bool = True,
 ) -> mpl.figure.Figure:
     """Produces a ranking plot showing the impact of parameters on the POI.
@@ -504,9 +500,7 @@ def ranking(
             figures in, defaults to "figures"
         max_pars (Optional[int], optional): number of parameters to include, defaults to
             None (which means all parameters are included)
-        close_figure (bool, optional): whether to close each figure immediately after
-            saving it, defaults to False (enable when producing many figures to avoid
-            memory issues, prevents rendering in notebooks)
+        close_figure (bool, optional): whether to close each figure, defaults to True
         save_figure (bool, optional): whether to save figure, defaults to True
 
     Returns:
@@ -557,7 +551,7 @@ def ranking(
 def scan(
     scan_results: fit.ScanResults,
     figure_folder: Union[str, pathlib.Path] = "figures",
-    close_figure: bool = False,
+    close_figure: bool = True,
     save_figure: bool = True,
 ) -> mpl.figure.Figure:
     """Visualizes the results of a likelihood scan.
@@ -566,9 +560,7 @@ def scan(
         scan_results (fit.ScanResults): results of a likelihood scan
         figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
             figures in, defaults to "figures"
-        close_figure (bool, optional): whether to close each figure immediately after
-            saving it, defaults to False (enable when producing many figures to avoid
-            memory issues, prevents rendering in notebooks)
+        close_figure (bool, optional): whether to close each figure, defaults to True
         save_figure (bool, optional): whether to save figure, defaults to True
 
     Returns:
@@ -596,7 +588,7 @@ def scan(
 def limit(
     limit_results: fit.LimitResults,
     figure_folder: Union[str, pathlib.Path] = "figures",
-    close_figure: bool = False,
+    close_figure: bool = True,
     save_figure: bool = True,
 ) -> mpl.figure.Figure:
     """Visualizes observed and expected CLs values as a function of the POI.
@@ -605,9 +597,7 @@ def limit(
         limit_results (fit.LimitResults): results of upper limit determination
         figure_folder (Union[str, pathlib.Path], optional): path to the folder to save
             figures in, defaults to "figures"
-        close_figure (bool, optional): whether to close each figure immediately after
-            saving it, defaults to False (enable when producing many figures to avoid
-            memory issues, prevents rendering in notebooks)
+        close_figure (bool, optional): whether to close each figure, defaults to True
         save_figure (bool, optional): whether to save figure, defaults to True
 
     Returns:

--- a/tests/visualize/test_visualize.py
+++ b/tests/visualize/test_visualize.py
@@ -509,7 +509,7 @@ def test_ranking(mock_draw):
     assert mock_draw.call_args[0][7] == figure_path
     assert mock_draw.call_args[1] == {"close_figure": True}
 
-    # maximum parameter amount specified, close figure, do not save figure
+    # maximum parameter amount specified, do not close figure, do not save figure
     _ = visualize.ranking(
         ranking_results,
         figure_folder=folder_path,

--- a/tests/visualize/test_visualize.py
+++ b/tests/visualize/test_visualize.py
@@ -267,10 +267,10 @@ def test_correlation_matrix(mock_draw):
         [mock_draw.call_args[0][1][i] == labels[i] for i in range(len(labels_pruned))]
     )
     assert mock_draw.call_args[0][2] == figure_path
-    assert mock_draw.call_args[1] == {"close_figure": False}
+    assert mock_draw.call_args[1] == {"close_figure": True}
 
-    # pruning of fixed parameter (all zeros in correlation matrix row/column), close
-    # figure, do not save
+    # pruning of fixed parameter (all zeros in correlation matrix row/column), do not
+    # close figure, do not save
     corr_mat_fixed = np.asarray([[1.0, 0.2, 0.0], [0.2, 1.0, 0.0], [0.0, 0.0, 0.0]])
     fit_results_fixed = fit.FitResults(
         np.empty(0), np.empty(0), labels, corr_mat_fixed, 1.0
@@ -278,7 +278,7 @@ def test_correlation_matrix(mock_draw):
     _ = visualize.correlation_matrix(
         fit_results_fixed,
         figure_folder=folder_path,
-        close_figure=True,
+        close_figure=False,
         save_figure=False,
     )
     assert np.allclose(mock_draw.call_args_list[1][0][0], corr_mat_pruned)
@@ -289,7 +289,7 @@ def test_correlation_matrix(mock_draw):
         ]
     )
     assert mock_draw.call_args[0][2] is None
-    assert mock_draw.call_args[1] == {"close_figure": True}
+    assert mock_draw.call_args[1] == {"close_figure": False}
 
 
 @mock.patch(
@@ -322,7 +322,7 @@ def test_pulls(mock_draw):
         ]
     )
     assert mock_draw.call_args[0][3] == figure_path
-    assert mock_draw.call_args[1] == {"close_figure": False}
+    assert mock_draw.call_args[1] == {"close_figure": True}
 
     # filtering single parameter instead of list
     _ = visualize.pulls(fit_results, figure_folder=folder_path, exclude=exclude[0])
@@ -337,14 +337,14 @@ def test_pulls(mock_draw):
     )
 
     # without filtering via list, but with staterror removal, fixed parameter removal,
-    # closing figure, not saving
+    # not closing figure, not saving
     fit_results.uncertainty[0] = 0.0
 
     bestfit_expected = np.asarray([1.0, 1.1])
     uncertainty_expected = np.asarray([1.0, 0.7])
     labels_expected = ["b", "c"]
     visualize.pulls(
-        fit_results, figure_folder=folder_path, close_figure=True, save_figure=False
+        fit_results, figure_folder=folder_path, close_figure=False, save_figure=False
     )
 
     assert np.allclose(mock_draw.call_args[0][0], bestfit_expected)
@@ -356,7 +356,7 @@ def test_pulls(mock_draw):
         ]
     )
     assert mock_draw.call_args[0][3] is None
-    assert mock_draw.call_args[1] == {"close_figure": True}
+    assert mock_draw.call_args[1] == {"close_figure": False}
 
 
 @mock.patch(
@@ -399,14 +399,14 @@ def test_ranking(mock_draw):
     assert np.allclose(mock_draw.call_args[0][5], impact_postfit_up[::-1])
     assert np.allclose(mock_draw.call_args[0][6], impact_postfit_down[::-1])
     assert mock_draw.call_args[0][7] == figure_path
-    assert mock_draw.call_args[1] == {"close_figure": False}
+    assert mock_draw.call_args[1] == {"close_figure": True}
 
     # maximum parameter amount specified, close figure, do not save figure
     _ = visualize.ranking(
         ranking_results,
         figure_folder=folder_path,
         max_pars=1,
-        close_figure=True,
+        close_figure=False,
         save_figure=False,
     )
     assert mock_draw.call_count == 2
@@ -418,9 +418,10 @@ def test_ranking(mock_draw):
     assert np.allclose(mock_draw.call_args[0][5], impact_postfit_up[1])
     assert np.allclose(mock_draw.call_args[0][6], impact_postfit_down[1])
     assert mock_draw.call_args[0][7] is None
-    assert mock_draw.call_args[1] == {"close_figure": True}
+    assert mock_draw.call_args[1] == {"close_figure": False}
 
 
+# TODO: move to new location
 @mock.patch(
     "cabinetry.histo.Histogram.from_path",
     side_effect=[
@@ -553,14 +554,14 @@ def test_scan(mock_draw):
     assert np.allclose(mock_draw.call_args[0][3], par_vals)
     assert np.allclose(mock_draw.call_args[0][4], par_nlls)
     assert mock_draw.call_args[0][5] == figure_path
-    assert mock_draw.call_args[1] == {"close_figure": False}
+    assert mock_draw.call_args[1] == {"close_figure": True}
 
-    # close figure, do not save figure
+    # do not close figure, do not save figure
     _ = visualize.scan(
-        scan_results, figure_folder=folder_path, close_figure=True, save_figure=False
+        scan_results, figure_folder=folder_path, close_figure=False, save_figure=False
     )
     assert mock_draw.call_args[0][5] is None
-    assert mock_draw.call_args[1] == {"close_figure": True}
+    assert mock_draw.call_args[1] == {"close_figure": False}
 
 
 @mock.patch(
@@ -585,11 +586,11 @@ def test_limit(mock_draw):
     assert np.allclose(mock_draw.call_args[0][1], limit_results.expected_CLs)
     assert np.allclose(mock_draw.call_args[0][2], limit_results.poi_values)
     assert mock_draw.call_args[0][3] == figure_path
-    assert mock_draw.call_args[1] == {"close_figure": False}
+    assert mock_draw.call_args[1] == {"close_figure": True}
 
-    # close figure, do not save figure
+    # do not close figure, do not save figure
     _ = visualize.limit(
-        limit_results, figure_folder=folder_path, close_figure=True, save_figure=False
+        limit_results, figure_folder=folder_path, close_figure=False, save_figure=False
     )
     assert mock_draw.call_args[0][3] is None
-    assert mock_draw.call_args[1] == {"close_figure": True}
+    assert mock_draw.call_args[1] == {"close_figure": False}


### PR DESCRIPTION
#264 caused figures to be returned from `visualize` functions. When used in a notebook with `matplotlib` inline backend, figures produced by functions returning a single figure were then rendered twice: once because they are still open, and once because they are the return value of the last line in the cell. This changes the default setting for functions returning a single figure (`correlation_matrix`, `pulls`, `ranking`, `scan`, `limit`) to `close_figure=True`. A cell such as

```python
cabinetry.visualize.pulls(...)
```

then will only show the produced figure once (because it is the return value of the last line in the cell). The same behavior can be achieved in other ways, see https://github.com/alexander-held/cabinetry/issues/265#issuecomment-907621136 for more details.

Multi-figure functions like `data_mc` will keep the default `close_figure=False`, so all produced figures show up by default (the return value of these functions is a list of dicts, so when showing the return value the figures do not get rendered again automatically).

This update changes the behavior introduced in #240 for single-figure functions.

Also changes the order of tests to move the `templates` test so the test order matches the implementation order (which was changed in #264).

```
* figures returned by functions producing a single figure are closed by default
* prevents duplicate display of figures in notebooks
```