### PR TITLE
ci: update package list

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,13 +50,13 @@ jobs:
     - name: Test with pytest, without typeguard, generate coverage report
       if: matrix.python-version == 3.7
       run: |
-        apt-get update
+        sudo apt-get update
         sudo apt-get install ghostscript  # for pdf comparison
         pytest --cov-report=xml --typeguard-packages=""  # typeguard issue with typing.NamedTuple in Python 3.7
     - name: Test with pytest and typeguard
       if: matrix.python-version != 3.7
       run: |
-        apt-get update
+        sudo apt-get update
         sudo apt-get install ghostscript  # for pdf comparison
         python -m pip install .[pyhf_backends]  # install pyhf backends
         pytest --runslow  # also test pyhf backends

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,11 +50,13 @@ jobs:
     - name: Test with pytest, without typeguard, generate coverage report
       if: matrix.python-version == 3.7
       run: |
+        apt-get update
         sudo apt-get install ghostscript  # for pdf comparison
         pytest --cov-report=xml --typeguard-packages=""  # typeguard issue with typing.NamedTuple in Python 3.7
     - name: Test with pytest and typeguard
       if: matrix.python-version != 3.7
       run: |
+        apt-get update
         sudo apt-get install ghostscript  # for pdf comparison
         python -m pip install .[pyhf_backends]  # install pyhf backends
         pytest --runslow  # also test pyhf backends

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -28,6 +28,7 @@ jobs:
         python -m pip uninstall --yes pyhf
         python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/pyhf.git
         python -m pip list
+        sudo apt-get update
         sudo apt-get install ghostscript  # for pdf comparison
     - name: Test with pytest
       run: |
@@ -54,6 +55,7 @@ jobs:
         python -m pip uninstall --yes awkward
         python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/awkward-1.0.git
         python -m pip list
+        sudo apt-get update
         sudo apt-get install ghostscript  # for pdf comparison
     - name: Test with pytest
       run: |
@@ -80,6 +82,7 @@ jobs:
         python -m pip uninstall --yes uproot
         python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/uproot4.git
         python -m pip list
+        sudo apt-get update
         sudo apt-get install ghostscript  # for pdf comparison
     - name: Test with pytest
       run: |
@@ -107,6 +110,7 @@ jobs:
         python -m pip install --upgrade --no-cache-dir cython
         python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/iminuit.git
         python -m pip list
+        sudo apt-get update
         sudo apt-get install ghostscript  # for pdf comparison
     - name: Test with pytest
       run: |
@@ -133,6 +137,7 @@ jobs:
         python -m pip uninstall --yes boost-histogram
         python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/boost-histogram.git
         python -m pip list
+        sudo apt-get update
         sudo apt-get install ghostscript  # for pdf comparison
     - name: Test with pytest
       run: |


### PR DESCRIPTION
CI started failing during `ghostscript` installation. This is caused by the package list being slightly outdated and fixed by updating it via `apt-get update` before installing `ghostscript`. Thanks a lot to @matthewfeickert for the debugging help!

```
* update package list to fix failing ghostscript installation in CI
```