### PR TITLE
feat: Add `MANIFEST.in`

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Check MANIFEST
       run: |
-        check-manifest
+        check-manifest --verbose
 
     - name: Build a wheel and a sdist
       run: |

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -1,0 +1,48 @@
+name: test distribution build
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+  pull_request:
+    branches:
+    - master
+  workflow_dispatch:
+
+jobs:
+  build-package:
+    name: Build and test Python distro
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Install python-build, check-manifest, and twine
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install build check-manifest twine
+        python -m pip list
+
+    - name: Check MANIFEST
+      run: |
+        check-manifest
+
+    - name: Build a wheel and a sdist
+      run: |
+        python -m build --outdir dist/ .
+
+    - name: Verify the distribution
+      run: twine check dist/*
+
+    - name: List contents of sdist
+      run: python -m tarfile --list dist/cabinetry-*.tar.gz
+
+    - name: List contents of wheel
+      run: python -m zipfile --list dist/cabinetry-*.whl

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,12 @@
+prune **
+graft src
+graft tests
+
+include setup.py
+include setup.cfg
+include LICENSE
+include README.md
+include pyproject.toml
+include MANIFEST.in
+
+global-exclude __pycache__ *.py[cod]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,4 +9,4 @@ include README.md
 include pyproject.toml
 include MANIFEST.in
 
-global-exclude __pycache__ *.py[cod]
+global-exclude __pycache__ *.py[cod] *.png


### PR DESCRIPTION
Add a `MANIFEST.in` to the project that initially adds nothing (prunes everything), then adds only the files in `src` and `tests`, and then adds all ["default" files for a `sdist` in `MANIFEST.in`](https://packaging.python.org/guides/using-manifest-in/#how-files-are-included-in-an-sdist). Additionally add a GHA based workflow to test building a package using `build` that also checks the package manifest and will list the contents of the resulting `sdist` and `wheel` for visual checks of the CI logs.

For additional context c.f. https://github.com/scikit-hep/pyhf/pull/1449

**Suggested squash and merge commit message**
```
* Add a MANIFEST.in to tell packagers what to include when building a package
* Use `prune **` to remove all files from the sdist
   - c.f. https://packaging.python.org/guides/using-manifest-in/#manifest-in-commands
   - "Setuptools also has undocumented support for ** matching zero or more characters including forward slash, backslash, and colon."
* Manually include all "default" files for an sdist in MANIFEST.in
   - c.f. https://packaging.python.org/guides/using-manifest-in/#how-files-are-included-in-an-sdist
* Add package publishing build test CI
   - Add list of sdist and wheel contents which allows for easier checking of the sdist contents in CI logs
```