### PR TITLE
style: apply optional formatting to magic commas and strings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,4 @@ extras_require["develop"] = sorted(
 )
 extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))
 
-setup(
-    extras_require=extras_require,
-)
+setup(extras_require=extras_require)

--- a/src/cabinetry/cli/__init__.py
+++ b/src/cabinetry/cli/__init__.py
@@ -242,10 +242,7 @@ def scan(
     help='folder to save figures to (default: "figures")',
 )
 def limit(
-    ws_spec: io.TextIOWrapper,
-    asimov: bool,
-    tolerance: float,
-    figfolder: str,
+    ws_spec: io.TextIOWrapper, asimov: bool, tolerance: float, figfolder: str
 ) -> None:
     """Calculates upper limits and visualizes CLs distribution.
 
@@ -261,10 +258,7 @@ def limit(
 @click.command()
 @click.argument("ws_spec", type=click.File("r"))
 @click.option("--asimov", is_flag=True, help="fit Asimov dataset (default: False)")
-def significance(
-    ws_spec: io.TextIOWrapper,
-    asimov: bool,
-) -> None:
+def significance(ws_spec: io.TextIOWrapper, asimov: bool) -> None:
     """Calculates observed and expected discovery significance.
 
     WS_SPEC: path to workspace used in fit

--- a/src/cabinetry/contrib/histogram_creation.py
+++ b/src/cabinetry/contrib/histogram_creation.py
@@ -54,9 +54,7 @@ def from_uproot(
     if weight_is_expression:
         # need to read observables and weights
         array_generator = uproot.iterate(
-            paths_with_trees,
-            expressions=[variable, weight],
-            cut=selection_filter,
+            paths_with_trees, expressions=[variable, weight], cut=selection_filter
         )
         obs_list = []
         weight_list = []
@@ -69,9 +67,7 @@ def from_uproot(
     else:
         # only need to read the observables
         array_generator = uproot.iterate(
-            paths_with_trees,
-            expressions=[variable],
-            cut=selection_filter,
+            paths_with_trees, expressions=[variable], cut=selection_filter
         )
         obs_list = []
         for arr in array_generator:

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -590,7 +590,7 @@ def limit(
     if bracket is None:
         bracket = (bracket_left_default, bracket_right_default)
     elif bracket[0] == bracket[1]:
-        raise ValueError(f"the two bracket values must not be the same: " f"{bracket}")
+        raise ValueError(f"the two bracket values must not be the same: {bracket}")
 
     cache_CLs: Dict[float, tuple] = {}  # cache storing all relevant results
 
@@ -676,7 +676,7 @@ def limit(
             # invalid starting bracket is most common issue
             log.error(
                 f"CLs values at {bracket[0]:.4f} and {bracket[1]:.4f} do not bracket "
-                f"CLs=0.05, try a different starting bracket"
+                "CLs=0.05, try a different starting bracket"
             )
             raise
 

--- a/src/cabinetry/fit/__init__.py
+++ b/src/cabinetry/fit/__init__.py
@@ -20,9 +20,7 @@ from cabinetry.fit.results_containers import (
 log = logging.getLogger(__name__)
 
 
-def print_results(
-    fit_results: FitResults,
-) -> None:
+def print_results(fit_results: FitResults) -> None:
     """Prints the best-fit parameter results and associated uncertainties.
 
     Args:
@@ -156,11 +154,7 @@ def _fit_model_custom(
         twice_nll = -2 * model.logpdf(pars, data)
         return twice_nll[0]
 
-    m = iminuit.Minuit(
-        twice_nll_func,
-        init_pars,
-        name=labels,
-    )
+    m = iminuit.Minuit(twice_nll_func, init_pars, name=labels)
     m.errors = step_size
     m.limits = par_bounds
     m.fixed = fix_pars

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -78,7 +78,7 @@ class Histogram(bh.Histogram, family=cabinetry):
             if not histo_path_modified.with_suffix(".npz").exists():
                 log.warning(
                     f"the modified histogram {histo_path_modified.with_suffix('.npz')} "
-                    f"does not exist",
+                    "does not exist",
                 )
                 log.warning("loading the un-modified histogram instead!")
             else:

--- a/src/cabinetry/histo.py
+++ b/src/cabinetry/histo.py
@@ -78,7 +78,7 @@ class Histogram(bh.Histogram, family=cabinetry):
             if not histo_path_modified.with_suffix(".npz").exists():
                 log.warning(
                     f"the modified histogram {histo_path_modified.with_suffix('.npz')} "
-                    "does not exist",
+                    "does not exist"
                 )
                 log.warning("loading the un-modified histogram instead!")
             else:
@@ -213,7 +213,7 @@ class Histogram(bh.Histogram, family=cabinetry):
         if len(not_empty_but_nan) > 0:
             log.warning(
                 f"{name} has non-empty bins with ill-defined stat. unc.: "
-                f"{not_empty_but_nan}",
+                f"{not_empty_but_nan}"
             )
 
     def normalize_to_yield(self, reference_histogram: H) -> float:

--- a/src/cabinetry/route.py
+++ b/src/cabinetry/route.py
@@ -313,7 +313,7 @@ def apply_to_all_templates(
                         continue
 
                     log.debug(
-                        f"      variation "
+                        "      variation "
                         f"{systematic['Name'] if template is not None else 'Nominal'}"
                         f"{' ' + template if template is not None else ''}"
                     )
@@ -331,8 +331,7 @@ def apply_to_all_templates(
                     if func_override is not None:
                         # call the user-defined function
                         log.debug(
-                            f"executing user-defined override "
-                            f"{func_override.__name__}"
+                            f"executing user-defined override {func_override.__name__}"
                         )
                         func_override(region, sample, systematic, template)
                     else:

--- a/src/cabinetry/tabulate.py
+++ b/src/cabinetry/tabulate.py
@@ -88,8 +88,10 @@ def _yields_per_bin(
             )
             total_dict.update(
                 {
-                    header_name: f"{total_model[i_bin]:.2f} "
-                    f"\u00B1 {total_stdev_model[i_chan][i_bin]:.2f}"
+                    header_name: (
+                        f"{total_model[i_bin]:.2f} "
+                        f"\u00B1 {total_stdev_model[i_chan][i_bin]:.2f}"
+                    )
                 }
             )
             data_dict.update({header_name: f"{data[i_chan][i_bin]:.2f}"})
@@ -145,10 +147,7 @@ def _yields_per_channel(
     for i_chan, channel_name in zip(channel_indices, channels):
         total_model = np.sum(model_yields[i_chan], axis=0)  # sum over samples
         total_dict.update(
-            {
-                channel_name: f"{total_model:.2f} "
-                f"\u00B1 {total_stdev_model[i_chan]:.2f}"
-            }
+            {channel_name: f"{total_model:.2f} \u00B1 {total_stdev_model[i_chan]:.2f}"}
         )
         data_dict.update({channel_name: f"{data[i_chan]:.2f}"})
     table += [total_dict, data_dict]

--- a/src/cabinetry/tabulate.py
+++ b/src/cabinetry/tabulate.py
@@ -99,11 +99,7 @@ def _yields_per_bin(
 
     log.info(
         f"yields per bin for {label} model prediction:\n"
-        + tabulate.tabulate(
-            table,
-            headers=headers,
-            tablefmt="fancy_grid",
-        )
+        + tabulate.tabulate(table, headers=headers, tablefmt="fancy_grid")
     )
     return table
 
@@ -154,11 +150,7 @@ def _yields_per_channel(
 
     log.info(
         f"yields per channel for {label} model prediction:\n"
-        + tabulate.tabulate(
-            table,
-            headers="keys",
-            tablefmt="fancy_grid",
-        )
+        + tabulate.tabulate(table, headers="keys", tablefmt="fancy_grid")
     )
     return table
 

--- a/src/cabinetry/visualize/__init__.py
+++ b/src/cabinetry/visualize/__init__.py
@@ -476,11 +476,7 @@ def pulls(
     labels_np = labels_np[mask]
 
     fig = plot_result.pulls(
-        bestfit,
-        uncertainty,
-        labels_np,
-        figure_path,
-        close_figure=close_figure,
+        bestfit, uncertainty, labels_np, figure_path, close_figure=close_figure
     )
     return fig
 

--- a/src/cabinetry/visualize/plot_model.py
+++ b/src/cabinetry/visualize/plot_model.py
@@ -93,10 +93,7 @@ def data_mc(
     mc_containers = []
     for mc_sample_yield in mc_histograms_yields:
         mc_container = ax1.bar(
-            bin_centers,
-            mc_sample_yield,
-            width=bin_width,
-            bottom=total_yield,
+            bin_centers, mc_sample_yield, width=bin_width, bottom=total_yield
         )
         mc_containers.append(mc_container)
 
@@ -266,13 +263,7 @@ def templates(
     ax2 = fig.add_subplot(gs[1])
 
     # ratio plot line through unity and stat. uncertainty of nominal
-    ax2.plot(
-        [bin_edges[0], bin_edges[-1]],
-        [1, 1],
-        "--",
-        color="black",
-        linewidth=1,
-    )
+    ax2.plot([bin_edges[0], bin_edges[-1]], [1, 1], "--", color="black", linewidth=1)
     rel_nominal_stat_unc = nominal_histo["stdev"] / nominal_histo["yields"]
     ax2.bar(
         bin_centers,
@@ -316,13 +307,7 @@ def templates(
         # lines to show each template distribution
         line_y = [y for y in template["yields"] for _ in range(2)]
 
-        ax1.plot(
-            line_x,
-            line_y,
-            color=color,
-            linestyle=linestyle,
-            label=template_label,
-        )
+        ax1.plot(line_x, line_y, color=color, linestyle=linestyle, label=template_label)
         if template_label == "nominal":
             # band for stat. uncertainty of nominal prediction
             ax1.bar(
@@ -349,12 +334,7 @@ def templates(
             template_ratio_plot = template["yields"] / nominal_histo["yields"]
             line_y = [y for y in template_ratio_plot for _ in range(2)]
 
-            ax2.plot(
-                line_x,
-                line_y,
-                color=color,
-                linestyle=linestyle,
-            )
+            ax2.plot(line_x, line_y, color=color, linestyle=linestyle)
             ax2.errorbar(
                 bin_centers,
                 template_ratio_plot,

--- a/src/cabinetry/visualize/plot_result.py
+++ b/src/cabinetry/visualize/plot_result.py
@@ -363,11 +363,7 @@ def limit(
 
     # expected CLs
     ax.plot(
-        poi_values,
-        expected_CLs[:, 2],
-        "--",
-        color="black",
-        label=r"expected CL$_S$",
+        poi_values, expected_CLs[:, 2], "--", color="black", label=r"expected CL$_S$"
     )
 
     # observed CLs values

--- a/src/cabinetry/workspace.py
+++ b/src/cabinetry/workspace.py
@@ -116,10 +116,7 @@ class WorkspaceBuilder:
         return modifier
 
     def normplusshape_modifiers(
-        self,
-        region: Dict[str, Any],
-        sample: Dict[str, Any],
-        systematic: Dict[str, Any],
+        self, region: Dict[str, Any], sample: Dict[str, Any], systematic: Dict[str, Any]
     ) -> List[Dict[str, Any]]:
         """Returns modifiers for a correlated shape + normalization effect.
 
@@ -235,7 +232,7 @@ class WorkspaceBuilder:
                     # OverallSys (norm uncertainty with Gaussian constraint)
                     log.debug(
                         f"adding OverallSys {systematic['Name']} to sample"
-                        f" {sample['Name']} in region {region['Name']}",
+                        f" {sample['Name']} in region {region['Name']}"
                     )
                     modifiers.append(self.normalization_modifier(systematic))
                 elif systematic["Type"] == "NormPlusShape":
@@ -243,7 +240,7 @@ class WorkspaceBuilder:
                     # and a HistoSys for the shape variation
                     log.debug(
                         f"adding OverallSys and HistoSys {systematic['Name']} to sample"
-                        f" {sample['Name']} in region {region['Name']}",
+                        f" {sample['Name']} in region {region['Name']}"
                     )
                     modifiers += self.normplusshape_modifiers(
                         region, sample, systematic

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -455,7 +455,7 @@ def test_significance(mock_util, mock_sig, tmp_path):
 
 @mock.patch("cabinetry.visualize.data_mc", autospec=True)
 @mock.patch(
-    "cabinetry.model_utils.prediction", return_value=("mock_model_pred"), autospec=True
+    "cabinetry.model_utils.prediction", return_value="mock_model_pred", autospec=True
 )
 @mock.patch(
     "cabinetry.fit.fit",

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -50,10 +50,7 @@ def test_templates(mock_validate, mock_create_histograms, cli_helpers, tmp_path)
     # different method
     result = runner.invoke(cli.templates, ["--method", "unknown", config_path])
     assert result.exit_code == 0
-    assert mock_create_histograms.call_args == (
-        (config,),
-        {"method": "unknown"},
-    )
+    assert mock_create_histograms.call_args == ((config,), {"method": "unknown"})
 
 
 @mock.patch("cabinetry.template_postprocessor.run", autospec=True)
@@ -186,14 +183,8 @@ def test_fit(mock_util, mock_fit, mock_pulls, mock_corrmat, tmp_path):
         cli.fit, ["--figfolder", "folder", "--pulls", "--corrmat", workspace_path]
     )
     assert result.exit_code == 0
-    assert mock_corrmat.call_args == (
-        (fit_results,),
-        {"figure_folder": "folder"},
-    )
-    assert mock_pulls.call_args == (
-        (fit_results,),
-        {"figure_folder": "folder"},
-    )
+    assert mock_corrmat.call_args == ((fit_results,), {"figure_folder": "folder"})
+    assert mock_pulls.call_args == ((fit_results,), {"figure_folder": "folder"})
 
 
 @mock.patch("cabinetry.visualize.ranking", autospec=True)
@@ -261,10 +252,7 @@ def test_ranking(mock_util, mock_fit, mock_rank, mock_vis, tmp_path):
     assert result.exit_code == 0
     assert mock_util.call_args == ((workspace,), {"asimov": True})
     assert mock_fit.call_args == (("model", "data"), {})
-    assert mock_rank.call_args == (
-        ("model", "data"),
-        {"fit_results": fit_results},
-    )
+    assert mock_rank.call_args == (("model", "data"), {"fit_results": fit_results})
     assert mock_vis.call_args_list[-1][1] == {"figure_folder": "folder", "max_pars": 3}
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,11 +199,7 @@ def example_spec_with_background():
             {
                 "config": {
                     "parameters": [
-                        {
-                            "name": "Signal strength",
-                            "bounds": [[0, 10]],
-                            "inits": [1.0],
-                        }
+                        {"name": "Signal strength", "bounds": [[0, 10]], "inits": [1.0]}
                     ],
                     "poi": "Signal strength",
                 },
@@ -230,7 +226,7 @@ def example_spec_no_aux():
                                 "data": None,
                                 "name": "Signal strength",
                                 "type": "normfactor",
-                            },
+                            }
                         ],
                         "name": "Signal",
                     }
@@ -280,7 +276,7 @@ def example_spec_lumi():
                             "inits": [1.05],
                             "name": "lumi",
                             "sigmas": [0.02],
-                        },
+                        }
                     ],
                     "poi": "Signal strength",
                 },

--- a/tests/fit/test_fit.py
+++ b/tests/fit/test_fit.py
@@ -210,11 +210,7 @@ def test__run_minos(caplog):
             + pars[0]
         )
 
-    m = iminuit.Minuit(
-        func_to_minimize,
-        [1.0, 1.0],
-        name=["a", "b"],
-    )
+    m = iminuit.Minuit(func_to_minimize, [1.0, 1.0], name=["a", "b"])
     m.errordef = 1
     m.migrad()
     fit._run_minos(m, ["b"], ["a", "b"])
@@ -223,10 +219,7 @@ def test__run_minos(caplog):
     caplog.clear()
 
     # proper labels not known to iminuit
-    m = iminuit.Minuit(
-        func_to_minimize,
-        [1.0, 1.0],
-    )
+    m = iminuit.Minuit(func_to_minimize, [1.0, 1.0])
     m.errordef = 1
     m.migrad()
     fit._run_minos(m, ["x0"], ["a", "b"])
@@ -235,10 +228,7 @@ def test__run_minos(caplog):
     caplog.clear()
 
     # unknown parameter, MINOS does not run
-    m = iminuit.Minuit(
-        func_to_minimize,
-        [1.0, 1.0],
-    )
+    m = iminuit.Minuit(func_to_minimize, [1.0, 1.0])
     m.errordef = 1
     m.migrad()
     fit._run_minos(m, ["x2"], ["a", "b"])
@@ -304,10 +294,7 @@ def test_fit(mock_fit, mock_print, mock_gof):
     # custom fit
     fit_results = fit.fit(model, data, custom_fit=True)
     assert mock_fit.call_count == 2
-    assert mock_fit.call_args == (
-        (model, data),
-        {"minos": None, "custom_fit": True},
-    )
+    assert mock_fit.call_args == ((model, data), {"minos": None, "custom_fit": True})
     assert mock_print.call_args[0][0].bestfit == [1.0]
     assert mock_print.call_args[0][0].uncertainty == [0.1]
     assert fit_results.bestfit == [1.0]

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -216,10 +216,7 @@ def test_sample_contains_modifier(sample_and_modifier, contained):
             (
                 {},
                 {"Name": "Signal"},
-                {
-                    "Type": "NormPlusShape",
-                    "Up": {"Symmetrize": True},
-                },
+                {"Type": "NormPlusShape", "Up": {"Symmetrize": True}},
                 "Up",
             ),
             False,

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -216,13 +216,9 @@ def test_yield_stdev(example_spec, example_spec_multibin):
 
 @mock.patch("cabinetry.model_utils.yield_stdev", return_value=([[0.3]], [0.3]))
 @mock.patch(
-    "cabinetry.model_utils.prefit_uncertainties",
-    return_value=([0.04956657, 0.0]),
+    "cabinetry.model_utils.prefit_uncertainties", return_value=([0.04956657, 0.0])
 )
-@mock.patch(
-    "cabinetry.model_utils.asimov_parameters",
-    return_value=([1.0, 1.0]),
-)
+@mock.patch("cabinetry.model_utils.asimov_parameters", return_value=([1.0, 1.0]))
 def test_prediction(mock_asimov, mock_unc, mock_stdev, example_spec):
     model = pyhf.Workspace(example_spec).model()
 

--- a/tests/test_tabulate.py
+++ b/tests/test_tabulate.py
@@ -9,11 +9,7 @@ from cabinetry import tabulate
 
 
 @pytest.mark.parametrize(
-    "test_input, expected",
-    [
-        (("abc", 0), "abc\nbin 1"),
-        (("abc", 2), "abc\nbin 3"),
-    ],
+    "test_input, expected", [(("abc", 0), "abc\nbin 1"), (("abc", 2), "abc\nbin 3")]
 )
 def test__header_name(test_input, expected):
     assert tabulate._header_name(*test_input) == expected
@@ -94,21 +90,13 @@ def test__yields_per_channel(
         model, yields, total_stdev, data, channels, label
     )
     assert yield_table == [
-        {
-            "sample": "Signal",
-            "region_1": "30.00",
-            "region_2": "8.00",
-        },
+        {"sample": "Signal", "region_1": "30.00", "region_2": "8.00"},
         {
             "sample": "total",
             "region_1": "30.00 \u00B1 5.39",
             "region_2": "8.00 \u00B1 1.00",
         },
-        {
-            "sample": "data",
-            "region_1": "43.00",
-            "region_2": "10.00",
-        },
+        {"sample": "data", "region_1": "43.00", "region_2": "10.00"},
     ]
     assert (
         "yields per channel for pre-fit model prediction:" in caplog.records[0].message

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -484,8 +484,7 @@ def test_WorkspaceBuilder_observations(mock_histogram):
     return_value=[{"name: measurement"}],
 )
 @mock.patch(
-    "cabinetry.workspace.WorkspaceBuilder.channels",
-    return_value=[{"name: channel"}],
+    "cabinetry.workspace.WorkspaceBuilder.channels", return_value=[{"name: channel"}]
 )
 def test_WorkspaceBuilder_build(mock_channels, mock_measuremets, mock_observations):
     ws_builder = workspace.WorkspaceBuilder({"General": {"HistogramFolder": "path"}})

--- a/tests/visualize/test_plot_model.py
+++ b/tests/visualize/test_plot_model.py
@@ -129,10 +129,7 @@ def test_templates(tmp_path):
         "yields": np.asarray([0.9, 0.9]),
         "stdev": np.asarray([0.06, 0.07]),
     }
-    up_histo_mod = {
-        "yields": np.asarray([1.3, 1.6]),
-        "stdev": np.asarray([0.05, 0.07]),
-    }
+    up_histo_mod = {"yields": np.asarray([1.3, 1.6]), "stdev": np.asarray([0.05, 0.07])}
     down_histo_mod = {
         "yields": np.asarray([0.85, 0.95]),
         "stdev": np.asarray([0.06, 0.07]),

--- a/tests/visualize/test_visualize.py
+++ b/tests/visualize/test_visualize.py
@@ -87,12 +87,7 @@ def test_data_mc_from_histograms(mock_load, mock_draw, mock_stdev):
         (
             (
                 [
-                    {
-                        "label": "data",
-                        "isData": True,
-                        "yields": [1.0],
-                        "variable": "x",
-                    },
+                    {"label": "data", "isData": True, "yields": [1.0], "variable": "x"},
                     {
                         "label": "sample_1",
                         "isData": False,
@@ -144,14 +139,7 @@ def test_data_mc_from_histograms(mock_load, mock_draw, mock_stdev):
     side_effect=[["Signal Region"], ["Signal Region"], ["Signal Region"], []],
 )
 @mock.patch("cabinetry.model_utils._data_per_channel", return_value=[[12.0]])
-def test_data_mc(
-    mock_data,
-    mock_filter,
-    mock_dict,
-    mock_bins,
-    mock_draw,
-    example_spec,
-):
+def test_data_mc(mock_data, mock_filter, mock_dict, mock_bins, mock_draw, example_spec):
     config = {"config": "abc"}
     figure_folder = "tmp"
     model = pyhf.Workspace(example_spec).model()


### PR DESCRIPTION
This applies changes from `black` that are introduced by `--experimental-string-processing` (which will eventually become the default), as long as running `black` again without that flag does not revert the changes. It also applies changes from [`--skip-magic-trailing-comma`](https://black.readthedocs.io/en/latest/the_black_code_style/current_style.html#the-magic-trailing-comma), again as long as those changes are not reverted by running `black` without that flag. Magic commas have not been used purposefully for formatting in the codebase so far, so the changes due to this should be coming mostly from code that was too long for a single line, later on made shorter such that it once again fits into a single line, but was not formatted again due to a trailing comma.

```
* apply selected changes from black --experimental-string-processing
* apply selected changes from black --skip-magic-trailing-comma
```