### PR TITLE
chore: updating version to 0.3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cabinetry
-version = 0.2.3
+version = 0.3.0
 author = Alexander Held
 description = design and steer profile likelihood fits
 long_description = file: README.md

--- a/src/cabinetry/__init__.py
+++ b/src/cabinetry/__init__.py
@@ -12,7 +12,7 @@ import cabinetry.visualize  # noqa: F401
 import cabinetry.workspace  # noqa: F401
 
 
-__version__ = "0.2.3"
+__version__ = "0.3.0"
 
 
 def set_logging() -> None:


### PR DESCRIPTION
Updating to version 0.3.0. `cabinetry` now returns figure objects for further customization, and multiple breaking API changes have been introduced. The minimum required `pyhf` version is now 0.6.3, and Python 3.9 is officially supported.

```
* updating version to 0.3.0
```