### PR TITLE
feat: return histogram instead of tuple from histogram creation backend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 21.8b0
+    rev: 21.9b0
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
@@ -22,7 +22,7 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-bugbear, flake8-import-order, flake8-print]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.25.0
+    rev: v2.26.0
     hooks:
     -   id: pyupgrade
         args: ["--py37-plus"]

--- a/src/cabinetry/template_builder.py
+++ b/src/cabinetry/template_builder.py
@@ -309,7 +309,7 @@ class _Builder:
         if self.method == "uproot":
             from cabinetry.contrib import histogram_creation
 
-            yields, stdev = histogram_creation.from_uproot(
+            histogram = histogram_creation.from_uproot(
                 ntuple_paths,
                 pos_in_file,
                 variable,
@@ -322,8 +322,9 @@ class _Builder:
             raise NotImplementedError(f"unknown backend {self.method}")
 
         # store information in a Histogram instance and save it
-        histogram = histo.Histogram.from_arrays(bins, yields, stdev)
-        self._name_and_save(histogram, region, sample, systematic, template)
+        self._name_and_save(
+            histo.Histogram(histogram), region, sample, systematic, template
+        )
 
     def _name_and_save(
         self,

--- a/tests/contrib/test_histogram_creation.py
+++ b/tests/contrib/test_histogram_creation.py
@@ -17,33 +17,33 @@ def test_from_uproot(tmp_path, utils):
     )
 
     # read - no weights or selection
-    yields, stdev = histogram_creation.from_uproot(fnames, treename, varname, bins)
-    assert np.allclose(yields, [1, 1, 2])
-    assert np.allclose(stdev, [1, 1, 1.41421356])
+    hist = histogram_creation.from_uproot(fnames, treename, varname, bins)
+    assert np.allclose(hist.values(), [1, 1, 2])
+    assert np.allclose(np.sqrt(hist.variances()), [1, 1, 1.41421356])
 
     # read - with selection cut
     selection = "var < 3.1"
-    yields, stdev = histogram_creation.from_uproot(
+    hist = histogram_creation.from_uproot(
         fnames, treename, varname, bins, selection_filter=selection
     )
-    assert np.allclose(yields, [1, 1, 1])
-    assert np.allclose(stdev, [1, 1, 1])
+    assert np.allclose(hist.values(), [1, 1, 1])
+    assert np.allclose(np.sqrt(hist.variances()), [1, 1, 1])
 
     # read - with weight
     weightname_apply = "weight*2"
-    yields, stdev = histogram_creation.from_uproot(
+    hist = histogram_creation.from_uproot(
         fnames, treename, varname, bins, weight=weightname_apply
     )
-    assert np.allclose(yields, [2, 2, 6])
-    assert np.allclose(stdev, [2, 2, 4.47213595])
+    assert np.allclose(hist.values(), [2, 2, 6])
+    assert np.allclose(np.sqrt(hist.variances()), [2, 2, 4.47213595])
 
     # read - with weight that is only a float
     weight_float = "2.0"
-    yields, stdev = histogram_creation.from_uproot(
+    hist = histogram_creation.from_uproot(
         fnames, treename, varname, bins, weight=weight_float
     )
-    assert np.allclose(yields, [2, 2, 4])
-    assert np.allclose(stdev, [2, 2, 2.82842712])
+    assert np.allclose(hist.values(), [2, 2, 4])
+    assert np.allclose(np.sqrt(hist.variances()), [2, 2, 2.82842712])
 
     # create an additional file to test wildcards / input lists
     extra_path = tmp_path / "test_2.root"
@@ -53,21 +53,12 @@ def test_from_uproot(tmp_path, utils):
 
     # read - with wildcard, matching two files
     fnames = [tmp_path / "test*.root"]
-    yields, stdev = histogram_creation.from_uproot(fnames, treename, varname, bins)
-    assert np.allclose(yields, [2, 2, 4])
-    assert np.allclose(stdev, [1.41421356, 1.41421356, 2])
+    hist = histogram_creation.from_uproot(fnames, treename, varname, bins)
+    assert np.allclose(hist.values(), [2, 2, 4])
+    assert np.allclose(np.sqrt(hist.variances()), [1.41421356, 1.41421356, 2])
 
     # read - with two list entries
     fnames = [tmp_path / "test.root", tmp_path / "test_2.root"]
-    yields, stdev = histogram_creation.from_uproot(fnames, treename, varname, bins)
-    assert np.allclose(yields, [2, 2, 4])
-    assert np.allclose(stdev, [1.41421356, 1.41421356, 2])
-
-
-def test__bin_data():
-    data = np.asarray([1.1, 2.2, 2.9, 2.5, 1.4])
-    weights = np.asarray([1.0, 1.1, 0.9, 0.8, 1.5])
-    bins = np.asarray([1, 2, 3])
-    yields, stdev = histogram_creation._bin_data(data, weights, bins)
-    assert np.allclose(yields, [2.5, 2.8])
-    assert np.allclose(stdev, [1.80277564, 1.63095064])
+    hist = histogram_creation.from_uproot(fnames, treename, varname, bins)
+    assert np.allclose(hist.values(), [2, 2, 4])
+    assert np.allclose(np.sqrt(hist.variances()), [1.41421356, 1.41421356, 2])

--- a/tests/test_template_builder.py
+++ b/tests/test_template_builder.py
@@ -240,9 +240,9 @@ def test__Builder():
 
 
 @mock.patch("cabinetry.template_builder._Builder._name_and_save")
-@mock.patch("cabinetry.histo.Histogram.from_arrays", return_value="histogram")
+@mock.patch("cabinetry.histo.Histogram", return_value="cabinetry_histogram")
 @mock.patch(
-    "cabinetry.contrib.histogram_creation.from_uproot", return_value=([1], [0.1])
+    "cabinetry.contrib.histogram_creation.from_uproot", return_value="histogram"
 )
 def test__Builder_create_histogram(mock_uproot_builder, mock_histo, mock_save):
     # the binning [0] is not a proper binning, but simplifies the comparison
@@ -266,12 +266,12 @@ def test__Builder_create_histogram(mock_uproot_builder, mock_histo, mock_save):
         )
     ]
 
-    # verify the histogram conversion call
-    assert mock_histo.call_args_list == [(([0], [1], [0.1]), {})]
+    # conversion from bh.Histogram to cabinetry Histogram
+    assert mock_histo.call_args_list == [(("histogram",), {})]
 
-    # verify the call for saving
+    # verify the call for saving wrapped histogram
     assert mock_save.call_args_list == [
-        (("histogram", region, sample, systematic, None), {})
+        (("cabinetry_histogram", region, sample, systematic, None), {})
     ]
 
     # other backends


### PR DESCRIPTION
The `uproot`-based backend for ntuple reading and histogram creation previously used `boost-histogram` to bin data, then subsequently extracted yields and uncertainties and returned those in a tuple to `cabinetry.template_builder`, where they would again be turned into a (`cabinetry`) histogram and saved. This changes the interface such that `cabinetry.contrib.histogram_creation.from_uproot` returns a `boost-histogram` histogram, which then gets wrapped by a `cabinetry` histogram and saved. The conversion to a tuple of yields/uncertainties is skipped, as it was unnecessary. Returning a histogram instead of a tuple also brings this in line with the format of user-provided and `register_template_builder`-decorated functions that have to also return `boost-histogram` histograms.

Also updates `pre-commit`.

**Breaking changes:**
- `cabinetry.contrib.histogram_creation.from_uproot` now returns a histogram instead of a tuple

```
* breaking change: contrib.histogram_creation.from_uproot now returns a histogram
* avoided unnecessary conversion from histogram to tuple to histogram with uproot backend
* updated pre-commit
```