### PR TITLE
test: additional call argument formatting harmonization

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -253,7 +253,7 @@ def test_ranking(mock_util, mock_fit, mock_rank, mock_vis, tmp_path):
     assert mock_util.call_args == ((workspace,), {"asimov": True})
     assert mock_fit.call_args == (("model", "data"), {})
     assert mock_rank.call_args == (("model", "data"), {"fit_results": fit_results})
-    assert mock_vis.call_args_list[-1][1] == {"figure_folder": "folder", "max_pars": 3}
+    assert mock_vis.call_args[1] == {"figure_folder": "folder", "max_pars": 3}
 
 
 @mock.patch("cabinetry.visualize.scan", autospec=True)
@@ -409,7 +409,7 @@ def test_limit(mock_util, mock_limit, mock_vis, tmp_path):
     assert result.exit_code == 0
     assert mock_util.call_args == ((workspace,), {"asimov": True})
     assert mock_limit.call_args == (("model", "data"), {"tolerance": 0.1})
-    assert mock_vis.call_args_list[-1][1] == {"figure_folder": "folder"}
+    assert mock_vis.call_args[1] == {"figure_folder": "folder"}
 
 
 @mock.patch("cabinetry.fit.significance", autospec=True)

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -338,13 +338,13 @@ def test_create_histograms():
     # no router
     with mock.patch("cabinetry.route.apply_to_all_templates") as mock_apply:
         template_builder.create_histograms(config, method)
-        assert len(mock_apply.call_args_list) == 1
-        config_call, func_call = mock_apply.call_args_list[0][0]
+        assert mock_apply.call_count == 1
+        config_call, func_call = mock_apply.call_args[0]
         assert config_call == config
         assert (
             func_call.__name__ == "_create_histogram"
         )  # could also compare to function
-        assert mock_apply.call_args_list[0][1] == {"match_func": None}
+        assert mock_apply.call_args[1] == {"match_func": None}
 
     # including a router
     mock_router = mock.MagicMock()
@@ -357,10 +357,10 @@ def test_create_histograms():
             == "_wrap_custom_template_builder"
         )
 
-        assert len(mock_apply.call_args_list) == 1
-        config_call, func_call = mock_apply.call_args_list[0][0]
+        assert mock_apply.call_count == 1
+        config_call, func_call = mock_apply.call_args[0]
         assert config_call == config
         assert func_call.__name__ == "_create_histogram"
-        assert mock_apply.call_args_list[0][1] == {
+        assert mock_apply.call_args[1] == {
             "match_func": mock_router._find_template_builder_match
         }


### PR DESCRIPTION
This is a minor follow-up to #269, introducing a bit more harmonization. `call_args` is used instead of `call_args_list[-1]` depending on the context, and `call_count` is used instead of the `call_args_list` length.

```
* further harmonized formatting of expected call arguments for mocked objects in tests
```