### PR TITLE
feat: add Python 3.9 support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -91,7 +91,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -118,7 +118,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,10 +12,10 @@ repos:
         additional_dependencies: ["numpy>=1.20", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML"]
         args: ["--python-version=3.7"]
     -   id: mypy
-        name: mypy with Python 3.8
+        name: mypy with Python 3.9
         files: src/cabinetry
         additional_dependencies: ["numpy>=1.20", "boost-histogram>=1.0.1", "click>=8", "types-tabulate", "types-PyYAML"]
-        args: ["--python-version=3.8"]
+        args: ["--python-version=3.9"]
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,7 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ classifiers =
     Development Status :: 3 - Alpha
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     License :: OSI Approved :: BSD License
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Physics


### PR DESCRIPTION
`pyhf` added Python 3.9 support via https://github.com/scikit-hep/pyhf/pull/1574, which is now available as of `pyhf` v0.6.3. This means that also `cabinetry` can officially support Python 3.9 (the only blocker for this was `pyhf`). Tests are added for Python 3.9, and others are updated where sensible.

resolves #275

```
* add Python 3.9 support and test Python 3.9 in CI
```